### PR TITLE
feat: 営業進捗管理システムを追加

### DIFF
--- a/src/app/sales/accounts/page.tsx
+++ b/src/app/sales/accounts/page.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Card, CardContent, Badge, Button, Input, Select } from '@/components/ui';
+import { Loading } from '@/components/Loading';
+import {
+  getSalesAccounts,
+  createSalesAccount,
+  updateSalesAccount,
+  deleteSalesAccount,
+} from '@/lib/sales';
+import { getUsers } from '@/lib/firestore';
+import {
+  SalesAccount,
+  SalesAccountFormData,
+  SalesAccountType,
+  SALES_ACCOUNT_TYPES,
+} from '@/types/sales';
+import { User } from '@/types';
+import {
+  ArrowLeft,
+  Building2,
+  Plus,
+  Search,
+  Phone,
+  Mail,
+  MapPin,
+  User as UserIcon,
+  Edit,
+  Trash2,
+  X,
+  Briefcase,
+} from 'lucide-react';
+
+export default function SalesAccountsPage() {
+  return (
+    <AuthGuard>
+      <SalesAccountsContent />
+    </AuthGuard>
+  );
+}
+
+function SalesAccountsContent() {
+  const { user } = useAuth();
+  const [accounts, setAccounts] = useState<SalesAccount[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterType, setFilterType] = useState<SalesAccountType | ''>('');
+
+  // モーダル状態
+  const [showModal, setShowModal] = useState(false);
+  const [editingAccount, setEditingAccount] = useState<SalesAccount | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [formData, setFormData] = useState<SalesAccountFormData>({
+    name: '',
+    type: 'MSW',
+  });
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      const [accountsData, usersData] = await Promise.all([
+        getSalesAccounts(),
+        getUsers(),
+      ]);
+      setAccounts(accountsData);
+      setUsers(usersData);
+    } catch (error) {
+      console.error('Failed to fetch data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    setEditingAccount(null);
+    setFormData({
+      name: '',
+      type: 'MSW',
+      phone: '',
+      email: '',
+      address: '',
+      contactPerson: '',
+      contactPhone: '',
+      contactEmail: '',
+      assignedToId: user?.id,
+      assignedToName: user?.name,
+      notes: '',
+    });
+    setShowModal(true);
+  };
+
+  const openEditModal = (account: SalesAccount) => {
+    setEditingAccount(account);
+    setFormData({
+      name: account.name,
+      type: account.type,
+      phone: account.phone || '',
+      email: account.email || '',
+      address: account.address || '',
+      contactPerson: account.contactPerson || '',
+      contactPhone: account.contactPhone || '',
+      contactEmail: account.contactEmail || '',
+      assignedToId: account.assignedToId || '',
+      assignedToName: account.assignedToName || '',
+      notes: account.notes || '',
+    });
+    setShowModal(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.name.trim() || !user) return;
+
+    setSubmitting(true);
+    try {
+      if (editingAccount) {
+        await updateSalesAccount(editingAccount.id, formData);
+      } else {
+        await createSalesAccount(formData, user.id, user.name);
+      }
+      setShowModal(false);
+      await fetchData();
+    } catch (error) {
+      console.error('Failed to save account:', error);
+      alert('保存に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (account: SalesAccount) => {
+    if (!confirm(`「${account.name}」を削除しますか？`)) return;
+
+    try {
+      await deleteSalesAccount(account.id);
+      await fetchData();
+    } catch (error) {
+      console.error('Failed to delete account:', error);
+      alert(error instanceof Error ? error.message : '削除に失敗しました');
+    }
+  };
+
+  const handleAssigneeChange = (userId: string) => {
+    const selectedUser = users.find((u) => u.id === userId);
+    setFormData({
+      ...formData,
+      assignedToId: userId,
+      assignedToName: selectedUser?.name || '',
+    });
+  };
+
+  // フィルタリング
+  const filteredAccounts = accounts.filter((account) => {
+    const matchesSearch =
+      !searchQuery ||
+      account.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      account.contactPerson?.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesType = !filterType || account.type === filterType;
+    return matchesSearch && matchesType;
+  });
+
+  if (loading) {
+    return (
+      <>
+        <Header />
+        <Loading text="読み込み中..." />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="pb-8">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          {/* ヘッダー */}
+          <div className="flex items-center mb-6">
+            <Link href="/sales" className="p-2 -ml-2 rounded-lg hover:bg-gray-100">
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </Link>
+            <h1 className="ml-2 text-xl font-bold text-gray-900">営業先一覧</h1>
+            <Button onClick={openCreateModal} className="ml-auto" size="sm">
+              <Plus className="w-4 h-4 mr-1" />
+              新規登録
+            </Button>
+          </div>
+
+          {/* フィルター */}
+          <Card className="mb-4">
+            <CardContent className="p-4">
+              <div className="flex gap-4">
+                <div className="flex-1">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+                    <Input
+                      placeholder="営業先名・担当者名で検索"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+                <Select
+                  value={filterType}
+                  onChange={(e) => setFilterType(e.target.value as SalesAccountType | '')}
+                  options={[
+                    { value: '', label: 'すべてのタイプ' },
+                    ...SALES_ACCOUNT_TYPES.map((t) => ({ value: t, label: t })),
+                  ]}
+                  className="w-40"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 営業先一覧 */}
+          {filteredAccounts.length === 0 ? (
+            <Card>
+              <CardContent className="text-center py-12">
+                <Building2 className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                <p className="text-gray-500">営業先が登録されていません</p>
+                <Button onClick={openCreateModal} className="mt-4">
+                  <Plus className="w-4 h-4 mr-1" />
+                  営業先を登録
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {filteredAccounts.map((account) => (
+                <Card key={account.id} className="hover:shadow-md transition-shadow">
+                  <CardContent className="p-4">
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <h3 className="font-semibold text-gray-900">{account.name}</h3>
+                          <Badge variant="info">{account.type}</Badge>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-2 text-sm text-gray-600 mt-2">
+                          {account.contactPerson && (
+                            <div className="flex items-center">
+                              <UserIcon className="w-4 h-4 mr-1 text-gray-400" />
+                              {account.contactPerson}
+                            </div>
+                          )}
+                          {account.phone && (
+                            <div className="flex items-center">
+                              <Phone className="w-4 h-4 mr-1 text-gray-400" />
+                              {account.phone}
+                            </div>
+                          )}
+                          {account.email && (
+                            <div className="flex items-center">
+                              <Mail className="w-4 h-4 mr-1 text-gray-400" />
+                              {account.email}
+                            </div>
+                          )}
+                          {account.address && (
+                            <div className="flex items-center col-span-2">
+                              <MapPin className="w-4 h-4 mr-1 text-gray-400" />
+                              {account.address}
+                            </div>
+                          )}
+                        </div>
+
+                        <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
+                          <span>案件: {account.totalDeals || 0}件</span>
+                          <span>進行中: {account.activeDeals || 0}件</span>
+                          <span>成約: {account.completedDeals || 0}件</span>
+                          {account.assignedToName && (
+                            <span className="flex items-center">
+                              <Briefcase className="w-3 h-3 mr-1" />
+                              {account.assignedToName}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-1 ml-4">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => openEditModal(account)}
+                        >
+                          <Edit className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleDelete(account)}
+                          className="text-red-500 hover:text-red-700"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* 登録/編集モーダル */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between p-4 border-b">
+              <h2 className="font-semibold text-lg">
+                {editingAccount ? '営業先編集' : '営業先登録'}
+              </h2>
+              <button onClick={() => setShowModal(false)} className="p-1 hover:bg-gray-100 rounded">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="p-4 space-y-4">
+              <Input
+                label="営業先名"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                required
+                placeholder="例: 〇〇病院"
+              />
+
+              <Select
+                label="タイプ"
+                value={formData.type}
+                onChange={(e) => setFormData({ ...formData, type: e.target.value as SalesAccountType })}
+                options={SALES_ACCOUNT_TYPES.map((t) => ({ value: t, label: t }))}
+                required
+              />
+
+              <div className="grid grid-cols-2 gap-4">
+                <Input
+                  label="電話番号"
+                  value={formData.phone || ''}
+                  onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+                  placeholder="03-1234-5678"
+                />
+                <Input
+                  label="メール"
+                  type="email"
+                  value={formData.email || ''}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  placeholder="example@hospital.jp"
+                />
+              </div>
+
+              <Input
+                label="住所"
+                value={formData.address || ''}
+                onChange={(e) => setFormData({ ...formData, address: e.target.value })}
+                placeholder="東京都〇〇区..."
+              />
+
+              <div className="border-t pt-4">
+                <h3 className="font-medium text-sm text-gray-700 mb-3">先方担当者情報</h3>
+                <Input
+                  label="担当者名"
+                  value={formData.contactPerson || ''}
+                  onChange={(e) => setFormData({ ...formData, contactPerson: e.target.value })}
+                  placeholder="田中 太郎"
+                />
+                <div className="grid grid-cols-2 gap-4 mt-3">
+                  <Input
+                    label="担当者電話"
+                    value={formData.contactPhone || ''}
+                    onChange={(e) => setFormData({ ...formData, contactPhone: e.target.value })}
+                  />
+                  <Input
+                    label="担当者メール"
+                    type="email"
+                    value={formData.contactEmail || ''}
+                    onChange={(e) => setFormData({ ...formData, contactEmail: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="border-t pt-4">
+                <Select
+                  label="自社担当者"
+                  value={formData.assignedToId || ''}
+                  onChange={(e) => handleAssigneeChange(e.target.value)}
+                  options={[
+                    { value: '', label: '未割当' },
+                    ...users.map((u) => ({ value: u.id, label: u.name })),
+                  ]}
+                />
+              </div>
+
+              <div className="flex gap-3 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowModal(false)}
+                  className="flex-1"
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" loading={submitting} className="flex-1">
+                  {editingAccount ? '更新' : '登録'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sales/deals/[id]/page.tsx
+++ b/src/app/sales/deals/[id]/page.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Card, CardContent, Badge, Button, Input, Select, Textarea } from '@/components/ui';
+import { Loading } from '@/components/Loading';
+import {
+  getSalesDeal,
+  getSalesAccount,
+  updateSalesDeal,
+  updateDealStatus,
+  deleteSalesDeal,
+} from '@/lib/sales';
+import { getUsers, getBranches } from '@/lib/firestore';
+import {
+  SalesDeal,
+  SalesAccount,
+  SalesDealStatus,
+  SALES_DEAL_STATUSES,
+  SALES_DEAL_STATUS_CONFIG,
+  SALES_DEAL_STATUS_ORDER,
+  CARE_LEVELS,
+  CareLevel,
+} from '@/types/sales';
+import { User, Branch } from '@/types';
+import {
+  ArrowLeft,
+  Building2,
+  User as UserIcon,
+  Calendar,
+  Phone,
+  Edit,
+  Trash2,
+  ChevronRight,
+  CheckCircle,
+  Clock,
+  AlertTriangle,
+  X,
+  Save,
+} from 'lucide-react';
+
+export default function SalesDealDetailPage() {
+  return (
+    <AuthGuard>
+      <SalesDealDetailContent />
+    </AuthGuard>
+  );
+}
+
+function SalesDealDetailContent() {
+  const params = useParams();
+  const router = useRouter();
+  const { user } = useAuth();
+  const dealId = params.id as string;
+
+  const [deal, setDeal] = useState<SalesDeal | null>(null);
+  const [account, setAccount] = useState<SalesAccount | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 編集モード
+  const [isEditing, setIsEditing] = useState(false);
+  const [editData, setEditData] = useState<Partial<SalesDeal>>({});
+  const [saving, setSaving] = useState(false);
+
+  // ステータス変更モーダル
+  const [showStatusModal, setShowStatusModal] = useState(false);
+  const [newStatus, setNewStatus] = useState<SalesDealStatus | ''>('');
+  const [statusNote, setStatusNote] = useState('');
+
+  useEffect(() => {
+    fetchData();
+  }, [dealId]);
+
+  const fetchData = async () => {
+    try {
+      const [dealData, usersData, branchesData] = await Promise.all([
+        getSalesDeal(dealId),
+        getUsers(),
+        getBranches(),
+      ]);
+
+      if (!dealData) {
+        setError('案件が見つかりません');
+        return;
+      }
+
+      setDeal(dealData);
+      setUsers(usersData);
+      setBranches(branchesData);
+
+      // 営業先情報を取得
+      const accountData = await getSalesAccount(dealData.accountId);
+      setAccount(accountData);
+
+      // 編集用データを初期化
+      setEditData(dealData);
+    } catch (err) {
+      console.error('Failed to fetch deal:', err);
+      setError('データの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!deal || !user) return;
+
+    setSaving(true);
+    try {
+      await updateSalesDeal(deal.id, {
+        residentName: editData.residentName,
+        residentAge: editData.residentAge,
+        residentGender: editData.residentGender,
+        careLevel: editData.careLevel,
+        adlSummary: editData.adlSummary,
+        targetBranchId: editData.targetBranchId,
+        targetBranchName: editData.targetBranchName,
+        expectedMoveInDate: editData.expectedMoveInDate,
+        actualMoveInDate: editData.actualMoveInDate,
+        invoiceDate: editData.invoiceDate,
+        invoiceAmount: editData.invoiceAmount,
+        notes: editData.notes,
+      });
+      await fetchData();
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to save:', err);
+      alert('保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleStatusChange = async () => {
+    if (!deal || !user || !newStatus) return;
+
+    setSaving(true);
+    try {
+      await updateDealStatus(deal.id, newStatus, user.id, user.name, statusNote);
+      await fetchData();
+      setShowStatusModal(false);
+      setNewStatus('');
+      setStatusNote('');
+    } catch (err) {
+      console.error('Failed to update status:', err);
+      alert('ステータス更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deal || !confirm('この案件を削除しますか？')) return;
+
+    try {
+      await deleteSalesDeal(deal.id);
+      router.push('/sales/deals');
+    } catch (err) {
+      console.error('Failed to delete:', err);
+      alert('削除に失敗しました');
+    }
+  };
+
+  const handleBranchChange = (branchId: string) => {
+    const selectedBranch = branches.find((b) => b.id === branchId);
+    setEditData({
+      ...editData,
+      targetBranchId: branchId,
+      targetBranchName: selectedBranch?.name || '',
+    });
+  };
+
+  if (loading) {
+    return (
+      <>
+        <Header />
+        <Loading text="読み込み中..." />
+      </>
+    );
+  }
+
+  if (error || !deal) {
+    return (
+      <>
+        <Header />
+        <div className="max-w-2xl mx-auto px-4 py-8">
+          <Card>
+            <CardContent className="text-center py-8">
+              <AlertTriangle className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
+              <p className="text-gray-600 mb-4">{error || '案件が見つかりません'}</p>
+              <Button onClick={() => router.push('/sales/deals')}>
+                案件一覧に戻る
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </>
+    );
+  }
+
+  const config = SALES_DEAL_STATUS_CONFIG[deal.status];
+  const currentOrder = SALES_DEAL_STATUS_ORDER[deal.status];
+
+  return (
+    <>
+      <Header />
+      <main className="pb-8">
+        <div className="max-w-2xl mx-auto px-4 py-6">
+          {/* ヘッダー */}
+          <div className="flex items-center mb-6">
+            <Link href="/sales/deals" className="p-2 -ml-2 rounded-lg hover:bg-gray-100">
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </Link>
+            <h1 className="ml-2 text-xl font-bold text-gray-900">案件詳細</h1>
+            <div className="ml-auto flex gap-2">
+              {!isEditing ? (
+                <>
+                  <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
+                    <Edit className="w-4 h-4 mr-1" />
+                    編集
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleDelete}
+                    className="text-red-500"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button variant="outline" size="sm" onClick={() => setIsEditing(false)}>
+                    キャンセル
+                  </Button>
+                  <Button size="sm" onClick={handleSave} loading={saving}>
+                    <Save className="w-4 h-4 mr-1" />
+                    保存
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* ステータス・パイプライン */}
+          <Card className="mb-4">
+            <CardContent>
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                  <Badge className={`${config.bgColor} ${config.color} text-base px-3 py-1`}>
+                    {deal.status}
+                  </Badge>
+                </div>
+                <Button size="sm" onClick={() => setShowStatusModal(true)}>
+                  ステータス変更
+                </Button>
+              </div>
+
+              {/* パイプライン進捗 */}
+              <div className="flex items-center gap-1 overflow-x-auto pb-2">
+                {SALES_DEAL_STATUSES.map((status, index) => {
+                  const statusOrder = SALES_DEAL_STATUS_ORDER[status];
+                  const isCompleted = currentOrder > 0 && statusOrder <= currentOrder;
+                  const isCurrent = status === deal.status;
+                  const statusConfig = SALES_DEAL_STATUS_CONFIG[status];
+
+                  return (
+                    <div key={status} className="flex items-center">
+                      <div
+                        className={`flex flex-col items-center ${
+                          isCurrent ? 'scale-110' : ''
+                        }`}
+                      >
+                        <div
+                          className={`w-6 h-6 rounded-full flex items-center justify-center text-xs ${
+                            isCompleted
+                              ? 'bg-green-500 text-white'
+                              : isCurrent
+                                ? `${statusConfig.bgColor} ${statusConfig.color}`
+                                : 'bg-gray-200 text-gray-500'
+                          }`}
+                        >
+                          {isCompleted && !isCurrent ? (
+                            <CheckCircle className="w-4 h-4" />
+                          ) : (
+                            index + 1
+                          )}
+                        </div>
+                        <span
+                          className={`text-xs mt-1 whitespace-nowrap ${
+                            isCurrent ? 'font-bold' : 'text-gray-500'
+                          }`}
+                        >
+                          {status}
+                        </span>
+                      </div>
+                      {index < SALES_DEAL_STATUSES.length - 1 && (
+                        <div
+                          className={`w-4 h-0.5 mx-1 ${
+                            isCompleted ? 'bg-green-500' : 'bg-gray-200'
+                          }`}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 営業先情報 */}
+          <Card className="mb-4">
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-3 flex items-center">
+                <Building2 className="w-4 h-4 mr-2 text-gray-500" />
+                営業先
+              </h2>
+              {account && (
+                <div className="text-sm">
+                  <p className="font-medium">{account.name}</p>
+                  <p className="text-gray-500">{account.type}</p>
+                  {account.contactPerson && (
+                    <p className="text-gray-600 mt-1">担当: {account.contactPerson}</p>
+                  )}
+                  {account.phone && (
+                    <p className="text-gray-600 flex items-center mt-1">
+                      <Phone className="w-3 h-3 mr-1" />
+                      {account.phone}
+                    </p>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* 入居者情報 */}
+          <Card className="mb-4">
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-3 flex items-center">
+                <UserIcon className="w-4 h-4 mr-2 text-gray-500" />
+                入居者情報
+              </h2>
+
+              {isEditing ? (
+                <div className="space-y-3">
+                  <Input
+                    label="入居者名"
+                    value={editData.residentName || ''}
+                    onChange={(e) => setEditData({ ...editData, residentName: e.target.value })}
+                  />
+                  <div className="grid grid-cols-2 gap-3">
+                    <Input
+                      label="年齢"
+                      type="number"
+                      value={editData.residentAge || ''}
+                      onChange={(e) =>
+                        setEditData({ ...editData, residentAge: parseInt(e.target.value) || undefined })
+                      }
+                    />
+                    <Select
+                      label="性別"
+                      value={editData.residentGender || ''}
+                      onChange={(e) =>
+                        setEditData({
+                          ...editData,
+                          residentGender: e.target.value as '男性' | '女性' | '不明',
+                        })
+                      }
+                      options={[
+                        { value: '', label: '選択' },
+                        { value: '男性', label: '男性' },
+                        { value: '女性', label: '女性' },
+                        { value: '不明', label: '不明' },
+                      ]}
+                    />
+                  </div>
+                  <Select
+                    label="介護度"
+                    value={editData.careLevel || ''}
+                    onChange={(e) => setEditData({ ...editData, careLevel: e.target.value as CareLevel })}
+                    options={[
+                      { value: '', label: '選択' },
+                      ...CARE_LEVELS.map((c) => ({ value: c, label: c })),
+                    ]}
+                  />
+                  <Textarea
+                    label="ADL概要"
+                    value={editData.adlSummary || ''}
+                    onChange={(e) => setEditData({ ...editData, adlSummary: e.target.value })}
+                    rows={2}
+                  />
+                </div>
+              ) : (
+                <div className="text-sm space-y-2">
+                  <p>
+                    <span className="text-gray-500">名前:</span>{' '}
+                    <span className="font-medium">{deal.residentName || '未設定'}</span>
+                  </p>
+                  {deal.residentAge && (
+                    <p>
+                      <span className="text-gray-500">年齢:</span> {deal.residentAge}歳
+                      {deal.residentGender && ` (${deal.residentGender})`}
+                    </p>
+                  )}
+                  {deal.careLevel && (
+                    <p>
+                      <span className="text-gray-500">介護度:</span> {deal.careLevel}
+                    </p>
+                  )}
+                  {deal.adlSummary && (
+                    <p>
+                      <span className="text-gray-500">ADL:</span> {deal.adlSummary}
+                    </p>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* 入居情報 */}
+          <Card className="mb-4">
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-3 flex items-center">
+                <Calendar className="w-4 h-4 mr-2 text-gray-500" />
+                入居情報
+              </h2>
+
+              {isEditing ? (
+                <div className="space-y-3">
+                  <Select
+                    label="入居先施設"
+                    value={editData.targetBranchId || ''}
+                    onChange={(e) => handleBranchChange(e.target.value)}
+                    options={[
+                      { value: '', label: '未定' },
+                      ...branches.map((b) => ({ value: b.id, label: b.name })),
+                    ]}
+                  />
+                  <Input
+                    label="入居予定日"
+                    type="date"
+                    value={editData.expectedMoveInDate || ''}
+                    onChange={(e) => setEditData({ ...editData, expectedMoveInDate: e.target.value })}
+                  />
+                  <Input
+                    label="実際の入居日"
+                    type="date"
+                    value={editData.actualMoveInDate || ''}
+                    onChange={(e) => setEditData({ ...editData, actualMoveInDate: e.target.value })}
+                  />
+                  <Input
+                    label="請求書到着日"
+                    type="date"
+                    value={editData.invoiceDate || ''}
+                    onChange={(e) => setEditData({ ...editData, invoiceDate: e.target.value })}
+                  />
+                  <Input
+                    label="請求金額"
+                    type="number"
+                    value={editData.invoiceAmount || ''}
+                    onChange={(e) =>
+                      setEditData({ ...editData, invoiceAmount: parseInt(e.target.value) || undefined })
+                    }
+                  />
+                </div>
+              ) : (
+                <div className="text-sm space-y-2">
+                  <p>
+                    <span className="text-gray-500">入居先:</span>{' '}
+                    {deal.targetBranchName || '未定'}
+                  </p>
+                  <p>
+                    <span className="text-gray-500">入居予定日:</span>{' '}
+                    {deal.expectedMoveInDate || '未定'}
+                  </p>
+                  {deal.actualMoveInDate && (
+                    <p>
+                      <span className="text-gray-500">実際の入居日:</span> {deal.actualMoveInDate}
+                    </p>
+                  )}
+                  {deal.invoiceDate && (
+                    <p>
+                      <span className="text-gray-500">請求書到着日:</span> {deal.invoiceDate}
+                    </p>
+                  )}
+                  {deal.invoiceAmount && (
+                    <p>
+                      <span className="text-gray-500">請求金額:</span>{' '}
+                      {deal.invoiceAmount.toLocaleString()}円
+                    </p>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* メモ */}
+          <Card className="mb-4">
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-3">メモ</h2>
+              {isEditing ? (
+                <Textarea
+                  value={editData.notes || ''}
+                  onChange={(e) => setEditData({ ...editData, notes: e.target.value })}
+                  rows={3}
+                />
+              ) : (
+                <p className="text-sm text-gray-600 whitespace-pre-wrap">
+                  {deal.notes || 'メモなし'}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* ステータス履歴 */}
+          <Card>
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-3 flex items-center">
+                <Clock className="w-4 h-4 mr-2 text-gray-500" />
+                ステータス履歴
+              </h2>
+              <div className="space-y-3">
+                {deal.statusHistory
+                  .slice()
+                  .reverse()
+                  .map((entry, index) => (
+                    <div key={index} className="flex items-start gap-3 text-sm">
+                      <div className="w-2 h-2 rounded-full bg-blue-500 mt-1.5" />
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            className={`${SALES_DEAL_STATUS_CONFIG[entry.status].bgColor} ${SALES_DEAL_STATUS_CONFIG[entry.status].color}`}
+                          >
+                            {entry.status}
+                          </Badge>
+                          <span className="text-gray-500 text-xs">
+                            {entry.changedAt.toLocaleString('ja-JP')}
+                          </span>
+                        </div>
+                        <p className="text-gray-600 text-xs mt-1">
+                          {entry.changedByName}
+                          {entry.note && ` - ${entry.note}`}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+
+      {/* ステータス変更モーダル */}
+      {showStatusModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl max-w-sm w-full">
+            <div className="flex items-center justify-between p-4 border-b">
+              <h2 className="font-semibold text-lg">ステータス変更</h2>
+              <button
+                onClick={() => setShowStatusModal(false)}
+                className="p-1 hover:bg-gray-100 rounded"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="p-4 space-y-4">
+              <Select
+                label="新しいステータス"
+                value={newStatus}
+                onChange={(e) => setNewStatus(e.target.value as SalesDealStatus)}
+                options={[
+                  { value: '', label: '選択してください' },
+                  ...SALES_DEAL_STATUSES.map((s) => ({ value: s, label: s })),
+                  { value: '失注', label: '失注' },
+                  { value: '保留', label: '保留' },
+                ]}
+              />
+
+              <Textarea
+                label="備考（任意）"
+                value={statusNote}
+                onChange={(e) => setStatusNote(e.target.value)}
+                placeholder="ステータス変更の理由など"
+                rows={2}
+              />
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setShowStatusModal(false)}
+                  className="flex-1"
+                >
+                  キャンセル
+                </Button>
+                <Button
+                  onClick={handleStatusChange}
+                  loading={saving}
+                  disabled={!newStatus}
+                  className="flex-1"
+                >
+                  変更
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sales/deals/page.tsx
+++ b/src/app/sales/deals/page.tsx
@@ -1,0 +1,449 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Card, CardContent, Badge, Button, Input, Select, Textarea } from '@/components/ui';
+import { Loading } from '@/components/Loading';
+import {
+  getSalesDeals,
+  getSalesAccounts,
+  createSalesDeal,
+  updateDealStatus,
+} from '@/lib/sales';
+import { getUsers, getBranches } from '@/lib/firestore';
+import {
+  SalesDeal,
+  SalesDealFormData,
+  SalesAccount,
+  SalesDealStatus,
+  SALES_DEAL_STATUSES,
+  SALES_DEAL_STATUS_CONFIG,
+  CARE_LEVELS,
+  CareLevel,
+} from '@/types/sales';
+import { User, Branch } from '@/types';
+import {
+  ArrowLeft,
+  Plus,
+  Search,
+  Filter,
+  ChevronRight,
+  X,
+  User as UserIcon,
+  Calendar,
+  Building2,
+} from 'lucide-react';
+
+export default function SalesDealsPage() {
+  return (
+    <AuthGuard>
+      <SalesDealsContent />
+    </AuthGuard>
+  );
+}
+
+function SalesDealsContent() {
+  const { user } = useAuth();
+  const searchParams = useSearchParams();
+  const initialStatus = searchParams.get('status') as SalesDealStatus | null;
+  const initialAssignee = searchParams.get('assignee');
+
+  const [deals, setDeals] = useState<SalesDeal[]>([]);
+  const [accounts, setAccounts] = useState<SalesAccount[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // フィルター
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterStatus, setFilterStatus] = useState<SalesDealStatus | ''>(initialStatus || '');
+  const [filterAssignee, setFilterAssignee] = useState(initialAssignee || '');
+  const [filterAccount, setFilterAccount] = useState('');
+
+  // モーダル状態
+  const [showModal, setShowModal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [formData, setFormData] = useState<SalesDealFormData>({
+    accountId: '',
+    status: 'テレアポ',
+  });
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const fetchData = async () => {
+    try {
+      const [dealsData, accountsData, usersData, branchesData] = await Promise.all([
+        getSalesDeals(),
+        getSalesAccounts(),
+        getUsers(),
+        getBranches(),
+      ]);
+      setDeals(dealsData);
+      setAccounts(accountsData);
+      setUsers(usersData);
+      setBranches(branchesData);
+    } catch (error) {
+      console.error('Failed to fetch data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    setFormData({
+      accountId: '',
+      status: 'テレアポ',
+      assignedToId: user?.id,
+      assignedToName: user?.name,
+    });
+    setShowModal(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.accountId || !user) return;
+
+    setSubmitting(true);
+    try {
+      await createSalesDeal(formData, user.id, user.name);
+      setShowModal(false);
+      await fetchData();
+    } catch (error) {
+      console.error('Failed to create deal:', error);
+      alert('作成に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleAssigneeChange = (userId: string) => {
+    const selectedUser = users.find((u) => u.id === userId);
+    setFormData({
+      ...formData,
+      assignedToId: userId,
+      assignedToName: selectedUser?.name || '',
+    });
+  };
+
+  const handleBranchChange = (branchId: string) => {
+    const selectedBranch = branches.find((b) => b.id === branchId);
+    setFormData({
+      ...formData,
+      targetBranchId: branchId,
+      targetBranchName: selectedBranch?.name || '',
+    });
+  };
+
+  // フィルタリング
+  const filteredDeals = deals.filter((deal) => {
+    const matchesSearch =
+      !searchQuery ||
+      deal.residentName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      deal.accountName?.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesStatus = !filterStatus || deal.status === filterStatus;
+    const matchesAssignee = !filterAssignee || deal.assignedToId === filterAssignee;
+    const matchesAccount = !filterAccount || deal.accountId === filterAccount;
+    return matchesSearch && matchesStatus && matchesAssignee && matchesAccount;
+  });
+
+  if (loading) {
+    return (
+      <>
+        <Header />
+        <Loading text="読み込み中..." />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="pb-8">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          {/* ヘッダー */}
+          <div className="flex items-center mb-6">
+            <Link href="/sales" className="p-2 -ml-2 rounded-lg hover:bg-gray-100">
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </Link>
+            <h1 className="ml-2 text-xl font-bold text-gray-900">案件一覧</h1>
+            <Button onClick={openCreateModal} className="ml-auto" size="sm">
+              <Plus className="w-4 h-4 mr-1" />
+              新規案件
+            </Button>
+          </div>
+
+          {/* フィルター */}
+          <Card className="mb-4">
+            <CardContent className="p-4">
+              <div className="flex flex-wrap gap-3">
+                <div className="flex-1 min-w-[200px]">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+                    <Input
+                      placeholder="入居者名・営業先名で検索"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+                <Select
+                  value={filterStatus}
+                  onChange={(e) => setFilterStatus(e.target.value as SalesDealStatus | '')}
+                  options={[
+                    { value: '', label: 'すべてのステータス' },
+                    ...SALES_DEAL_STATUSES.map((s) => ({ value: s, label: s })),
+                    { value: '失注', label: '失注' },
+                    { value: '保留', label: '保留' },
+                  ]}
+                  className="w-40"
+                />
+                <Select
+                  value={filterAssignee}
+                  onChange={(e) => setFilterAssignee(e.target.value)}
+                  options={[
+                    { value: '', label: 'すべての担当者' },
+                    ...users.map((u) => ({ value: u.id, label: u.name })),
+                  ]}
+                  className="w-36"
+                />
+                <Select
+                  value={filterAccount}
+                  onChange={(e) => setFilterAccount(e.target.value)}
+                  options={[
+                    { value: '', label: 'すべての営業先' },
+                    ...accounts.map((a) => ({ value: a.id, label: a.name })),
+                  ]}
+                  className="w-40"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 案件一覧 */}
+          {filteredDeals.length === 0 ? (
+            <Card>
+              <CardContent className="text-center py-12">
+                <Filter className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                <p className="text-gray-500">案件がありません</p>
+                <Button onClick={openCreateModal} className="mt-4">
+                  <Plus className="w-4 h-4 mr-1" />
+                  案件を作成
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-3">
+              {filteredDeals.map((deal) => {
+                const config = SALES_DEAL_STATUS_CONFIG[deal.status];
+                return (
+                  <Link key={deal.id} href={`/sales/deals/${deal.id}`}>
+                    <Card className="hover:shadow-md transition-shadow cursor-pointer">
+                      <CardContent className="p-4">
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              <h3 className="font-semibold text-gray-900">
+                                {deal.residentName || '入居者未設定'}
+                              </h3>
+                              <Badge className={`${config.bgColor} ${config.color}`}>
+                                {deal.status}
+                              </Badge>
+                            </div>
+
+                            <div className="flex items-center gap-4 text-sm text-gray-600 mt-2">
+                              <span className="flex items-center">
+                                <Building2 className="w-4 h-4 mr-1 text-gray-400" />
+                                {deal.accountName}
+                              </span>
+                              {deal.careLevel && (
+                                <span>{deal.careLevel}</span>
+                              )}
+                              {deal.targetBranchName && (
+                                <span>→ {deal.targetBranchName}</span>
+                              )}
+                            </div>
+
+                            <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                              {deal.assignedToName && (
+                                <span className="flex items-center">
+                                  <UserIcon className="w-3 h-3 mr-1" />
+                                  {deal.assignedToName}
+                                </span>
+                              )}
+                              {deal.expectedMoveInDate && (
+                                <span className="flex items-center">
+                                  <Calendar className="w-3 h-3 mr-1" />
+                                  入居予定: {deal.expectedMoveInDate}
+                                </span>
+                              )}
+                              <span>
+                                更新: {(deal.updatedAt || deal.createdAt).toLocaleDateString('ja-JP')}
+                              </span>
+                            </div>
+                          </div>
+
+                          <ChevronRight className="w-5 h-5 text-gray-400" />
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* 新規案件モーダル */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl max-w-lg w-full max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between p-4 border-b">
+              <h2 className="font-semibold text-lg">新規案件</h2>
+              <button onClick={() => setShowModal(false)} className="p-1 hover:bg-gray-100 rounded">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="p-4 space-y-4">
+              <Select
+                label="営業先"
+                value={formData.accountId}
+                onChange={(e) => setFormData({ ...formData, accountId: e.target.value })}
+                options={[
+                  { value: '', label: '選択してください' },
+                  ...accounts.map((a) => ({ value: a.id, label: `${a.name} (${a.type})` })),
+                ]}
+                required
+              />
+
+              <Select
+                label="ステータス"
+                value={formData.status}
+                onChange={(e) => setFormData({ ...formData, status: e.target.value as SalesDealStatus })}
+                options={SALES_DEAL_STATUSES.map((s) => ({ value: s, label: s }))}
+                required
+              />
+
+              <Select
+                label="担当者"
+                value={formData.assignedToId || ''}
+                onChange={(e) => handleAssigneeChange(e.target.value)}
+                options={[
+                  { value: '', label: '未割当' },
+                  ...users.map((u) => ({ value: u.id, label: u.name })),
+                ]}
+              />
+
+              <div className="border-t pt-4">
+                <h3 className="font-medium text-sm text-gray-700 mb-3">入居者情報（任意）</h3>
+
+                <Input
+                  label="入居者名"
+                  value={formData.residentName || ''}
+                  onChange={(e) => setFormData({ ...formData, residentName: e.target.value })}
+                  placeholder="山田 太郎"
+                />
+
+                <div className="grid grid-cols-2 gap-4 mt-3">
+                  <Input
+                    label="年齢"
+                    type="number"
+                    value={formData.residentAge || ''}
+                    onChange={(e) => setFormData({ ...formData, residentAge: parseInt(e.target.value) || undefined })}
+                  />
+                  <Select
+                    label="性別"
+                    value={formData.residentGender || ''}
+                    onChange={(e) => setFormData({ ...formData, residentGender: e.target.value as '男性' | '女性' | '不明' })}
+                    options={[
+                      { value: '', label: '選択' },
+                      { value: '男性', label: '男性' },
+                      { value: '女性', label: '女性' },
+                      { value: '不明', label: '不明' },
+                    ]}
+                  />
+                </div>
+
+                <div className="mt-3">
+                  <Select
+                    label="介護度"
+                    value={formData.careLevel || ''}
+                    onChange={(e) => setFormData({ ...formData, careLevel: e.target.value as CareLevel })}
+                    options={[
+                      { value: '', label: '選択' },
+                      ...CARE_LEVELS.map((c) => ({ value: c, label: c })),
+                    ]}
+                  />
+                </div>
+
+                <div className="mt-3">
+                  <Textarea
+                    label="ADL概要"
+                    value={formData.adlSummary || ''}
+                    onChange={(e) => setFormData({ ...formData, adlSummary: e.target.value })}
+                    placeholder="歩行可、食事自立、排泄一部介助..."
+                    rows={2}
+                  />
+                </div>
+              </div>
+
+              <div className="border-t pt-4">
+                <h3 className="font-medium text-sm text-gray-700 mb-3">入居情報（任意）</h3>
+
+                <Select
+                  label="入居先施設"
+                  value={formData.targetBranchId || ''}
+                  onChange={(e) => handleBranchChange(e.target.value)}
+                  options={[
+                    { value: '', label: '未定' },
+                    ...branches.map((b) => ({ value: b.id, label: b.name })),
+                  ]}
+                />
+
+                <div className="mt-3">
+                  <Input
+                    label="入居予定日"
+                    type="date"
+                    value={formData.expectedMoveInDate || ''}
+                    onChange={(e) => setFormData({ ...formData, expectedMoveInDate: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-3">
+                <Textarea
+                  label="メモ"
+                  value={formData.notes || ''}
+                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                  rows={2}
+                />
+              </div>
+
+              <div className="flex gap-3 pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowModal(false)}
+                  className="flex-1"
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" loading={submitting} className="flex-1">
+                  作成
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Card, CardContent, Badge, Button } from '@/components/ui';
+import { Loading } from '@/components/Loading';
+import { getSalesDeals, getSalesAccounts, getPipelineSummary } from '@/lib/sales';
+import {
+  SalesDeal,
+  SalesAccount,
+  PipelineSummary,
+  SALES_DEAL_STATUS_CONFIG,
+  SALES_DEAL_STATUSES,
+} from '@/types/sales';
+import {
+  Building2,
+  Users,
+  TrendingUp,
+  AlertCircle,
+  Plus,
+  ChevronRight,
+  Phone,
+  FileText,
+  Handshake,
+  Home,
+  Receipt,
+} from 'lucide-react';
+
+export default function SalesDashboardPage() {
+  return (
+    <AuthGuard>
+      <SalesDashboardContent />
+    </AuthGuard>
+  );
+}
+
+function SalesDashboardContent() {
+  const { user } = useAuth();
+  const [accounts, setAccounts] = useState<SalesAccount[]>([]);
+  const [deals, setDeals] = useState<SalesDeal[]>([]);
+  const [pipeline, setPipeline] = useState<PipelineSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [accountsData, dealsData, pipelineData] = await Promise.all([
+          getSalesAccounts(),
+          getSalesDeals(),
+          getPipelineSummary(),
+        ]);
+        setAccounts(accountsData);
+        setDeals(dealsData);
+        setPipeline(pipelineData);
+      } catch (error) {
+        console.error('Failed to fetch data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <>
+        <Header />
+        <Loading text="読み込み中..." />
+      </>
+    );
+  }
+
+  const activeDeals = deals.filter((d) => !['請求書到着', '失注'].includes(d.status));
+  const completedDeals = deals.filter((d) => d.status === '請求書到着');
+  const myDeals = deals.filter((d) => d.assignedToId === user?.id);
+
+  // 停滞案件（7日以上更新なし）
+  const now = new Date();
+  const staleDeals = activeDeals.filter((deal) => {
+    const lastActivity = deal.updatedAt || deal.createdAt;
+    const daysSince = Math.floor((now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60 * 24));
+    return daysSince >= 7;
+  });
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'テレアポ':
+        return <Phone className="w-4 h-4" />;
+      case '資料送付':
+        return <FileText className="w-4 h-4" />;
+      case '面談':
+        return <Users className="w-4 h-4" />;
+      case '担当者決定':
+        return <Handshake className="w-4 h-4" />;
+      case '入居相談':
+      case '入居契約':
+      case '入居確認':
+        return <Home className="w-4 h-4" />;
+      case '請求書到着':
+        return <Receipt className="w-4 h-4" />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      <Header />
+      <main className="pb-8">
+        <div className="max-w-6xl mx-auto px-4 py-6">
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-2xl font-bold text-gray-900">営業進捗管理</h1>
+            <div className="flex gap-2">
+              <Link href="/sales/accounts">
+                <Button variant="outline" size="sm">
+                  <Building2 className="w-4 h-4 mr-1" />
+                  営業先一覧
+                </Button>
+              </Link>
+              <Link href="/sales/deals">
+                <Button size="sm">
+                  <Plus className="w-4 h-4 mr-1" />
+                  新規案件
+                </Button>
+              </Link>
+            </div>
+          </div>
+
+          {/* サマリーカード */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-gray-500">営業先</p>
+                    <p className="text-2xl font-bold">{accounts.length}</p>
+                  </div>
+                  <Building2 className="w-8 h-8 text-blue-500" />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-gray-500">進行中案件</p>
+                    <p className="text-2xl font-bold">{activeDeals.length}</p>
+                  </div>
+                  <TrendingUp className="w-8 h-8 text-green-500" />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-gray-500">成約</p>
+                    <p className="text-2xl font-bold">{completedDeals.length}</p>
+                  </div>
+                  <Receipt className="w-8 h-8 text-purple-500" />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className={staleDeals.length > 0 ? 'border-orange-200 bg-orange-50' : ''}>
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-gray-500">要対応</p>
+                    <p className="text-2xl font-bold text-orange-600">{staleDeals.length}</p>
+                  </div>
+                  <AlertCircle className="w-8 h-8 text-orange-500" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* パイプライン */}
+          <Card className="mb-6">
+            <CardContent>
+              <h2 className="font-semibold text-gray-900 mb-4">パイプライン</h2>
+              <div className="grid grid-cols-4 md:grid-cols-8 gap-2">
+                {SALES_DEAL_STATUSES.map((status) => {
+                  const config = SALES_DEAL_STATUS_CONFIG[status];
+                  const count = pipeline.find((p) => p.status === status)?.count || 0;
+                  return (
+                    <Link
+                      key={status}
+                      href={`/sales/deals?status=${encodeURIComponent(status)}`}
+                      className="block"
+                    >
+                      <div
+                        className={`p-3 rounded-lg text-center hover:opacity-80 transition-opacity ${config.bgColor}`}
+                      >
+                        <div className={`flex justify-center mb-1 ${config.color}`}>
+                          {getStatusIcon(status)}
+                        </div>
+                        <p className="text-2xl font-bold">{count}</p>
+                        <p className={`text-xs ${config.color}`}>{status}</p>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            {/* 自分の案件 */}
+            <Card>
+              <CardContent>
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="font-semibold text-gray-900">自分の案件</h2>
+                  <Link href={`/sales/deals?assignee=${user?.id}`}>
+                    <Button variant="ghost" size="sm">
+                      すべて見る
+                      <ChevronRight className="w-4 h-4 ml-1" />
+                    </Button>
+                  </Link>
+                </div>
+                {myDeals.length === 0 ? (
+                  <p className="text-gray-500 text-sm">担当案件がありません</p>
+                ) : (
+                  <div className="space-y-2">
+                    {myDeals.slice(0, 5).map((deal) => {
+                      const config = SALES_DEAL_STATUS_CONFIG[deal.status];
+                      return (
+                        <Link
+                          key={deal.id}
+                          href={`/sales/deals/${deal.id}`}
+                          className="flex items-center justify-between p-2 rounded-lg hover:bg-gray-50"
+                        >
+                          <div>
+                            <p className="font-medium text-sm">{deal.residentName || '未設定'}</p>
+                            <p className="text-xs text-gray-500">{deal.accountName}</p>
+                          </div>
+                          <Badge className={`${config.bgColor} ${config.color}`}>
+                            {deal.status}
+                          </Badge>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* 停滞案件 */}
+            <Card className={staleDeals.length > 0 ? 'border-orange-200' : ''}>
+              <CardContent>
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="font-semibold text-gray-900 flex items-center">
+                    <AlertCircle className="w-4 h-4 mr-2 text-orange-500" />
+                    要対応（7日以上更新なし）
+                  </h2>
+                </div>
+                {staleDeals.length === 0 ? (
+                  <p className="text-gray-500 text-sm">停滞案件はありません</p>
+                ) : (
+                  <div className="space-y-2">
+                    {staleDeals.slice(0, 5).map((deal) => {
+                      const config = SALES_DEAL_STATUS_CONFIG[deal.status];
+                      const lastActivity = deal.updatedAt || deal.createdAt;
+                      const daysSince = Math.floor(
+                        (now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
+                      );
+                      return (
+                        <Link
+                          key={deal.id}
+                          href={`/sales/deals/${deal.id}`}
+                          className="flex items-center justify-between p-2 rounded-lg hover:bg-gray-50"
+                        >
+                          <div>
+                            <p className="font-medium text-sm">{deal.residentName || '未設定'}</p>
+                            <p className="text-xs text-gray-500">
+                              {deal.assignedToName || '未割当'} • {daysSince}日経過
+                            </p>
+                          </div>
+                          <Badge className={`${config.bgColor} ${config.color}`}>
+                            {deal.status}
+                          </Badge>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/lib/sales.ts
+++ b/src/lib/sales.ts
@@ -1,0 +1,389 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  Timestamp,
+  increment,
+  writeBatch,
+} from 'firebase/firestore';
+import { db, DEFAULT_TENANT_ID } from './firebase';
+import {
+  SalesAccount,
+  SalesAccountFormData,
+  SalesDeal,
+  SalesDealFormData,
+  SalesDealStatus,
+  StatusHistoryEntry,
+  PipelineSummary,
+  SALES_DEAL_STATUSES,
+} from '@/types/sales';
+
+// ヘルパー: dbが初期化されているかチェック
+function ensureDb() {
+  if (!db) {
+    throw new Error('Firestore is not initialized');
+  }
+  return db;
+}
+
+// ======== 営業先（SalesAccount） ========
+
+// 営業先一覧取得
+export async function getSalesAccounts(tenantId: string = DEFAULT_TENANT_ID): Promise<SalesAccount[]> {
+  const firestore = ensureDb();
+  const q = query(
+    collection(firestore, 'salesAccounts'),
+    where('tenantId', '==', tenantId),
+    orderBy('createdAt', 'desc')
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+    createdAt: doc.data().createdAt?.toDate() || new Date(),
+    updatedAt: doc.data().updatedAt?.toDate(),
+  })) as SalesAccount[];
+}
+
+// 営業先取得（単一）
+export async function getSalesAccount(accountId: string): Promise<SalesAccount | null> {
+  const firestore = ensureDb();
+  const docRef = doc(firestore, 'salesAccounts', accountId);
+  const docSnap = await getDoc(docRef);
+  if (!docSnap.exists()) return null;
+  return {
+    id: docSnap.id,
+    ...docSnap.data(),
+    createdAt: docSnap.data().createdAt?.toDate() || new Date(),
+    updatedAt: docSnap.data().updatedAt?.toDate(),
+  } as SalesAccount;
+}
+
+// 営業先作成
+export async function createSalesAccount(
+  data: SalesAccountFormData,
+  createdBy: string,
+  createdByName: string,
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<string> {
+  const firestore = ensureDb();
+  const docRef = await addDoc(collection(firestore, 'salesAccounts'), {
+    ...data,
+    tenantId,
+    totalDeals: 0,
+    activeDeals: 0,
+    completedDeals: 0,
+    createdAt: Timestamp.now(),
+    createdBy,
+    createdByName,
+  });
+  return docRef.id;
+}
+
+// 営業先更新
+export async function updateSalesAccount(
+  accountId: string,
+  data: Partial<SalesAccountFormData>
+): Promise<void> {
+  const firestore = ensureDb();
+  const docRef = doc(firestore, 'salesAccounts', accountId);
+  await updateDoc(docRef, {
+    ...data,
+    updatedAt: Timestamp.now(),
+  });
+}
+
+// 営業先削除
+export async function deleteSalesAccount(accountId: string): Promise<void> {
+  const firestore = ensureDb();
+  // 関連する案件があるかチェック
+  const dealsQuery = query(
+    collection(firestore, 'salesDeals'),
+    where('accountId', '==', accountId)
+  );
+  const dealsSnapshot = await getDocs(dealsQuery);
+  if (!dealsSnapshot.empty) {
+    throw new Error('この営業先には案件が紐付いているため削除できません');
+  }
+  await deleteDoc(doc(firestore, 'salesAccounts', accountId));
+}
+
+// ======== 案件（SalesDeal） ========
+
+// 案件一覧取得
+export async function getSalesDeals(
+  tenantId: string = DEFAULT_TENANT_ID,
+  filters?: {
+    accountId?: string;
+    status?: SalesDealStatus;
+    assignedToId?: string;
+  }
+): Promise<SalesDeal[]> {
+  const firestore = ensureDb();
+  let q = query(
+    collection(firestore, 'salesDeals'),
+    where('tenantId', '==', tenantId),
+    orderBy('createdAt', 'desc')
+  );
+
+  const snapshot = await getDocs(q);
+  let deals = snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+    createdAt: doc.data().createdAt?.toDate() || new Date(),
+    updatedAt: doc.data().updatedAt?.toDate(),
+    statusHistory: (doc.data().statusHistory || []).map((h: { changedAt: { toDate: () => Date } }) => ({
+      ...h,
+      changedAt: h.changedAt?.toDate?.() || new Date(),
+    })),
+  })) as SalesDeal[];
+
+  // フィルタリング（クライアント側）
+  if (filters?.accountId) {
+    deals = deals.filter((d) => d.accountId === filters.accountId);
+  }
+  if (filters?.status) {
+    deals = deals.filter((d) => d.status === filters.status);
+  }
+  if (filters?.assignedToId) {
+    deals = deals.filter((d) => d.assignedToId === filters.assignedToId);
+  }
+
+  return deals;
+}
+
+// 案件取得（単一）
+export async function getSalesDeal(dealId: string): Promise<SalesDeal | null> {
+  const firestore = ensureDb();
+  const docRef = doc(firestore, 'salesDeals', dealId);
+  const docSnap = await getDoc(docRef);
+  if (!docSnap.exists()) return null;
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    ...data,
+    createdAt: data.createdAt?.toDate() || new Date(),
+    updatedAt: data.updatedAt?.toDate(),
+    statusHistory: (data.statusHistory || []).map((h: { changedAt: { toDate: () => Date } }) => ({
+      ...h,
+      changedAt: h.changedAt?.toDate?.() || new Date(),
+    })),
+  } as SalesDeal;
+}
+
+// 案件作成
+export async function createSalesDeal(
+  data: SalesDealFormData,
+  createdBy: string,
+  createdByName: string,
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<string> {
+  const firestore = ensureDb();
+  const batch = writeBatch(firestore);
+
+  // 営業先の名前を取得
+  const account = await getSalesAccount(data.accountId);
+  if (!account) {
+    throw new Error('営業先が見つかりません');
+  }
+
+  // 初期ステータス履歴
+  const initialHistory: StatusHistoryEntry = {
+    status: data.status,
+    changedAt: new Date(),
+    changedBy: createdBy,
+    changedByName: createdByName,
+    note: '案件作成',
+  };
+
+  // 案件作成
+  const dealRef = doc(collection(firestore, 'salesDeals'));
+  batch.set(dealRef, {
+    ...data,
+    accountName: account.name,
+    tenantId,
+    statusHistory: [initialHistory],
+    createdAt: Timestamp.now(),
+    createdBy,
+    createdByName,
+  });
+
+  // 営業先の統計更新
+  const accountRef = doc(firestore, 'salesAccounts', data.accountId);
+  batch.update(accountRef, {
+    totalDeals: increment(1),
+    activeDeals: increment(1),
+    updatedAt: Timestamp.now(),
+  });
+
+  await batch.commit();
+  return dealRef.id;
+}
+
+// 案件更新
+export async function updateSalesDeal(
+  dealId: string,
+  data: Partial<SalesDealFormData & { actualMoveInDate?: string; invoiceDate?: string; invoiceAmount?: number }>
+): Promise<void> {
+  const firestore = ensureDb();
+  const docRef = doc(firestore, 'salesDeals', dealId);
+  await updateDoc(docRef, {
+    ...data,
+    updatedAt: Timestamp.now(),
+  });
+}
+
+// ステータス更新（履歴付き）
+export async function updateDealStatus(
+  dealId: string,
+  newStatus: SalesDealStatus,
+  changedBy: string,
+  changedByName: string,
+  note?: string
+): Promise<void> {
+  const firestore = ensureDb();
+  const deal = await getSalesDeal(dealId);
+  if (!deal) {
+    throw new Error('案件が見つかりません');
+  }
+
+  const oldStatus = deal.status;
+  const batch = writeBatch(firestore);
+
+  // ステータス履歴エントリ
+  const historyEntry: StatusHistoryEntry = {
+    status: newStatus,
+    changedAt: new Date(),
+    changedBy,
+    changedByName,
+    note,
+  };
+
+  // 案件更新
+  const dealRef = doc(firestore, 'salesDeals', dealId);
+  batch.update(dealRef, {
+    status: newStatus,
+    statusHistory: [...deal.statusHistory, historyEntry],
+    updatedAt: Timestamp.now(),
+  });
+
+  // 営業先の統計更新
+  const accountRef = doc(firestore, 'salesAccounts', deal.accountId);
+  const isOldActive = !['請求書到着', '失注'].includes(oldStatus);
+  const isNewActive = !['請求書到着', '失注'].includes(newStatus);
+  const isNewCompleted = newStatus === '請求書到着';
+  const wasCompleted = oldStatus === '請求書到着';
+
+  if (isOldActive && !isNewActive) {
+    batch.update(accountRef, { activeDeals: increment(-1) });
+  } else if (!isOldActive && isNewActive) {
+    batch.update(accountRef, { activeDeals: increment(1) });
+  }
+
+  if (isNewCompleted && !wasCompleted) {
+    batch.update(accountRef, { completedDeals: increment(1) });
+  } else if (wasCompleted && !isNewCompleted) {
+    batch.update(accountRef, { completedDeals: increment(-1) });
+  }
+
+  await batch.commit();
+}
+
+// 案件削除
+export async function deleteSalesDeal(dealId: string): Promise<void> {
+  const firestore = ensureDb();
+  const deal = await getSalesDeal(dealId);
+  if (!deal) {
+    throw new Error('案件が見つかりません');
+  }
+
+  const batch = writeBatch(firestore);
+
+  // 案件削除
+  batch.delete(doc(firestore, 'salesDeals', dealId));
+
+  // 営業先の統計更新
+  const accountRef = doc(firestore, 'salesAccounts', deal.accountId);
+  const isActive = !['請求書到着', '失注'].includes(deal.status);
+  const isCompleted = deal.status === '請求書到着';
+
+  batch.update(accountRef, {
+    totalDeals: increment(-1),
+    ...(isActive && { activeDeals: increment(-1) }),
+    ...(isCompleted && { completedDeals: increment(-1) }),
+    updatedAt: Timestamp.now(),
+  });
+
+  await batch.commit();
+}
+
+// ======== 集計・レポート ========
+
+// パイプライン集計
+export async function getPipelineSummary(
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<PipelineSummary[]> {
+  const deals = await getSalesDeals(tenantId);
+
+  return SALES_DEAL_STATUSES.map((status) => {
+    const statusDeals = deals.filter((d) => d.status === status);
+    return {
+      status,
+      count: statusDeals.length,
+      deals: statusDeals,
+    };
+  });
+}
+
+// 担当者別の案件数取得
+export async function getDealsByAssignee(
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<{ assignedToId: string; assignedToName: string; count: number; deals: SalesDeal[] }[]> {
+  const deals = await getSalesDeals(tenantId);
+
+  const byAssignee: Record<string, { assignedToId: string; assignedToName: string; deals: SalesDeal[] }> = {};
+
+  deals.forEach((deal) => {
+    const key = deal.assignedToId || 'unassigned';
+    if (!byAssignee[key]) {
+      byAssignee[key] = {
+        assignedToId: deal.assignedToId || '',
+        assignedToName: deal.assignedToName || '未割当',
+        deals: [],
+      };
+    }
+    byAssignee[key].deals.push(deal);
+  });
+
+  return Object.values(byAssignee).map((item) => ({
+    ...item,
+    count: item.deals.length,
+  }));
+}
+
+// 停滞案件の取得
+export async function getStaleDeals(
+  tenantId: string = DEFAULT_TENANT_ID,
+  staleDays: number = 7
+): Promise<SalesDeal[]> {
+  const deals = await getSalesDeals(tenantId);
+  const now = new Date();
+
+  return deals.filter((deal) => {
+    if (['請求書到着', '失注'].includes(deal.status)) return false;
+
+    const lastActivity = deal.updatedAt || deal.createdAt;
+    const daysSinceActivity = Math.floor(
+      (now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    return daysSinceActivity >= staleDays;
+  });
+}

--- a/src/types/sales.ts
+++ b/src/types/sales.ts
@@ -1,0 +1,295 @@
+// ======== 営業進捗管理システムの型定義 ========
+
+// 営業先タイプ
+export type SalesAccountType = 'MSW' | '仲介会社' | 'ケアマネ' | 'その他';
+
+export const SALES_ACCOUNT_TYPES: SalesAccountType[] = [
+  'MSW',
+  '仲介会社',
+  'ケアマネ',
+  'その他',
+];
+
+// 案件ステータス
+export type SalesDealStatus =
+  | 'テレアポ'
+  | '資料送付'
+  | '面談'
+  | '担当者決定'
+  | '入居相談'
+  | '入居契約'
+  | '入居確認'
+  | '請求書到着'
+  | '失注'
+  | '保留';
+
+export const SALES_DEAL_STATUSES: SalesDealStatus[] = [
+  'テレアポ',
+  '資料送付',
+  '面談',
+  '担当者決定',
+  '入居相談',
+  '入居契約',
+  '入居確認',
+  '請求書到着',
+];
+
+// パイプライン順序（進捗計算用）
+export const SALES_DEAL_STATUS_ORDER: Record<SalesDealStatus, number> = {
+  'テレアポ': 1,
+  '資料送付': 2,
+  '面談': 3,
+  '担当者決定': 4,
+  '入居相談': 5,
+  '入居契約': 6,
+  '入居確認': 7,
+  '請求書到着': 8,
+  '失注': -1,
+  '保留': 0,
+};
+
+// ステータス設定（色など）
+export const SALES_DEAL_STATUS_CONFIG: Record<SalesDealStatus, {
+  label: string;
+  color: string;
+  bgColor: string;
+}> = {
+  'テレアポ': { label: 'テレアポ', color: 'text-gray-700', bgColor: 'bg-gray-100' },
+  '資料送付': { label: '資料送付', color: 'text-blue-700', bgColor: 'bg-blue-100' },
+  '面談': { label: '面談', color: 'text-purple-700', bgColor: 'bg-purple-100' },
+  '担当者決定': { label: '担当者決定', color: 'text-indigo-700', bgColor: 'bg-indigo-100' },
+  '入居相談': { label: '入居相談', color: 'text-cyan-700', bgColor: 'bg-cyan-100' },
+  '入居契約': { label: '入居契約', color: 'text-orange-700', bgColor: 'bg-orange-100' },
+  '入居確認': { label: '入居確認', color: 'text-teal-700', bgColor: 'bg-teal-100' },
+  '請求書到着': { label: '請求書到着', color: 'text-green-700', bgColor: 'bg-green-100' },
+  '失注': { label: '失注', color: 'text-red-700', bgColor: 'bg-red-100' },
+  '保留': { label: '保留', color: 'text-yellow-700', bgColor: 'bg-yellow-100' },
+};
+
+// 介護度（prospect.tsから再利用可能だが、独立性のため定義）
+export type CareLevel =
+  | '要支援1'
+  | '要支援2'
+  | '要介護1'
+  | '要介護2'
+  | '要介護3'
+  | '要介護4'
+  | '要介護5'
+  | '自立'
+  | '申請中'
+  | '不明';
+
+export const CARE_LEVELS: CareLevel[] = [
+  '自立',
+  '要支援1',
+  '要支援2',
+  '要介護1',
+  '要介護2',
+  '要介護3',
+  '要介護4',
+  '要介護5',
+  '申請中',
+  '不明',
+];
+
+// ======== 営業先（SalesAccount） ========
+
+export interface SalesAccount {
+  id: string;
+  tenantId: string;
+
+  // 基本情報
+  name: string;                    // 会社名/施設名
+  type: SalesAccountType;          // タイプ（MSW/仲介会社/ケアマネ）
+  phone?: string;                  // 電話番号
+  email?: string;                  // メールアドレス
+  address?: string;                // 住所
+
+  // 担当者情報（先方）
+  contactPerson?: string;          // 担当者名
+  contactPhone?: string;           // 担当者電話
+  contactEmail?: string;           // 担当者メール
+
+  // 自社担当
+  assignedToId?: string;           // 担当営業ID
+  assignedToName?: string;         // 担当営業名
+
+  // メモ
+  notes?: string;
+
+  // 統計（自動更新）
+  totalDeals?: number;             // 総案件数
+  activeDeals?: number;            // 進行中案件数
+  completedDeals?: number;         // 成約数
+
+  // メタ
+  createdAt: Date;
+  updatedAt?: Date;
+  createdBy?: string;
+  createdByName?: string;
+}
+
+// 営業先作成フォーム
+export interface SalesAccountFormData {
+  name: string;
+  type: SalesAccountType;
+  phone?: string;
+  email?: string;
+  address?: string;
+  contactPerson?: string;
+  contactPhone?: string;
+  contactEmail?: string;
+  assignedToId?: string;
+  assignedToName?: string;
+  notes?: string;
+}
+
+// ======== 案件（SalesDeal） ========
+
+// ステータス変更履歴
+export interface StatusHistoryEntry {
+  status: SalesDealStatus;
+  changedAt: Date;
+  changedBy: string;
+  changedByName: string;
+  note?: string;
+}
+
+// ADL情報
+export interface ADLInfo {
+  standing?: string;     // 立位
+  bathing?: string;      // 入浴
+  eating?: string;       // 食事
+  toileting?: string;    // 排泄
+  mobility?: string;     // 移動
+  communication?: string; // コミュニケーション
+  other?: string;        // その他
+}
+
+export interface SalesDeal {
+  id: string;
+  tenantId: string;
+
+  // 営業先への参照
+  accountId: string;
+  accountName?: string;            // 非正規化（表示用）
+
+  // ステータス
+  status: SalesDealStatus;
+  statusHistory: StatusHistoryEntry[];
+
+  // 自社担当
+  assignedToId?: string;
+  assignedToName?: string;
+
+  // 入居者情報
+  residentName?: string;           // 入居者名
+  residentAge?: number;            // 年齢
+  residentGender?: '男性' | '女性' | '不明';
+  careLevel?: CareLevel;           // 介護度
+  adl?: ADLInfo;                   // ADL情報
+  adlSummary?: string;             // ADL概要（テキスト）
+
+  // 入居情報
+  targetBranchId?: string;         // 入居先事業所ID
+  targetBranchName?: string;       // 入居先事業所名
+  expectedMoveInDate?: string;     // 入居予定日
+  actualMoveInDate?: string;       // 実際の入居日
+
+  // 請求情報
+  invoiceDate?: string;            // 請求書到着日
+  invoiceAmount?: number;          // 請求金額
+
+  // メモ
+  notes?: string;
+
+  // 通知
+  lastNotifiedAt?: Date;           // 最終通知日時
+
+  // prospectとの連携（オプション）
+  prospectId?: string;             // 連携するprospect ID
+
+  // メタ
+  createdAt: Date;
+  updatedAt?: Date;
+  createdBy?: string;
+  createdByName?: string;
+}
+
+// 案件作成フォーム
+export interface SalesDealFormData {
+  accountId: string;
+  status: SalesDealStatus;
+  assignedToId?: string;
+  assignedToName?: string;
+  residentName?: string;
+  residentAge?: number;
+  residentGender?: '男性' | '女性' | '不明';
+  careLevel?: CareLevel;
+  adl?: ADLInfo;
+  adlSummary?: string;
+  targetBranchId?: string;
+  targetBranchName?: string;
+  expectedMoveInDate?: string;
+  notes?: string;
+}
+
+// ======== 集計・レポート用 ========
+
+// パイプライン集計
+export interface PipelineSummary {
+  status: SalesDealStatus;
+  count: number;
+  deals: SalesDeal[];
+}
+
+// 営業成績
+export interface SalesPerformance {
+  userId: string;
+  userName: string;
+  period: string;                  // YYYY-MM
+  newDeals: number;                // 新規案件数
+  completedDeals: number;          // 成約数
+  lostDeals: number;               // 失注数
+  conversionRate: number;          // 成約率
+}
+
+// 月次レポート
+export interface MonthlySalesReport {
+  period: string;                  // YYYY-MM
+  totalNewDeals: number;
+  totalCompletedDeals: number;
+  totalLostDeals: number;
+  byAccount: {
+    accountId: string;
+    accountName: string;
+    accountType: SalesAccountType;
+    deals: number;
+    completed: number;
+  }[];
+  byAssignee: SalesPerformance[];
+  pipelineSummary: PipelineSummary[];
+}
+
+// ======== 通知設定 ========
+
+export const SALES_NOTIFICATION_TRIGGERS: SalesDealStatus[] = [
+  '面談',
+  '入居契約',
+  '入居確認',
+  '請求書到着',
+];
+
+// 停滞アラート日数
+export const STALE_DEAL_DAYS: Record<SalesDealStatus, number> = {
+  'テレアポ': 7,
+  '資料送付': 5,
+  '面談': 7,
+  '担当者決定': 14,
+  '入居相談': 14,
+  '入居契約': 7,
+  '入居確認': 3,
+  '請求書到着': 30,
+  '失注': 999,
+  '保留': 30,
+};


### PR DESCRIPTION
営業先（MSW/仲介会社/ケアマネ）と案件のパイプライン管理機能を実装

## 新規ファイル
- src/types/sales.ts: 型定義（SalesAccount, SalesDeal, ステータス等）
- src/lib/sales.ts: Firestore CRUD関数
- src/app/sales/page.tsx: ダッシュボード（パイプライン全体表示）
- src/app/sales/accounts/page.tsx: 営業先一覧・登録・編集
- src/app/sales/deals/page.tsx: 案件一覧・新規作成
- src/app/sales/deals/[id]/page.tsx: 案件詳細・ステータス変更

## 機能
- 営業先の登録・編集・削除
- 案件のパイプライン管理（テレアポ→資料送付→面談→...→請求書到着）
- ステータス変更履歴の記録
- 入居者情報（名前、年齢、介護度、ADL）の管理
- 停滞案件（7日以上更新なし）の表示
- 担当者別の案件管理