### PR TITLE
feat: 余裕メーターのラベル更新（赤：サポートが必要）

### DIFF
--- a/src/app/dashboard/os/checkin/page.tsx
+++ b/src/app/dashboard/os/checkin/page.tsx
@@ -15,6 +15,10 @@ import {
   CHECKIN_LABELS,
   CHECKIN_SCALE_LABELS,
   SUPPORT_PURPOSE_TEXT,
+  METER_LABELS,
+  METER_COLORS,
+  getMeterColor,
+  MeterColor,
 } from '@/types/chaos';
 import {
   ArrowLeft,
@@ -229,31 +233,39 @@ function OSCheckinContent() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="space-y-2">
-                  {history.map((checkin) => {
-                    // 簡易スコア計算
+                {/* 7日間の色推移（数値は表示しない） */}
+                <div className="flex gap-1 mb-4">
+                  {history.slice(0, 7).map((checkin) => {
                     const avgScore = Math.round(
                       ((checkin.physicalFatigue + checkin.mentalFatigue + checkin.anxiety +
                         checkin.decisionLoad + (4 - checkin.sleep) + (4 - checkin.consulted)) / 6) * 25
                     );
+                    const color = getMeterColor(avgScore);
                     return (
                       <div
                         key={checkin.id}
-                        className={`flex items-center justify-between p-3 rounded-lg ${
-                          avgScore >= 60 ? 'bg-red-50' :
-                          avgScore >= 40 ? 'bg-yellow-50' :
-                          'bg-green-50'
-                        }`}
+                        className={`w-8 h-8 rounded-full ${METER_COLORS[color].bg} ${METER_COLORS[color].border} border-2`}
+                        title={`${checkin.date}: ${METER_LABELS[color]}`}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="space-y-2">
+                  {history.map((checkin) => {
+                    const avgScore = Math.round(
+                      ((checkin.physicalFatigue + checkin.mentalFatigue + checkin.anxiety +
+                        checkin.decisionLoad + (4 - checkin.sleep) + (4 - checkin.consulted)) / 6) * 25
+                    );
+                    const color = getMeterColor(avgScore);
+                    return (
+                      <div
+                        key={checkin.id}
+                        className={`flex items-center justify-between p-3 rounded-lg ${METER_COLORS[color].bg}`}
                       >
                         <span className="text-sm font-medium">{checkin.date}</span>
-                        <div className="flex items-center gap-2">
-                          <TrendingUp className={`w-4 h-4 ${
-                            avgScore >= 60 ? 'text-red-600' :
-                            avgScore >= 40 ? 'text-yellow-600' :
-                            'text-green-600'
-                          }`} />
-                          <span className="text-sm">{avgScore}</span>
-                        </div>
+                        <span className={`text-sm font-medium ${METER_COLORS[color].text}`}>
+                          {METER_LABELS[color]}
+                        </span>
                       </div>
                     );
                   })}

--- a/src/app/dashboard/os/team/page.tsx
+++ b/src/app/dashboard/os/team/page.tsx
@@ -10,7 +10,7 @@ import { Loading } from '@/components/Loading';
 import { PreviewBadge } from '@/components/PreviewBadge';
 import { getChaosDashboardMetrics, getInterventions } from '@/lib/chaos';
 import { DEFAULT_TENANT_ID } from '@/lib/firebase';
-import { Intervention } from '@/types/chaos';
+import { Intervention, METER_LABELS, METER_COLORS, MeterColor } from '@/types/chaos';
 import { getChaosViewLevel, canViewTeamChaosData, ChaosViewLevel } from '@/lib/auth';
 import {
   ArrowLeft,
@@ -189,7 +189,7 @@ function OSTeamContent() {
             <Card className={`p-4 ${redCount > 0 ? 'bg-red-50 border-red-200' : ''}`}>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-gray-500">要支援（レッド）</p>
+                  <p className="text-sm text-gray-500">サポートが必要</p>
                   <p className={`text-2xl font-bold ${redCount > 0 ? 'text-red-600' : 'text-gray-900'}`}>
                     {redCount}
                   </p>
@@ -200,7 +200,7 @@ function OSTeamContent() {
             <Card className={`p-4 ${yellowCount > 0 ? 'bg-yellow-50 border-yellow-200' : ''}`}>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm text-gray-500">注意（イエロー）</p>
+                  <p className="text-sm text-gray-500">余裕少なめ</p>
                   <p className={`text-2xl font-bold ${yellowCount > 0 ? 'text-yellow-600' : 'text-gray-900'}`}>
                     {yellowCount}
                   </p>
@@ -265,19 +265,13 @@ function OSTeamContent() {
                         </div>
                         <div className="flex items-center gap-3">
                           <div className="text-right">
-                            <p className="text-lg font-bold">{member.score}</p>
                             <div className="flex items-center gap-1">
                               {member.trend === 'up' && <TrendingUp className="w-3 h-3 text-red-500" />}
                               {member.trend === 'down' && <TrendingUp className="w-3 h-3 text-green-500 rotate-180" />}
                               <Badge
-                                className={
-                                  member.level === 'red' ? 'bg-red-100 text-red-700' :
-                                  member.level === 'yellow' ? 'bg-yellow-100 text-yellow-700' :
-                                  'bg-green-100 text-green-700'
-                                }
+                                className={METER_COLORS[member.level as MeterColor].bg + ' ' + METER_COLORS[member.level as MeterColor].text}
                               >
-                                {member.level === 'red' ? '要支援' :
-                                 member.level === 'yellow' ? '注意' : '良好'}
+                                {METER_LABELS[member.level as MeterColor]}
                               </Badge>
                             </div>
                           </div>

--- a/src/types/chaos.ts
+++ b/src/types/chaos.ts
@@ -298,3 +298,25 @@ export const CHECKIN_SCALE_LABELS = [
 // 支援目的の文言（評価ではないことを明示）
 export const SUPPORT_PURPOSE_TEXT = 'この情報は支援のために使用されます。評価には直結しません。';
 export const ONEONONE_PURPOSE_TEXT = '1on1は評価や指導ではなく、あなたを支えるための安全装置です。';
+
+// 余裕メーター（社員向け表示）
+export type MeterColor = 'green' | 'yellow' | 'red';
+
+export const METER_LABELS: Record<MeterColor, string> = {
+  green: '余裕あり',
+  yellow: '余裕少なめ',
+  red: 'サポートが必要',
+} as const;
+
+export const METER_COLORS: Record<MeterColor, { bg: string; text: string; border: string }> = {
+  green: { bg: 'bg-green-100', text: 'text-green-700', border: 'border-green-200' },
+  yellow: { bg: 'bg-yellow-100', text: 'text-yellow-700', border: 'border-yellow-200' },
+  red: { bg: 'bg-red-100', text: 'text-red-700', border: 'border-red-200' },
+} as const;
+
+// スコアから余裕メーターの色を判定
+export function getMeterColor(score: number): MeterColor {
+  if (score >= 70) return 'red';
+  if (score >= 40) return 'yellow';
+  return 'green';
+}


### PR DESCRIPTION
- 余裕メーターの定数を追加
  - METER_LABELS: green=余裕あり, yellow=余裕少なめ, red=サポートが必要
  - METER_COLORS: 各色のスタイル定義
  - getMeterColor(): スコアから色を判定する関数
- チェックインページ更新
  - 数値を非表示にし、ラベルのみ表示
  - 7日間の色推移を丸で表示
- チームページ更新
  - スコア数値を非表示
  - ラベルを正しい表現に更新

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
