### PR TITLE
feat: 部屋ロックUI・API実装（申込中ステータス連携）

### DIFF
--- a/src/app/api/prospects/[id]/lock-room/route.ts
+++ b/src/app/api/prospects/[id]/lock-room/route.ts
@@ -1,0 +1,194 @@
+// ======== 部屋ロックAPI ========
+import { NextRequest, NextResponse } from 'next/server';
+import { lockRoomForApplication, unlockRoom, updateProspect, getProspect, getRooms } from '@/lib/prospect';
+import { DEFAULT_TENANT_ID } from '@/lib/firebase';
+import { UserRole } from '@/types';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/prospects/:id/lock-room
+ * 部屋をロックして入居希望に紐付ける
+ * Body:
+ *   - roomId: ロックする部屋ID
+ *   - userId: 操作ユーザーID
+ *   - userName: 操作ユーザー名
+ *   - userRole: 操作ユーザー権限
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: prospectId } = await params;
+    const body = await request.json();
+    const { roomId, userId, userName, userRole } = body;
+
+    // パラメータチェック
+    if (!roomId || !userId || !userName || !userRole) {
+      return NextResponse.json(
+        { success: false, error: 'roomId, userId, userName, userRoleは必須です' },
+        { status: 400 }
+      );
+    }
+
+    // プロスペクトの存在確認
+    const prospect = await getProspect(prospectId);
+    if (!prospect) {
+      return NextResponse.json(
+        { success: false, error: '入居希望が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 既にロック済みの部屋がある場合は先に解除
+    if (prospect.selectedRoomId) {
+      await unlockRoom(
+        prospect.selectedRoomId,
+        userId,
+        userName,
+        userRole as UserRole,
+        DEFAULT_TENANT_ID
+      );
+    }
+
+    // 部屋をロック
+    const lockResult = await lockRoomForApplication(
+      roomId,
+      prospectId,
+      userId,
+      userName,
+      userRole as UserRole,
+      DEFAULT_TENANT_ID
+    );
+
+    if (!lockResult.success) {
+      return NextResponse.json(
+        { success: false, error: lockResult.error },
+        { status: 400 }
+      );
+    }
+
+    // 部屋情報を取得して名前を保存
+    const rooms = await getRooms(DEFAULT_TENANT_ID);
+    const lockedRoom = rooms.find((r) => r.id === roomId);
+    const roomName = lockedRoom
+      ? `${lockedRoom.buildingName} ${lockedRoom.roomNumber}`
+      : roomId;
+
+    // プロスペクトを更新（部屋情報を紐付け）
+    await updateProspect(
+      prospectId,
+      {
+        selectedRoomId: roomId,
+        selectedRoomName: roomName,
+        appliedAt: new Date(),
+      },
+      userId,
+      userName,
+      userRole as UserRole
+    );
+
+    return NextResponse.json({
+      success: true,
+      message: `部屋「${roomName}」をロックしました`,
+      data: {
+        prospectId,
+        roomId,
+        roomName,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to lock room:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/prospects/:id/lock-room
+ * 部屋のロックを解除
+ * Body:
+ *   - userId: 操作ユーザーID
+ *   - userName: 操作ユーザー名
+ *   - userRole: 操作ユーザー権限
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: prospectId } = await params;
+    const body = await request.json();
+    const { userId, userName, userRole } = body;
+
+    // パラメータチェック
+    if (!userId || !userName || !userRole) {
+      return NextResponse.json(
+        { success: false, error: 'userId, userName, userRoleは必須です' },
+        { status: 400 }
+      );
+    }
+
+    // プロスペクトの存在確認
+    const prospect = await getProspect(prospectId);
+    if (!prospect) {
+      return NextResponse.json(
+        { success: false, error: '入居希望が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // ロック済み部屋がない場合
+    if (!prospect.selectedRoomId) {
+      return NextResponse.json(
+        { success: false, error: 'ロック済みの部屋がありません' },
+        { status: 400 }
+      );
+    }
+
+    // 部屋のロックを解除
+    const unlockResult = await unlockRoom(
+      prospect.selectedRoomId,
+      userId,
+      userName,
+      userRole as UserRole,
+      DEFAULT_TENANT_ID
+    );
+
+    if (!unlockResult.success) {
+      return NextResponse.json(
+        { success: false, error: unlockResult.error },
+        { status: 400 }
+      );
+    }
+
+    // プロスペクトの部屋情報をクリア
+    await updateProspect(
+      prospectId,
+      {
+        selectedRoomId: undefined,
+        selectedRoomName: undefined,
+        appliedAt: undefined,
+      },
+      userId,
+      userName,
+      userRole as UserRole
+    );
+
+    return NextResponse.json({
+      success: true,
+      message: 'ロックを解除しました',
+    });
+  } catch (error) {
+    console.error('Failed to unlock room:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/rooms/available/route.ts
+++ b/src/app/api/rooms/available/route.ts
@@ -1,0 +1,52 @@
+// ======== 空室一覧API ========
+import { NextRequest, NextResponse } from 'next/server';
+import { getRooms, findAvailableRooms } from '@/lib/prospect';
+import { DEFAULT_TENANT_ID } from '@/lib/firebase';
+
+/**
+ * GET /api/rooms/available
+ * 空室一覧を取得（ロック済み部屋も含む）
+ * Query params:
+ *   - buildingName: 建物名でフィルター（任意）
+ *   - onlyAvailable: trueなら空室のみ（デフォルト: false）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const buildingName = searchParams.get('buildingName') || undefined;
+    const onlyAvailable = searchParams.get('onlyAvailable') === 'true';
+    const tenantId = DEFAULT_TENANT_ID;
+
+    let rooms;
+    if (onlyAvailable) {
+      rooms = await findAvailableRooms(tenantId, buildingName);
+    } else {
+      rooms = await getRooms(tenantId, buildingName);
+      // 空室と予約のみを返す（入居中は除外）
+      rooms = rooms.filter((r) => r.status === '空室' || r.status === '予約');
+    }
+
+    // レスポンス用にDate→ISO文字列に変換
+    const roomsResponse = rooms.map((room) => ({
+      ...room,
+      lockedAt: room.lockedAt?.toISOString() || null,
+      createdAt: room.createdAt?.toISOString() || null,
+      updatedAt: room.updatedAt?.toISOString() || null,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      rooms: roomsResponse,
+      count: roomsResponse.length,
+    });
+  } catch (error) {
+    console.error('Failed to fetch available rooms:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/prospects/[id]/page.tsx
+++ b/src/app/dashboard/prospects/[id]/page.tsx
@@ -46,6 +46,8 @@ import {
   Home,
   ChevronDown,
   ChevronUp,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 import { getUsers } from '@/lib/firestore';
 import { ProspectDocuments } from '@/components/ProspectDocuments';
@@ -80,6 +82,12 @@ function ProspectDetailContent() {
   // 折りたたみ
   const [showRawData, setShowRawData] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+
+  // 部屋選択モーダル
+  const [showRoomModal, setShowRoomModal] = useState(false);
+  const [pendingStatus, setPendingStatus] = useState<ProspectStatus | null>(null);
+  const [allRooms, setAllRooms] = useState<Room[]>([]);
+  const [loadingRooms, setLoadingRooms] = useState(false);
 
   const canManage = hasMinRole(user?.role, 'leader');
 
@@ -127,10 +135,46 @@ function ProspectDetailContent() {
   const handleStatusChange = async (newStatus: ProspectStatus) => {
     if (!prospect || !user || !canManage) return;
 
+    // 「申込中」への変更時は部屋選択モーダルを表示
+    if (newStatus === '申込中') {
+      setPendingStatus(newStatus);
+      setLoadingRooms(true);
+      try {
+        const response = await fetch('/api/rooms/available');
+        const data = await response.json();
+        if (data.success) {
+          setAllRooms(data.rooms);
+        }
+      } catch (err) {
+        console.error('Failed to fetch rooms:', err);
+      } finally {
+        setLoadingRooms(false);
+      }
+      setShowRoomModal(true);
+      return;
+    }
+
+    // 「見送り」「クローズ」への変更時は自動的にロック解除
+    if ((newStatus === '見送り' || newStatus === 'クローズ') && prospect.selectedRoomId) {
+      try {
+        await fetch(`/api/prospects/${prospect.id}/lock-room`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            userId: user.id,
+            userName: user.name,
+            userRole: user.role,
+          }),
+        });
+      } catch (err) {
+        console.error('Failed to unlock room:', err);
+      }
+    }
+
     setSaving(true);
     setError(null);
     try {
-      const result = await updateProspectStatus(
+      await updateProspectStatus(
         prospect.id,
         newStatus,
         undefined,
@@ -142,6 +186,110 @@ function ProspectDetailContent() {
       await fetchData();
     } catch (err) {
       setError(err instanceof Error ? err.message : '更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // 部屋選択後の処理
+  const handleRoomSelect = async (roomId: string) => {
+    if (!prospect || !user || !pendingStatus) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      // 部屋をロック
+      const lockResponse = await fetch(`/api/prospects/${prospect.id}/lock-room`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          roomId,
+          userId: user.id,
+          userName: user.name,
+          userRole: user.role,
+        }),
+      });
+      const lockData = await lockResponse.json();
+
+      if (!lockData.success) {
+        setError(lockData.error || '部屋のロックに失敗しました');
+        return;
+      }
+
+      // ステータスを更新
+      await updateProspectStatus(
+        prospect.id,
+        pendingStatus,
+        undefined,
+        user.id,
+        user.name,
+        user.role
+      );
+
+      setSuccess(`ステータスを「${pendingStatus}」に更新し、${lockData.data.roomName}をロックしました`);
+      setShowRoomModal(false);
+      setPendingStatus(null);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // 部屋選択をスキップ
+  const handleSkipRoomSelect = async () => {
+    if (!prospect || !user || !pendingStatus) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      await updateProspectStatus(
+        prospect.id,
+        pendingStatus,
+        undefined,
+        user.id,
+        user.name,
+        user.role
+      );
+      setSuccess(`ステータスを「${pendingStatus}」に更新しました（部屋未選択）`);
+      setShowRoomModal(false);
+      setPendingStatus(null);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ロック解除
+  const handleUnlockRoom = async () => {
+    if (!prospect || !user || !prospect.selectedRoomId) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/prospects/${prospect.id}/lock-room`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: user.id,
+          userName: user.name,
+          userRole: user.role,
+        }),
+      });
+      const data = await response.json();
+
+      if (!data.success) {
+        setError(data.error || 'ロック解除に失敗しました');
+        return;
+      }
+
+      setSuccess('ロックを解除しました');
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'ロック解除に失敗しました');
     } finally {
       setSaving(false);
     }
@@ -319,6 +467,36 @@ function ProspectDetailContent() {
                       ]}
                       disabled={saving}
                     />
+                  </div>
+                </div>
+              )}
+
+              {/* ロック済み部屋の表示 */}
+              {prospect.selectedRoomId && (
+                <div className="mt-4 pt-4 border-t">
+                  <div className="flex items-center justify-between p-3 bg-blue-50 rounded-lg">
+                    <div className="flex items-center gap-2">
+                      <Lock className="w-4 h-4 text-blue-600" />
+                      <span className="text-sm text-blue-800">
+                        <span className="font-medium">{prospect.selectedRoomName}</span> をロック中
+                      </span>
+                      {prospect.appliedAt && (
+                        <span className="text-xs text-blue-600">
+                          （{new Date(prospect.appliedAt).toLocaleDateString('ja-JP')}〜）
+                        </span>
+                      )}
+                    </div>
+                    {canManage && (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={handleUnlockRoom}
+                        disabled={saving}
+                      >
+                        <Unlock className="w-4 h-4 mr-1" />
+                        解除
+                      </Button>
+                    )}
                   </div>
                 </div>
               )}
@@ -575,6 +753,103 @@ function ProspectDetailContent() {
             )}
           </Card>
         </div>
+
+        {/* 部屋選択モーダル */}
+        {showRoomModal && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] overflow-hidden">
+              <div className="p-4 border-b flex items-center justify-between">
+                <h3 className="text-lg font-bold flex items-center gap-2">
+                  <Home className="w-5 h-5" />
+                  部屋を選択
+                </h3>
+                <button
+                  onClick={() => {
+                    setShowRoomModal(false);
+                    setPendingStatus(null);
+                  }}
+                  className="p-2 hover:bg-gray-100 rounded"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+
+              <div className="p-4 overflow-y-auto max-h-[60vh]">
+                {loadingRooms ? (
+                  <div className="text-center py-8 text-gray-500">読み込み中...</div>
+                ) : allRooms.length === 0 ? (
+                  <div className="text-center py-8 text-gray-500">空室がありません</div>
+                ) : (
+                  <>
+                    <p className="text-sm text-gray-600 mb-4">
+                      申込に伴い、ロックする部屋を選択してください。
+                    </p>
+                    {/* 建物ごとにグループ化 */}
+                    {Object.entries(
+                      allRooms.reduce((acc, room) => {
+                        if (!acc[room.buildingName]) acc[room.buildingName] = [];
+                        acc[room.buildingName].push(room);
+                        return acc;
+                      }, {} as Record<string, Room[]>)
+                    ).map(([buildingName, rooms]) => (
+                      <div key={buildingName} className="mb-4">
+                        <h4 className="text-sm font-medium text-gray-700 mb-2">{buildingName}</h4>
+                        <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                          {rooms.map((room) => (
+                            <button
+                              key={room.id}
+                              onClick={() => handleRoomSelect(room.id)}
+                              disabled={saving || room.status === '予約'}
+                              className={`p-3 rounded-lg text-left transition ${
+                                room.status === '予約'
+                                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                                  : 'bg-green-50 hover:bg-green-100 text-green-800'
+                              }`}
+                            >
+                              <p className="font-medium">{room.roomNumber}</p>
+                              <p className="text-xs">
+                                {room.status === '予約' ? (
+                                  <span className="flex items-center gap-1">
+                                    <Lock className="w-3 h-3" />
+                                    ロック済
+                                  </span>
+                                ) : (
+                                  '空室'
+                                )}
+                              </p>
+                              {room.expectedCareLevel && (
+                                <p className="text-xs opacity-75">{room.expectedCareLevel}</p>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </>
+                )}
+              </div>
+
+              <div className="p-4 border-t flex justify-end gap-2">
+                <Button
+                  variant="secondary"
+                  onClick={handleSkipRoomSelect}
+                  disabled={saving}
+                >
+                  部屋を選択せずに進む
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    setShowRoomModal(false);
+                    setPendingStatus(null);
+                  }}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </main>
     </>
   );

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -12,9 +12,12 @@ import {
   seedFacilitiesIfEmpty,
   syncVacancyData,
 } from '@/lib/vacancy';
+import { getRooms } from '@/lib/prospect';
+import { Room } from '@/types/prospect';
 import { FacilityWithVacancy } from '@/types/vacancy';
 import { hasMinRole } from '@/lib/auth';
-import { Building2, Edit2, Save, X, RefreshCw, Clock, User, AlertTriangle, TrendingUp, Database } from 'lucide-react';
+import { Building2, Edit2, Save, X, RefreshCw, Clock, User, AlertTriangle, TrendingUp, Database, Lock, ChevronDown, ChevronUp } from 'lucide-react';
+import Link from 'next/link';
 
 // 稼働率を計算
 function calcOccupancyRate(capacity: number | undefined, vacantCount: number): number {
@@ -44,6 +47,8 @@ function OccupancyBar({ rate }: { rate: number }) {
 export default function VacancyPage() {
   const { user } = useAuth();
   const [facilities, setFacilities] = useState<FacilityWithVacancy[]>([]);
+  const [lockedRooms, setLockedRooms] = useState<Room[]>([]);
+  const [showLockedRooms, setShowLockedRooms] = useState(true);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValues, setEditValues] = useState<{ vacantCount: number; note: string }>({
@@ -79,8 +84,14 @@ export default function VacancyPage() {
     if (!user) return;
     try {
       await seedFacilitiesIfEmpty(user.tenantId);
-      const data = await getFacilitiesWithVacancy(user.tenantId);
+      const [data, rooms] = await Promise.all([
+        getFacilitiesWithVacancy(user.tenantId),
+        getRooms(user.tenantId),
+      ]);
       setFacilities(data);
+      // ロック済み部屋（予約ステータス）をフィルター
+      const locked = rooms.filter((r) => r.status === '予約' && r.lockedCaseId);
+      setLockedRooms(locked);
       setLastUpdated(new Date());
     } catch (err) {
       console.error('Failed to fetch facilities:', err);
@@ -253,6 +264,67 @@ export default function VacancyPage() {
                   </p>
                 </div>
               </div>
+            </Card>
+          )}
+
+          {/* ロック済み部屋 */}
+          {lockedRooms.length > 0 && (
+            <Card className="mb-6 border border-blue-200">
+              <button
+                onClick={() => setShowLockedRooms(!showLockedRooms)}
+                className="w-full p-4 flex items-center justify-between text-left"
+              >
+                <div className="flex items-center gap-2">
+                  <Lock className="w-5 h-5 text-blue-600" />
+                  <span className="font-medium text-blue-800">
+                    ロック中の部屋（{lockedRooms.length}室）
+                  </span>
+                </div>
+                {showLockedRooms ? (
+                  <ChevronUp className="w-5 h-5 text-gray-400" />
+                ) : (
+                  <ChevronDown className="w-5 h-5 text-gray-400" />
+                )}
+              </button>
+              {showLockedRooms && (
+                <div className="px-4 pb-4">
+                  <p className="text-sm text-gray-600 mb-3">
+                    入居希望者の申込によりロックされている部屋です
+                  </p>
+                  <div className="space-y-2">
+                    {lockedRooms.map((room) => (
+                      <div
+                        key={room.id}
+                        className="flex items-center justify-between p-3 bg-blue-50 rounded-lg"
+                      >
+                        <div>
+                          <span className="font-medium text-blue-800">
+                            {room.buildingName} {room.roomNumber}
+                          </span>
+                          {room.lockedByName && (
+                            <span className="text-xs text-blue-600 ml-2">
+                              by {room.lockedByName}
+                            </span>
+                          )}
+                          {room.lockedAt && (
+                            <span className="text-xs text-gray-500 ml-2">
+                              ({new Date(room.lockedAt).toLocaleDateString('ja-JP')}〜)
+                            </span>
+                          )}
+                        </div>
+                        {room.lockedCaseId && (
+                          <Link
+                            href={`/dashboard/prospects/${room.lockedCaseId}`}
+                            className="text-sm text-blue-600 hover:underline"
+                          >
+                            詳細
+                          </Link>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </Card>
           )}
 

--- a/src/types/prospect.ts
+++ b/src/types/prospect.ts
@@ -177,6 +177,11 @@ export interface Prospect {
   // 書類管理
   documents?: ProspectDocument[];  // アップロードされた書類
 
+  // 部屋ロック関連（申込中ステータス時）
+  selectedRoomId?: string;        // 選択された部屋ID
+  selectedRoomName?: string;      // 選択された部屋名（建物名 + 部屋番号）
+  appliedAt?: Date;               // 申込日時
+
   // メタ
   createdAt: Date;
   updatedAt?: Date;
@@ -235,6 +240,11 @@ export interface Room {
   status: RoomStatus;
   expectedCareLevel?: string;   // 入居想定介護度数
   note?: string;                // 備考
+  // ロック関連
+  lockedCaseId?: string;        // ロック元の入居希望ID
+  lockedAt?: Date;              // ロック日時
+  lockedBy?: string;            // ロックしたユーザーID
+  lockedByName?: string;        // ロックしたユーザー名
   createdAt: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
- 入居希望詳細でステータスを「申込中」に変更時に部屋選択モーダル表示
- 選択した部屋を自動ロック、入居希望に紐付け
- 見送り/クローズ時は自動的にロック解除
- 空室ページにロック済み部屋一覧を表示
- /api/rooms/available: 空室一覧API
- /api/prospects/:id/lock-room: 部屋ロック/解除API

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
