### PR TITLE
fix: ダッシュボード数値表示問題を修正

### DIFF
--- a/__tests__/dashboard-calc.test.ts
+++ b/__tests__/dashboard-calc.test.ts
@@ -1,0 +1,194 @@
+// ======== ダッシュボード計算ユーティリティのテスト ========
+
+import {
+  safeRate,
+  formatPercent,
+  formatFraction,
+  formatNumber,
+  calcOccupancyRate,
+  calcCvRate,
+  calcInterventionRate,
+  extractIndexUrl,
+  toDashboardError,
+} from '../src/lib/dashboard/calc';
+
+describe('dashboard/calc', () => {
+  describe('safeRate', () => {
+    it('分母が0の場合はnullを返す', () => {
+      expect(safeRate(0, 0)).toBe(null);
+      expect(safeRate(5, 0)).toBe(null);
+    });
+
+    it('正常な計算ができる', () => {
+      expect(safeRate(1, 2)).toBe(50);
+      expect(safeRate(1, 4)).toBe(25);
+      expect(safeRate(3, 4)).toBe(75);
+    });
+
+    it('100%を正しく計算する', () => {
+      expect(safeRate(10, 10)).toBe(100);
+    });
+
+    it('0%を正しく計算する', () => {
+      expect(safeRate(0, 10)).toBe(0);
+    });
+
+    it('四捨五入される', () => {
+      expect(safeRate(1, 3)).toBe(33); // 33.33... → 33
+      expect(safeRate(2, 3)).toBe(67); // 66.66... → 67
+    });
+
+    it('分母がInfinityの場合はnullを返す', () => {
+      expect(safeRate(1, Infinity)).toBe(null);
+    });
+
+    it('分母がNaNの場合はnullを返す', () => {
+      expect(safeRate(1, NaN)).toBe(null);
+    });
+  });
+
+  describe('formatPercent', () => {
+    it('nullの場合は"--"を返す', () => {
+      expect(formatPercent(null)).toBe('--');
+    });
+
+    it('undefinedの場合は"--"を返す', () => {
+      expect(formatPercent(undefined)).toBe('--');
+    });
+
+    it('数値の場合は"%"付きで返す', () => {
+      expect(formatPercent(50)).toBe('50%');
+      expect(formatPercent(0)).toBe('0%');
+      expect(formatPercent(100)).toBe('100%');
+    });
+
+    it('NaNの場合は"--"を返す', () => {
+      expect(formatPercent(NaN)).toBe('--');
+    });
+
+    it('Infinityの場合は"--"を返す', () => {
+      expect(formatPercent(Infinity)).toBe('--');
+    });
+  });
+
+  describe('formatFraction', () => {
+    it('分母が0の場合は"--"を返す', () => {
+      expect(formatFraction(0, 0)).toBe('--');
+      expect(formatFraction(5, 0)).toBe('--');
+    });
+
+    it('正常な分数を返す', () => {
+      expect(formatFraction(3, 5)).toBe('3/5');
+      expect(formatFraction(0, 10)).toBe('0/10');
+    });
+
+    it('分母がInfinityの場合は"--"を返す', () => {
+      expect(formatFraction(1, Infinity)).toBe('--');
+    });
+  });
+
+  describe('formatNumber', () => {
+    it('nullの場合は"--"を返す', () => {
+      expect(formatNumber(null)).toBe('--');
+    });
+
+    it('undefinedの場合は"--"を返す', () => {
+      expect(formatNumber(undefined)).toBe('--');
+    });
+
+    it('数値を文字列で返す', () => {
+      expect(formatNumber(42)).toBe('42');
+      expect(formatNumber(0)).toBe('0');
+    });
+
+    it('NaNの場合は"--"を返す', () => {
+      expect(formatNumber(NaN)).toBe('--');
+    });
+  });
+
+  describe('calcOccupancyRate', () => {
+    it('定員が0の場合はnullを返す', () => {
+      expect(calcOccupancyRate(0, 0)).toBe(null);
+    });
+
+    it('稼働率を正しく計算する', () => {
+      // 定員10, 空室2 → 入居8 → 80%
+      expect(calcOccupancyRate(10, 2)).toBe(80);
+      // 定員10, 空室0 → 入居10 → 100%
+      expect(calcOccupancyRate(10, 0)).toBe(100);
+      // 定員10, 空室10 → 入居0 → 0%
+      expect(calcOccupancyRate(10, 10)).toBe(0);
+    });
+  });
+
+  describe('calcCvRate', () => {
+    it('総案件数が0の場合はnullを返す', () => {
+      expect(calcCvRate(0, 0)).toBe(null);
+    });
+
+    it('CV率を正しく計算する', () => {
+      expect(calcCvRate(5, 10)).toBe(50);
+      expect(calcCvRate(0, 10)).toBe(0);
+      expect(calcCvRate(10, 10)).toBe(100);
+    });
+  });
+
+  describe('calcInterventionRate', () => {
+    it('総介入数が0の場合はnullを返す（100%ではない）', () => {
+      expect(calcInterventionRate(0, 0)).toBe(null);
+    });
+
+    it('介入実施率を正しく計算する', () => {
+      expect(calcInterventionRate(8, 10)).toBe(80);
+      expect(calcInterventionRate(0, 10)).toBe(0);
+      expect(calcInterventionRate(10, 10)).toBe(100);
+    });
+  });
+
+  describe('extractIndexUrl', () => {
+    it('FirebaseエラーからインデックスURLを抽出する', () => {
+      const error = new Error(
+        'The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/test/firestore/indexes'
+      );
+      expect(extractIndexUrl(error)).toBe(
+        'https://console.firebase.google.com/v1/r/project/test/firestore/indexes'
+      );
+    });
+
+    it('URLがない場合はundefinedを返す', () => {
+      const error = new Error('Some other error');
+      expect(extractIndexUrl(error)).toBeUndefined();
+    });
+
+    it('Error以外の値の場合はundefinedを返す', () => {
+      expect(extractIndexUrl('string error')).toBeUndefined();
+      expect(extractIndexUrl(null)).toBeUndefined();
+    });
+  });
+
+  describe('toDashboardError', () => {
+    it('インデックス必須エラーを正しく変換する', () => {
+      const error = new Error(
+        'The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/test/firestore/indexes'
+      );
+      const result = toDashboardError(error);
+      expect(result.code).toBe('INDEX_REQUIRED');
+      expect(result.createIndexUrl).toBe(
+        'https://console.firebase.google.com/v1/r/project/test/firestore/indexes'
+      );
+    });
+
+    it('権限エラーを正しく変換する', () => {
+      const error = new Error('permission-denied');
+      const result = toDashboardError(error);
+      expect(result.code).toBe('PERMISSION_DENIED');
+    });
+
+    it('不明なエラーをUNKNOWNとして変換する', () => {
+      const error = new Error('Unknown error');
+      const result = toDashboardError(error);
+      expect(result.code).toBe('UNKNOWN');
+      expect(result.message).toBe('Unknown error');
+    });
+  });
+});

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,54 @@
 {
   "indexes": [
     {
+      "collectionGroup": "staffCheckins",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "staffScoresDaily",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "staffScoresDaily",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "date", "order": "ASCENDING" },
+        { "fieldPath": "burnoutRiskScore", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "interventions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "salesAccounts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "tenantId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "salesDeals",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "tenantId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "pointHistory",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -30,6 +30,14 @@ import {
 } from '@/lib/scoring';
 import { getChaosViewLevel } from '@/lib/auth';
 import {
+  safeRate,
+  formatPercent,
+  calcOccupancyRate,
+  calcInterventionRate,
+  toDashboardError,
+  DashboardError,
+} from '@/lib/dashboard/calc';
+import {
   Heart,
   Shield,
   MessageCircle,
@@ -59,6 +67,7 @@ export default function DashboardPage() {
 function DashboardContent() {
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<DashboardError | null>(null);
 
   // 共通データ
   const [checkinHistory, setCheckinHistory] = useState<StaffCheckin[]>([]);
@@ -79,18 +88,30 @@ function DashboardContent() {
   } | null>(null);
 
   // Exec用データ
-  const [salesMetrics, setSalesMetrics] = useState({
+  const [salesMetrics, setSalesMetrics] = useState<{
+    accounts: number;
+    activeDeals: number;
+    completedDeals: number;
+    totalDeals: number;
+    cvRate: number | null;
+    expectedMoveIns: number;
+    rankA: number;
+    rankB: number;
+    rankC: number;
+    rankD: number;
+  }>({
     accounts: 0,
     activeDeals: 0,
     completedDeals: 0,
-    cvRate: 0,
+    totalDeals: 0,
+    cvRate: null,
     expectedMoveIns: 0,
     rankA: 0,
     rankB: 0,
     rankC: 0,
     rankD: 0,
   });
-  const [occupancyRate, setOccupancyRate] = useState(0);
+  const [occupancyRate, setOccupancyRate] = useState<number | null>(null);
 
   // 役割判定
   const viewLevel = user ? getChaosViewLevel(user.role, user.email) : 'self';
@@ -103,6 +124,8 @@ function DashboardContent() {
       if (!user) return;
 
       try {
+        setError(null);
+
         // 全員：自分のチェックイン履歴
         const history = await getCheckinHistory(user.id, 7);
         setCheckinHistory(history);
@@ -137,9 +160,8 @@ function DashboardContent() {
 
           const activeDeals = dealsData.filter(d => !['請求書到着', '失注'].includes(d.status));
           const completedDeals = dealsData.filter(d => d.status === '請求書到着');
-          const cvRate = dealsData.length > 0
-            ? Math.round((completedDeals.length / dealsData.length) * 100)
-            : 0;
+          // 安全な率計算（分母0の場合はnull）
+          const cvRate = safeRate(completedDeals.length, dealsData.length);
 
           // 入居確率スコアリング
           const activeProspects = prospectsData.filter(
@@ -153,6 +175,7 @@ function DashboardContent() {
             accounts: accountsData.length,
             activeDeals: activeDeals.length,
             completedDeals: completedDeals.length,
+            totalDeals: dealsData.length,
             cvRate,
             expectedMoveIns,
             rankA: rankDistribution.A,
@@ -161,14 +184,15 @@ function DashboardContent() {
             rankD: rankDistribution.D,
           });
 
-          // 稼働率
+          // 稼働率（安全な計算）
           const totalCapacity = facilitiesData.reduce((sum, f) => sum + (f.facility.capacity || 0), 0);
           const totalVacant = facilitiesData.reduce((sum, f) => sum + (f.vacancy?.vacantCount ?? 0), 0);
-          const rate = totalCapacity > 0 ? Math.round(((totalCapacity - totalVacant) / totalCapacity) * 100) : 0;
+          const rate = calcOccupancyRate(totalCapacity, totalVacant);
           setOccupancyRate(rate);
         }
-      } catch (error) {
-        console.error('Failed to fetch dashboard data:', error);
+      } catch (err) {
+        console.error('Failed to fetch dashboard data:', err);
+        setError(toDashboardError(err));
       } finally {
         setLoading(false);
       }
@@ -185,6 +209,14 @@ function DashboardContent() {
       </>
     );
   }
+
+  // エラー表示
+  const retryFetch = () => {
+    setLoading(true);
+    setError(null);
+    // Re-trigger useEffect
+    window.location.reload();
+  };
 
   // 今日の余裕メーター計算
   const todayCheckin = checkinHistory[0];
@@ -219,6 +251,35 @@ function DashboardContent() {
               </div>
             </CardContent>
           </Card>
+
+          {/* エラーバナー */}
+          {error && (
+            <Card className="mb-6 bg-red-50 border-red-200">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
+                    <div>
+                      <p className="text-sm font-medium text-red-800">
+                        データの取得に失敗しました
+                      </p>
+                      <p className="text-xs text-red-600 mt-1">
+                        {error.message}
+                      </p>
+                      {error.createIndexUrl && isExec && (
+                        <p className="text-xs text-red-500 mt-2">
+                          管理者向け: インデックス作成が必要です
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <Button variant="secondary" onClick={retryFetch} className="text-sm">
+                    再試行
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           {/* 役割別コンテンツ */}
           {isStaff && <StaffDashboard
@@ -560,20 +621,21 @@ function ExecDashboard({
     accounts: number;
     activeDeals: number;
     completedDeals: number;
-    cvRate: number;
+    totalDeals: number;
+    cvRate: number | null;
     expectedMoveIns: number;
     rankA: number;
     rankB: number;
     rankC: number;
     rankD: number;
   };
-  occupancyRate: number;
+  occupancyRate: number | null;
 }) {
   const redCount = teamData.filter(m => m.level === 'red').length;
   const yellowCount = teamData.filter(m => m.level === 'yellow').length;
-  const interventionRate = interventions.length > 0
-    ? Math.round((interventions.filter(i => i.status === 'done').length / interventions.length) * 100)
-    : 100;
+  // 安全な介入実施率計算（総介入数0の場合はnull、100%ではない）
+  const doneCount = interventions.filter(i => i.status === 'done').length;
+  const interventionRate = calcInterventionRate(doneCount, interventions.length);
 
   return (
     <div className="space-y-6">
@@ -583,7 +645,9 @@ function ExecDashboard({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-500">稼働率</p>
-              <p className="text-2xl font-bold text-blue-600">{occupancyRate}%</p>
+              <p className="text-2xl font-bold text-blue-600">
+                {formatPercent(occupancyRate)}
+              </p>
             </div>
             <Building2 className="w-8 h-8 text-blue-300" />
           </div>
@@ -600,9 +664,9 @@ function ExecDashboard({
         <Card className={`p-4 ${redCount > 0 ? 'bg-red-50' : yellowCount > 0 ? 'bg-yellow-50' : ''}`}>
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500">赤/黄率</p>
+              <p className="text-sm text-gray-500">赤/黄</p>
               <p className={`text-2xl font-bold ${redCount > 0 ? 'text-red-600' : yellowCount > 0 ? 'text-yellow-600' : 'text-green-600'}`}>
-                {redCount}/{yellowCount}
+                {teamData.length > 0 ? `${redCount}/${yellowCount}` : '--'}
               </p>
             </div>
             <AlertTriangle className={`w-8 h-8 ${redCount > 0 ? 'text-red-300' : 'text-gray-300'}`} />
@@ -612,7 +676,9 @@ function ExecDashboard({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-gray-500">介入実施率</p>
-              <p className="text-2xl font-bold text-purple-600">{interventionRate}%</p>
+              <p className="text-2xl font-bold text-purple-600">
+                {formatPercent(interventionRate)}
+              </p>
             </div>
             <CheckCircle className="w-8 h-8 text-purple-300" />
           </div>
@@ -642,7 +708,7 @@ function ExecDashboard({
               <p className="text-xs text-gray-600">M（成約）</p>
             </div>
             <div className="text-center p-3 bg-gray-50 rounded-lg">
-              <p className="text-2xl font-bold text-gray-600">{salesMetrics.cvRate}%</p>
+              <p className="text-2xl font-bold text-gray-600">{formatPercent(salesMetrics.cvRate)}</p>
               <p className="text-xs text-gray-600">CV率</p>
             </div>
           </div>

--- a/src/lib/dashboard/calc.ts
+++ b/src/lib/dashboard/calc.ts
@@ -1,0 +1,135 @@
+// ======== ダッシュボード数値計算ユーティリティ ========
+// ゼロ割や無効データ時の表示を統一
+
+/**
+ * 安全な率計算
+ * 分母が0の場合はnullを返す
+ */
+export function safeRate(numerator: number, denominator: number): number | null {
+  if (denominator === 0 || !Number.isFinite(denominator)) {
+    return null;
+  }
+  const rate = (numerator / denominator) * 100;
+  return Math.round(rate);
+}
+
+/**
+ * パーセント表示用フォーマット
+ * null/undefinedの場合は"--"を返す
+ */
+export function formatPercent(rate: number | null | undefined): string {
+  if (rate === null || rate === undefined || !Number.isFinite(rate)) {
+    return '--';
+  }
+  return `${rate}%`;
+}
+
+/**
+ * 分数表示用フォーマット（例: 3/5）
+ * 分母が0の場合は"--"を返す
+ */
+export function formatFraction(numerator: number, denominator: number): string {
+  if (denominator === 0 || !Number.isFinite(denominator)) {
+    return '--';
+  }
+  return `${numerator}/${denominator}`;
+}
+
+/**
+ * 数値表示用フォーマット
+ * null/undefinedの場合は"--"を返す
+ */
+export function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '--';
+  }
+  return value.toString();
+}
+
+/**
+ * 稼働率計算（入居数/定員）
+ * 定員が0の場合はnullを返す
+ */
+export function calcOccupancyRate(
+  totalCapacity: number,
+  vacantCount: number
+): number | null {
+  if (totalCapacity === 0) {
+    return null;
+  }
+  const occupied = totalCapacity - vacantCount;
+  return Math.round((occupied / totalCapacity) * 100);
+}
+
+/**
+ * CV率計算（成約数/総案件数）
+ * 総案件数が0の場合はnullを返す
+ */
+export function calcCvRate(
+  completedCount: number,
+  totalCount: number
+): number | null {
+  return safeRate(completedCount, totalCount);
+}
+
+/**
+ * 介入実施率計算（完了数/総介入数）
+ * 総介入数が0の場合はnullを返す（100%ではない）
+ */
+export function calcInterventionRate(
+  doneCount: number,
+  totalCount: number
+): number | null {
+  return safeRate(doneCount, totalCount);
+}
+
+// ======== ダッシュボードエラー型 ========
+
+export interface DashboardError {
+  code: string;
+  message: string;
+  createIndexUrl?: string;
+}
+
+/**
+ * FirebaseErrorからインデックス作成URLを抽出
+ */
+export function extractIndexUrl(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    const message = error.message;
+    const urlMatch = message.match(/(https:\/\/console\.firebase\.google\.com\/[^\s]+)/);
+    if (urlMatch) {
+      return urlMatch[1];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * エラーをDashboardError形式に変換
+ */
+export function toDashboardError(error: unknown): DashboardError {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const createIndexUrl = extractIndexUrl(error);
+
+  // FirebaseError判定
+  if (message.includes('requires an index')) {
+    return {
+      code: 'INDEX_REQUIRED',
+      message: 'Firestoreのインデックスが必要です',
+      createIndexUrl,
+    };
+  }
+
+  if (message.includes('permission-denied')) {
+    return {
+      code: 'PERMISSION_DENIED',
+      message: 'アクセス権限がありません',
+    };
+  }
+
+  return {
+    code: 'UNKNOWN',
+    message,
+  };
+}


### PR DESCRIPTION
- Firestoreインデックス定義を追加（staffCheckins, staffScoresDaily, interventions, salesAccounts, salesDeals）
- ゼロ割による誤った100%表示を修正（介入実施率、稼働率、CV率）
- 取得失敗時のエラーバナー追加（0埋め表示を防止）
- 分母0の場合は"--"を表示するよう統一
- 数値計算ユーティリティ追加（safeRate, formatPercent等）
- Unitテスト31件追加

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
