### PR TITLE
feat: 稟議新UIをダッシュボードに統合（PR6）

### DIFF
--- a/e2e/approvals.spec.ts
+++ b/e2e/approvals.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 稟議機能 E2Eテスト
+ * 稟議一覧・作成ページの存在確認とリダイレクトの検証
+ */
+
+test.describe('稟議 - ページ存在確認', () => {
+  test('稟議一覧ページが存在する', async ({ page }) => {
+    const response = await page.goto('/dashboard/approvals');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('稟議作成ページが存在する', async ({ page }) => {
+    const response = await page.goto('/dashboard/approvals/new');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('管理者向け稟議承認ページが存在する', async ({ page }) => {
+    const response = await page.goto('/admin/ringi');
+    expect(response?.status()).toBeLessThan(500);
+  });
+});
+
+test.describe('稟議 - 旧URLリダイレクト', () => {
+  test('/ringi が /dashboard/approvals にリダイレクトする', async ({ page }) => {
+    await page.goto('/ringi');
+    // クライアントサイドリダイレクトを待つ
+    await page.waitForTimeout(1000);
+    // URLが変わっていることを確認（認証リダイレクトも考慮）
+    const url = page.url();
+    expect(url).toMatch(/\/(dashboard\/approvals|login|onboarding)/);
+  });
+
+  test('/ringi/new が /dashboard/approvals/new にリダイレクトする', async ({ page }) => {
+    await page.goto('/ringi/new');
+    // クライアントサイドリダイレクトを待つ
+    await page.waitForTimeout(1000);
+    // URLが変わっていることを確認（認証リダイレクトも考慮）
+    const url = page.url();
+    expect(url).toMatch(/\/(dashboard\/approvals\/new|login|onboarding)/);
+  });
+});
+
+test.describe('稟議 - UI要素確認（未認証時）', () => {
+  test('稟議作成ページはローディングまたは認証画面を表示', async ({ page }) => {
+    await page.goto('/dashboard/approvals/new');
+    await page.waitForTimeout(1000);
+    // ページが正常にレンダリングされることを確認
+    await expect(page.locator('body')).toBeVisible();
+  });
+});
+
+test.describe('稟議 - ナビゲーション導線確認', () => {
+  test('ダッシュボードから稟議一覧へのリンクが存在する', async ({ page }) => {
+    const response = await page.goto('/dashboard');
+    expect(response?.status()).toBeLessThan(500);
+    // ページが読み込まれたことを確認
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/src/app/dashboard/approvals/page.tsx
+++ b/src/app/dashboard/approvals/page.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useAuth } from '@/contexts/AuthContext';
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
+import {
+  Plus,
+  FileText,
+  Clock,
+  CheckCircle,
+  XCircle,
+  Edit,
+  RotateCcw,
+  AlertTriangle,
+} from 'lucide-react';
+import { getRingisByUser } from '@/lib/ringi';
+import { Ringi, RingiStatus, RINGI_STATUS_LABELS, RINGI_STATUS_COLORS } from '@/types';
+
+export default function ApprovalsListPage() {
+  return (
+    <AuthGuard>
+      <ApprovalsListContent />
+    </AuthGuard>
+  );
+}
+
+function ApprovalsListContent() {
+  const { user } = useAuth();
+  const [ringis, setRingis] = useState<Ringi[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'all' | RingiStatus>('all');
+
+  useEffect(() => {
+    if (!user) return;
+
+    const loadRingis = async () => {
+      try {
+        const data = await getRingisByUser(user.id, user.tenantId);
+        setRingis(data);
+      } catch (error) {
+        console.error('Failed to load ringis:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadRingis();
+  }, [user]);
+
+  const filteredRingis =
+    filter === 'all' ? ringis : ringis.filter((r) => r.status === filter);
+
+  const statusIcon = (status: RingiStatus) => {
+    switch (status) {
+      case 'draft':
+        return <Edit className="w-4 h-4" />;
+      case 'submitted':
+        return <Clock className="w-4 h-4" />;
+      case 'approved':
+        return <CheckCircle className="w-4 h-4" />;
+      case 'rejected':
+        return <XCircle className="w-4 h-4" />;
+      case 'returned':
+        return <RotateCcw className="w-4 h-4" />;
+      default:
+        return <FileText className="w-4 h-4" />;
+    }
+  };
+
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat('ja-JP', {
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  };
+
+  // 件数集計
+  const draftCount = ringis.filter((r) => r.status === 'draft').length;
+  const submittedCount = ringis.filter((r) => r.status === 'submitted').length;
+  const returnedCount = ringis.filter((r) => r.status === 'returned').length;
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-zinc-50">
+        <Header />
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50">
+      <Header />
+      <div className="max-w-2xl mx-auto px-4 py-6 safe-bottom">
+        {/* Page Title & New Button */}
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-xl font-bold text-zinc-900">稟議</h1>
+          <Link href="/dashboard/approvals/new">
+            <Button size="sm">
+              <Plus className="w-4 h-4" />
+              新規稟議
+            </Button>
+          </Link>
+        </div>
+
+        {/* Summary Cards */}
+        {(draftCount > 0 || submittedCount > 0 || returnedCount > 0) && (
+          <div className="grid grid-cols-3 gap-3 mb-6">
+            <Card className="p-3 text-center">
+              <p className="text-2xl font-bold text-zinc-900">{draftCount}</p>
+              <p className="text-xs text-zinc-500">下書き</p>
+            </Card>
+            <Card className="p-3 text-center">
+              <p className="text-2xl font-bold text-amber-600">{submittedCount}</p>
+              <p className="text-xs text-zinc-500">申請中</p>
+            </Card>
+            {returnedCount > 0 && (
+              <Card className="p-3 text-center bg-orange-50 border-orange-200">
+                <p className="text-2xl font-bold text-orange-600">{returnedCount}</p>
+                <p className="text-xs text-orange-600">差戻し</p>
+              </Card>
+            )}
+            {returnedCount === 0 && (
+              <Card className="p-3 text-center">
+                <p className="text-2xl font-bold text-emerald-600">
+                  {ringis.filter((r) => r.status === 'approved').length}
+                </p>
+                <p className="text-xs text-zinc-500">承認済</p>
+              </Card>
+            )}
+          </div>
+        )}
+
+        {/* 差戻しアラート */}
+        {returnedCount > 0 && (
+          <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-xl flex items-center gap-3">
+            <AlertTriangle className="w-5 h-5 text-orange-600 shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-orange-700">
+                {returnedCount}件の稟議が差戻されています
+              </p>
+              <p className="text-xs text-orange-600">修正して再申請してください</p>
+            </div>
+          </div>
+        )}
+
+        {/* Filter */}
+        <div className="flex gap-2 mb-4 overflow-x-auto pb-2">
+          {(
+            ['all', 'draft', 'submitted', 'approved', 'rejected', 'returned'] as const
+          ).map((status) => (
+            <button
+              key={status}
+              onClick={() => setFilter(status)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+                filter === status
+                  ? 'bg-zinc-900 text-white'
+                  : 'bg-white text-zinc-600 hover:bg-zinc-100'
+              }`}
+            >
+              {status === 'all' ? 'すべて' : RINGI_STATUS_LABELS[status]}
+              {status !== 'all' && (
+                <span className="ml-1.5 text-xs opacity-70">
+                  {ringis.filter((r) => r.status === status).length}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* List */}
+        <div className="space-y-3">
+          {filteredRingis.length === 0 ? (
+            <Card className="p-8 text-center">
+              <FileText className="w-12 h-12 text-zinc-300 mx-auto mb-3" />
+              <p className="text-zinc-500">
+                {filter === 'all'
+                  ? '稟議がありません'
+                  : `${RINGI_STATUS_LABELS[filter]}の稟議がありません`}
+              </p>
+              <Link href="/dashboard/approvals/new" className="mt-4 inline-block">
+                <Button variant="secondary" size="sm">
+                  <Plus className="w-4 h-4" />
+                  新規稟議を作成
+                </Button>
+              </Link>
+            </Card>
+          ) : (
+            filteredRingis.map((ringi) => {
+              const colors = RINGI_STATUS_COLORS[ringi.status];
+              return (
+                <Link key={ringi.id} href={`/ringi/${ringi.id}`}>
+                  <Card className="p-4 hover:bg-zinc-50 transition-colors">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <Badge className={`${colors.bg} ${colors.text}`}>
+                            {statusIcon(ringi.status)}
+                            <span className="ml-1">{RINGI_STATUS_LABELS[ringi.status]}</span>
+                          </Badge>
+                          <span className="text-xs text-zinc-400">{ringi.category}</span>
+                          {ringi.urgency === '至急' && (
+                            <Badge className="bg-red-100 text-red-700 text-xs">至急</Badge>
+                          )}
+                        </div>
+                        <h3 className="font-medium text-zinc-900 truncate">{ringi.title}</h3>
+                        {ringi.description && (
+                          <p className="text-sm text-zinc-500 line-clamp-1 mt-1">
+                            {ringi.description}
+                          </p>
+                        )}
+                      </div>
+                      <div className="text-right shrink-0">
+                        {ringi.amount && (
+                          <p className="text-sm font-medium text-zinc-900">
+                            ¥{ringi.amount.toLocaleString()}
+                          </p>
+                        )}
+                        <p className="text-xs text-zinc-400 mt-1">
+                          {formatDate(ringi.createdAt)}
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                </Link>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { getCheckinHistory, getChaosDashboardMetrics, getInterventions } from '@
 import { getSalesDeals, getSalesAccounts } from '@/lib/sales';
 import { getProspects } from '@/lib/prospect';
 import { getFacilitiesWithVacancy } from '@/lib/vacancy';
+import { getRingisByUser, getPendingRingis } from '@/lib/ringi';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { Card, CardHeader, CardTitle, CardContent, Badge, Button } from '@/components/ui';
@@ -54,6 +55,10 @@ import {
   Briefcase,
   BarChart2,
   ArrowRight,
+  ClipboardList,
+  Plus,
+  RotateCcw,
+  FileText,
 } from 'lucide-react';
 
 export default function DashboardPage() {
@@ -86,6 +91,14 @@ function DashboardContent() {
     alertCount: { yellow: number; red: number };
     burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
   } | null>(null);
+
+  // 稟議データ（全員共通）
+  const [approvalStats, setApprovalStats] = useState<{
+    draft: number;
+    submitted: number;
+    returned: number;
+    pendingApproval: number; // 承認待ち（リーダー以上用）
+  }>({ draft: 0, submitted: 0, returned: 0, pendingApproval: 0 });
 
   // Exec用データ
   const [salesMetrics, setSalesMetrics] = useState<{
@@ -132,6 +145,29 @@ function DashboardContent() {
       } catch (err) {
         console.error('[dashboard:checkinHistory] Failed:', err);
         errors.push(toDashboardError(err));
+      }
+
+      // 全員：稟議データ
+      try {
+        const myRingis = await getRingisByUser(user.id, user.tenantId);
+        const draft = myRingis.filter(r => r.status === 'draft').length;
+        const submitted = myRingis.filter(r => r.status === 'submitted').length;
+        const returned = myRingis.filter(r => r.status === 'returned').length;
+
+        // リーダー以上：承認待ち件数
+        let pendingApproval = 0;
+        if (!isStaff) {
+          try {
+            const pending = await getPendingRingis(user.tenantId, user.branchId);
+            pendingApproval = pending.length;
+          } catch (e) {
+            console.error('[dashboard:pendingRingis] Failed:', e);
+          }
+        }
+
+        setApprovalStats({ draft, submitted, returned, pendingApproval });
+      } catch (err) {
+        console.error('[dashboard:approvalStats] Failed:', err);
       }
 
       // Manager以上：チーム・組織データ
@@ -324,12 +360,14 @@ function DashboardContent() {
             todayCheckin={todayCheckin}
             todayMeterColor={todayMeterColor}
             checkinHistory={checkinHistory}
+            approvalStats={approvalStats}
           />}
 
           {isManager && <ManagerDashboard
             teamData={teamData}
             interventions={interventions}
             orgMetrics={orgMetrics}
+            approvalStats={approvalStats}
           />}
 
           {isExec && <ExecDashboard
@@ -338,10 +376,108 @@ function DashboardContent() {
             orgMetrics={orgMetrics}
             salesMetrics={salesMetrics}
             occupancyRate={occupancyRate}
+            approvalStats={approvalStats}
           />}
         </div>
       </main>
     </>
+  );
+}
+
+// ========== 稟議カード（共通） ==========
+function ApprovalCard({
+  approvalStats,
+  isLeader = false,
+}: {
+  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
+  isLeader?: boolean;
+}) {
+  const hasReturned = approvalStats.returned > 0;
+  const hasPending = approvalStats.pendingApproval > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center justify-between">
+          <span className="flex items-center">
+            <ClipboardList className="w-5 h-5 mr-2 text-blue-600" />
+            稟議
+          </span>
+          <Link href="/dashboard/approvals/new">
+            <Button size="sm" variant="secondary">
+              <Plus className="w-4 h-4" />
+              新規
+            </Button>
+          </Link>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* 差戻しアラート */}
+        {hasReturned && (
+          <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg flex items-center gap-2">
+            <RotateCcw className="w-5 h-5 text-orange-600" />
+            <div>
+              <p className="text-sm font-medium text-orange-700">
+                {approvalStats.returned}件の差戻しがあります
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* 承認待ちアラート（リーダー以上） */}
+        {isLeader && hasPending && (
+          <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-2">
+            <Clock className="w-5 h-5 text-amber-600" />
+            <div>
+              <p className="text-sm font-medium text-amber-700">
+                {approvalStats.pendingApproval}件の承認待ちがあります
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* 件数サマリー */}
+        <div className="grid grid-cols-3 gap-2 mb-4">
+          <div className="p-3 rounded-lg text-center bg-zinc-50">
+            <p className="text-2xl font-bold text-zinc-900">{approvalStats.draft}</p>
+            <p className="text-xs text-zinc-500">下書き</p>
+          </div>
+          <div className="p-3 rounded-lg text-center bg-amber-50">
+            <p className="text-2xl font-bold text-amber-600">{approvalStats.submitted}</p>
+            <p className="text-xs text-zinc-500">申請中</p>
+          </div>
+          {hasReturned ? (
+            <div className="p-3 rounded-lg text-center bg-orange-50">
+              <p className="text-2xl font-bold text-orange-600">{approvalStats.returned}</p>
+              <p className="text-xs text-orange-600">差戻し</p>
+            </div>
+          ) : (
+            <div className="p-3 rounded-lg text-center bg-zinc-50">
+              <p className="text-2xl font-bold text-zinc-400">-</p>
+              <p className="text-xs text-zinc-400">差戻し</p>
+            </div>
+          )}
+        </div>
+
+        {/* アクションボタン */}
+        <div className="flex gap-2">
+          <Link href="/dashboard/approvals" className="flex-1">
+            <Button variant="secondary" className="w-full">
+              <FileText className="w-4 h-4 mr-1" />
+              一覧を見る
+            </Button>
+          </Link>
+          {isLeader && (
+            <Link href="/admin/ringi" className="flex-1">
+              <Button variant="secondary" className="w-full">
+                <CheckCircle className="w-4 h-4 mr-1" />
+                承認する
+              </Button>
+            </Link>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -350,10 +486,12 @@ function StaffDashboard({
   todayCheckin,
   todayMeterColor,
   checkinHistory,
+  approvalStats,
 }: {
   todayCheckin: StaffCheckin | undefined;
   todayMeterColor: MeterColor;
   checkinHistory: StaffCheckin[];
+  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
 }) {
   return (
     <div className="space-y-6">
@@ -452,7 +590,10 @@ function StaffDashboard({
         </CardContent>
       </Card>
 
-      {/* 5. 小さな成長（承認ワンポイント） */}
+      {/* 5. 稟議カード */}
+      <ApprovalCard approvalStats={approvalStats} />
+
+      {/* 6. 小さな成長（承認ワンポイント） */}
       <Card className="bg-gradient-to-r from-yellow-50 to-amber-50 border-yellow-200">
         <CardHeader>
           <CardTitle className="text-base flex items-center">
@@ -475,6 +616,7 @@ function ManagerDashboard({
   teamData,
   interventions,
   orgMetrics,
+  approvalStats,
 }: {
   teamData: { userId: string; userName: string; score: number; level: MeterColor }[];
   interventions: Intervention[];
@@ -484,6 +626,7 @@ function ManagerDashboard({
     alertCount: { yellow: number; red: number };
     burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
   } | null;
+  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
 }) {
   const redCount = teamData.filter(m => m.level === 'red').length;
   const yellowCount = teamData.filter(m => m.level === 'yellow').length;
@@ -594,6 +737,9 @@ function ManagerDashboard({
         </Card>
       </div>
 
+      {/* 稟議カード */}
+      <ApprovalCard approvalStats={approvalStats} isLeader />
+
       {/* 下段 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* 現場ボトルネック */}
@@ -646,6 +792,7 @@ function ExecDashboard({
   orgMetrics,
   salesMetrics,
   occupancyRate,
+  approvalStats,
 }: {
   teamData: { userId: string; userName: string; score: number; level: MeterColor }[];
   interventions: Intervention[];
@@ -668,6 +815,7 @@ function ExecDashboard({
     rankD: number;
   };
   occupancyRate: number | null;
+  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
 }) {
   const redCount = teamData.filter(m => m.level === 'red').length;
   const yellowCount = teamData.filter(m => m.level === 'yellow').length;
@@ -827,6 +975,9 @@ function ExecDashboard({
           </Link>
         </CardContent>
       </Card>
+
+      {/* 稟議カード */}
+      <ApprovalCard approvalStats={approvalStats} isLeader />
 
       {/* WBRサマリ */}
       <Card>

--- a/src/app/ringi/new/page.tsx
+++ b/src/app/ringi/new/page.tsx
@@ -1,163 +1,19 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/contexts/AuthContext';
-import { Card } from '@/components/ui/Card';
-import { Button } from '@/components/ui/Button';
-import { Input } from '@/components/ui/Input';
-import { Select } from '@/components/ui/Select';
-import { ArrowLeft, Save, Send } from 'lucide-react';
-import { createRingi, submitRingi } from '@/lib/ringi';
-import { RingiFormData, RINGI_CATEGORIES, RingiCategory } from '@/types';
-import Link from 'next/link';
 
+// 旧URL /ringi/new から新URL /dashboard/approvals/new へリダイレクト
 export default function NewRingiPage() {
   const router = useRouter();
-  const { user } = useAuth();
-  const [loading, setLoading] = useState(false);
-  const [formData, setFormData] = useState<RingiFormData>({
-    title: '',
-    category: '備品購入',
-    amount: undefined,
-    description: '',
-  });
 
-  const handleSubmit = async (asDraft: boolean) => {
-    if (!user) return;
-
-    if (!formData.title.trim()) {
-      alert('件名を入力してください');
-      return;
-    }
-    if (!formData.description?.trim()) {
-      alert('申請理由を入力してください');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const ringi = await createRingi(
-        formData,
-        user.id,
-        user.name,
-        user.branchId,
-        user.tenantId
-      );
-
-      if (!asDraft) {
-        // 即時申請
-        await submitRingi(
-          ringi.id,
-          user.id,
-          user.name,
-          user.role,
-          user.branchId
-        );
-      }
-
-      router.push('/ringi');
-    } catch (error) {
-      console.error('Failed to create ringi:', error);
-      alert('作成に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-  };
+  useEffect(() => {
+    router.replace('/dashboard/approvals/new');
+  }, [router]);
 
   return (
-    <div className="min-h-screen bg-zinc-50">
-      <div className="max-w-2xl mx-auto px-4 py-6 safe-top safe-bottom">
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-6">
-          <Link href="/ringi">
-            <Button variant="ghost" size="sm">
-              <ArrowLeft className="w-4 h-4" />
-            </Button>
-          </Link>
-          <h1 className="text-xl font-bold text-zinc-900">稟議作成</h1>
-        </div>
-
-        <Card className="p-6">
-          <div className="space-y-5">
-            {/* 件名 */}
-            <div>
-              <label className="block text-sm font-medium text-zinc-700 mb-1.5">
-                件名 <span className="text-red-500">*</span>
-              </label>
-              <Input
-                value={formData.title}
-                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                placeholder="例: 車椅子の購入について"
-              />
-            </div>
-
-            {/* カテゴリ */}
-            <div>
-              <label className="block text-sm font-medium text-zinc-700 mb-1.5">
-                カテゴリ
-              </label>
-              <Select
-                value={formData.category}
-                onChange={(e) => setFormData({ ...formData, category: e.target.value as RingiCategory })}
-                options={RINGI_CATEGORIES.map((cat) => ({ value: cat, label: cat }))}
-              />
-            </div>
-
-            {/* 金額 */}
-            <div>
-              <label className="block text-sm font-medium text-zinc-700 mb-1.5">
-                金額（任意）
-              </label>
-              <div className="relative">
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400">¥</span>
-                <Input
-                  type="number"
-                  value={formData.amount || ''}
-                  onChange={(e) => setFormData({ ...formData, amount: e.target.value ? Number(e.target.value) : undefined })}
-                  placeholder="0"
-                  className="pl-8"
-                />
-              </div>
-            </div>
-
-            {/* 申請理由 */}
-            <div>
-              <label className="block text-sm font-medium text-zinc-700 mb-1.5">
-                申請理由・詳細 <span className="text-red-500">*</span>
-              </label>
-              <textarea
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="購入の理由、必要性、期待される効果などを記載してください"
-                rows={6}
-                className="w-full px-4 py-3 rounded-xl border border-zinc-200 bg-white text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:border-transparent resize-none"
-              />
-            </div>
-
-            {/* Buttons */}
-            <div className="flex gap-3 pt-2">
-              <Button
-                variant="secondary"
-                onClick={() => handleSubmit(true)}
-                disabled={loading}
-                className="flex-1"
-              >
-                <Save className="w-4 h-4" />
-                下書き保存
-              </Button>
-              <Button
-                onClick={() => handleSubmit(false)}
-                disabled={loading}
-                className="flex-1"
-              >
-                <Send className="w-4 h-4" />
-                申請する
-              </Button>
-            </div>
-          </div>
-        </Card>
-      </div>
+    <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
     </div>
   );
 }

--- a/src/app/ringi/page.tsx
+++ b/src/app/ringi/page.tsx
@@ -1,5 +1,24 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+// 旧URL /ringi から新URL /dashboard/approvals へリダイレクト
+export default function RingiListPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/dashboard/approvals');
+  }, [router]);
+
+  return (
+    <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
+    </div>
+  );
+}
+
+/* 以下は旧実装（参考用に残す）
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
@@ -11,7 +30,7 @@ import { Plus, FileText, Clock, CheckCircle, XCircle, Edit } from 'lucide-react'
 import { getRingisByUser } from '@/lib/ringi';
 import { Ringi, RINGI_STATUS_LABELS, RINGI_STATUS_COLORS } from '@/types';
 
-export default function RingiListPage() {
+function RingiListPageOld() {
   const { user } = useAuth();
   const [ringis, setRingis] = useState<Ringi[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,7 +42,7 @@ export function Header() {
   const navItems = [
     { href: '/dashboard', label: 'ホーム', icon: Home },
     { href: '/attendance', label: '打刻', icon: Clock },
-    { href: '/ringi', label: '稟議', icon: ClipboardList },
+    { href: '/dashboard/approvals', label: '稟議', icon: ClipboardList },
     { href: '/dashboard/prospects', label: '入居希望', icon: UserPlus },
     { href: '/sales', label: '営業', icon: Briefcase },
     { href: '/dashboard/vacancy', label: '空室', icon: Building2 },


### PR DESCRIPTION
- ナビゲーションに稟議メニューを追加（/dashboard/approvals）
- /dashboard に稟議カードを追加（下書き/申請中/差戻し件数表示）
- /dashboard/approvals 一覧ページを新規作成
- 旧URL /ringi, /ringi/new からのリダイレクト設定
- E2Eテストを追加（approvals.spec.ts）

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
