### PR TITLE
feat: 打刻UI改善とE2Eテスト追加

### DIFF
--- a/e2e/attendance.spec.ts
+++ b/e2e/attendance.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 打刻機能 E2Eテスト
+ * 打刻ページの存在確認とUI要素の検証
+ */
+
+test.describe('打刻 - ページ存在確認', () => {
+  test('打刻ページが存在する', async ({ page }) => {
+    const response = await page.goto('/attendance');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('勤務履歴ページが存在する', async ({ page }) => {
+    const response = await page.goto('/attendance/history');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('残業申請ページが存在する', async ({ page }) => {
+    const response = await page.goto('/attendance/overtime');
+    expect(response?.status()).toBeLessThan(500);
+  });
+});
+
+test.describe('打刻 - UI要素確認（未認証時）', () => {
+  test('打刻ページはローディングまたは認証画面を表示', async ({ page }) => {
+    await page.goto('/attendance');
+    await page.waitForTimeout(1000);
+    // ページが正常にレンダリングされることを確認
+    await expect(page.locator('body')).toBeVisible();
+  });
+});
+
+test.describe('打刻 - モバイル表示', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('モバイルサイズで打刻ページが表示される', async ({ page }) => {
+    const response = await page.goto('/attendance');
+    expect(response?.status()).toBeLessThan(500);
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/e2e/self-check.spec.ts
+++ b/e2e/self-check.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * セルフチェック・ヘルスチェック E2Eテスト
+ * 管理者向けセルフチェックページとヘルスAPIの検証
+ */
+
+test.describe('セルフチェック - ページ存在確認', () => {
+  test('セルフチェックページが存在する', async ({ page }) => {
+    const response = await page.goto('/dashboard/admin/self-check');
+    expect(response?.status()).toBeLessThan(500);
+  });
+});
+
+test.describe('ヘルスAPI', () => {
+  test('/api/health がJSONを返す', async ({ request }) => {
+    const response = await request.get('/api/health');
+    expect(response.status()).toBe(200);
+
+    const json = await response.json();
+    // 必須フィールドの確認
+    expect(json).toHaveProperty('status');
+    expect(json).toHaveProperty('timestamp');
+    expect(json).toHaveProperty('environment');
+    expect(json).toHaveProperty('version');
+  });
+
+  test('/api/health のstatus がokである', async ({ request }) => {
+    const response = await request.get('/api/health');
+    const json = await response.json();
+    expect(json.status).toBe('ok');
+  });
+
+  test('/api/health にchecksフィールドがある', async ({ request }) => {
+    const response = await request.get('/api/health');
+    const json = await response.json();
+    expect(json).toHaveProperty('checks');
+    expect(json.checks).toHaveProperty('database');
+    expect(json.checks).toHaveProperty('auth');
+  });
+});
+
+test.describe('セルフチェック - UI要素確認（未認証時）', () => {
+  test('セルフチェックページはローディングまたは認証画面を表示', async ({ page }) => {
+    await page.goto('/dashboard/admin/self-check');
+    await page.waitForTimeout(1000);
+    // ページが正常にレンダリングされることを確認
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -19,16 +19,47 @@ import {
 import { formatTimeJST, formatMinutesToHHMM } from '@/lib/attendance-calc';
 import { TodayAttendanceState, ClockStatus } from '@/types/attendance';
 import { BRANCHES_SEED } from '@/data/employees';
-import { MapPin, Edit2, Clock, AlertCircle } from 'lucide-react';
+import {
+  MapPin,
+  Edit2,
+  Clock,
+  AlertCircle,
+  CheckCircle,
+  XCircle,
+  Play,
+  Square,
+  Coffee,
+  Home,
+  Building2,
+  History,
+} from 'lucide-react';
 
 // 状態表示ラベル
-const STATUS_LABELS: Record<ClockStatus, { label: string; color: string }> = {
-  not_started: { label: '未出勤', color: 'bg-gray-100 text-gray-700' },
-  working: { label: '勤務中', color: 'bg-green-100 text-green-700' },
-  on_break: { label: '休憩中', color: 'bg-yellow-100 text-yellow-700' },
-  completed: { label: '退勤済', color: 'bg-blue-100 text-blue-700' },
-  missing_out: { label: '退勤漏れ', color: 'bg-red-100 text-red-700' },
+const STATUS_LABELS: Record<ClockStatus, { label: string; color: string; bgColor: string }> = {
+  not_started: { label: '未出勤', color: 'text-gray-700', bgColor: 'bg-gray-100' },
+  working: { label: '勤務中', color: 'text-green-700', bgColor: 'bg-green-100' },
+  on_break: { label: '休憩中', color: 'text-amber-700', bgColor: 'bg-amber-100' },
+  completed: { label: '退勤済', color: 'text-blue-700', bgColor: 'bg-blue-100' },
+  missing_out: { label: '退勤漏れ', color: 'text-red-700', bgColor: 'bg-red-100' },
 };
+
+// 打刻履歴アイテムの型
+interface PunchHistoryItem {
+  type: 'clock_in' | 'break_start' | 'break_end' | 'clock_out';
+  time: Date;
+  label: string;
+  icon: typeof Play;
+  color: string;
+}
+
+// トースト通知の型
+interface Toast {
+  type: 'success' | 'error';
+  message: string;
+}
+
+// localStorage key
+const LAST_BRANCH_KEY = 'aa-hub-last-branch';
 
 export default function AttendancePage() {
   const { user } = useAuth();
@@ -38,9 +69,16 @@ export default function AttendancePage() {
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentTime, setCurrentTime] = useState(new Date());
-  const [selectedBranchId, setSelectedBranchId] = useState<string>(BRANCHES_SEED[0]?.id || '');
+  const [selectedBranchId, setSelectedBranchId] = useState<string>('');
   const [isEditingBranch, setIsEditingBranch] = useState(false);
   const [editBranchId, setEditBranchId] = useState<string>('');
+
+  // 確認ダイアログ
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<'clock_out' | null>(null);
+
+  // トースト通知
+  const [toast, setToast] = useState<Toast | null>(null);
 
   // 打刻修正用state
   const [isEditingTime, setIsEditingTime] = useState(false);
@@ -54,6 +92,22 @@ export default function AttendancePage() {
   useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
     return () => clearInterval(timer);
+  }, []);
+
+  // トースト自動消去
+  useEffect(() => {
+    if (toast) {
+      const timer = setTimeout(() => setToast(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [toast]);
+
+  // 前回の拠点をlocalStorageから読み込み
+  useEffect(() => {
+    const savedBranch = localStorage.getItem(LAST_BRANCH_KEY);
+    if (savedBranch && BRANCHES_SEED.some((b) => b.id === savedBranch)) {
+      setSelectedBranchId(savedBranch);
+    }
   }, []);
 
   // 勤怠状態の取得
@@ -76,11 +130,16 @@ export default function AttendancePage() {
     fetchState();
   }, [fetchState]);
 
+  // トースト表示
+  const showToast = (type: 'success' | 'error', message: string) => {
+    setToast({ type, message });
+  };
+
   // 打刻アクション
   const handleClockIn = async () => {
     if (!user) return;
     if (!selectedBranchId) {
-      setError('勤務先の拠点を選択してください');
+      setError('勤務先を選択してください');
       return;
     }
     setActionLoading(true);
@@ -89,13 +148,18 @@ export default function AttendancePage() {
     try {
       await clockIn(
         user.id,
-        user.email, // 仮のemployeeCode（本来は別途管理）
-        selectedBranchId, // 選択した拠点
+        user.email,
+        selectedBranchId,
         user.tenantId
       );
+      // 選択した拠点をlocalStorageに保存
+      localStorage.setItem(LAST_BRANCH_KEY, selectedBranchId);
       await fetchState();
+      showToast('success', '出勤しました');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '出勤打刻に失敗しました');
+      const message = err instanceof Error ? err.message : '出勤打刻に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
@@ -105,12 +169,17 @@ export default function AttendancePage() {
     if (!user) return;
     setActionLoading(true);
     setError(null);
+    setShowConfirmDialog(false);
+    setConfirmAction(null);
 
     try {
       await clockOut(user.id, user.tenantId);
       await fetchState();
+      showToast('success', '退勤しました。お疲れさまでした！');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '退勤打刻に失敗しました');
+      const message = err instanceof Error ? err.message : '退勤打刻に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
@@ -124,8 +193,11 @@ export default function AttendancePage() {
     try {
       await breakStart(user.id, user.tenantId);
       await fetchState();
+      showToast('success', '休憩を開始しました');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '休憩開始に失敗しました');
+      const message = err instanceof Error ? err.message : '休憩開始に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
@@ -139,8 +211,11 @@ export default function AttendancePage() {
     try {
       await breakEnd(user.id, user.tenantId);
       await fetchState();
+      showToast('success', '休憩を終了しました');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '休憩終了に失敗しました');
+      const message = err instanceof Error ? err.message : '休憩終了に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
@@ -153,10 +228,14 @@ export default function AttendancePage() {
 
     try {
       await changeBranch(user.id, editBranchId, user.tenantId);
+      localStorage.setItem(LAST_BRANCH_KEY, editBranchId);
       await fetchState();
       setIsEditingBranch(false);
+      showToast('success', '勤務先を変更しました');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '拠点変更に失敗しました');
+      const message = err instanceof Error ? err.message : '拠点変更に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
@@ -165,6 +244,12 @@ export default function AttendancePage() {
   const startEditingBranch = () => {
     setEditBranchId(state?.branchId || '');
     setIsEditingBranch(true);
+  };
+
+  // 退勤確認ダイアログを表示
+  const requestClockOut = () => {
+    setConfirmAction('clock_out');
+    setShowConfirmDialog(true);
   };
 
   // 打刻修正を開始
@@ -220,7 +305,6 @@ export default function AttendancePage() {
         breakEnd?: Date;
       } = {};
 
-      // 変更があった項目のみ更新
       if (editClockIn && state?.clockIn) {
         const newClockIn = parseTimeInput(editClockIn);
         if (newClockIn && formatTimeForInput(state.clockIn) !== editClockIn) {
@@ -260,11 +344,59 @@ export default function AttendancePage() {
       await fetchState();
       setIsEditingTime(false);
       setEditReason('');
+      showToast('success', '打刻を修正しました');
     } catch (err) {
-      setError(err instanceof Error ? err.message : '打刻修正に失敗しました');
+      const message = err instanceof Error ? err.message : '打刻修正に失敗しました';
+      setError(message);
+      showToast('error', message);
     } finally {
       setActionLoading(false);
     }
+  };
+
+  // 今日の打刻履歴を生成
+  const getPunchHistory = (): PunchHistoryItem[] => {
+    if (!state) return [];
+    const history: PunchHistoryItem[] = [];
+
+    if (state.clockIn) {
+      history.push({
+        type: 'clock_in',
+        time: state.clockIn,
+        label: '出勤',
+        icon: Play,
+        color: 'text-green-600',
+      });
+    }
+    if (state.breakStart) {
+      history.push({
+        type: 'break_start',
+        time: state.breakStart,
+        label: '休憩開始',
+        icon: Coffee,
+        color: 'text-amber-600',
+      });
+    }
+    if (state.breakEnd) {
+      history.push({
+        type: 'break_end',
+        time: state.breakEnd,
+        label: '休憩終了',
+        icon: Coffee,
+        color: 'text-amber-600',
+      });
+    }
+    if (state.clockOut) {
+      history.push({
+        type: 'clock_out',
+        time: state.clockOut,
+        label: '退勤',
+        icon: Square,
+        color: 'text-blue-600',
+      });
+    }
+
+    return history.sort((a, b) => a.time.getTime() - b.time.getTime());
   };
 
   if (loading) {
@@ -272,159 +404,117 @@ export default function AttendancePage() {
   }
 
   const statusInfo = state ? STATUS_LABELS[state.status] : STATUS_LABELS.not_started;
+  const punchHistory = getPunchHistory();
 
   return (
     <AuthGuard>
       <div className="min-h-screen bg-gray-50">
         <Header />
 
-        <main className="max-w-lg mx-auto px-4 py-6">
-          {/* 現在時刻 */}
-          <div className="text-center mb-6">
-            <div className="text-4xl font-bold text-gray-800">
-              {currentTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
-            </div>
-            <div className="text-gray-500 mt-1">
-              {currentTime.toLocaleDateString('ja-JP', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-                weekday: 'long',
-              })}
-            </div>
+        {/* トースト通知 */}
+        {toast && (
+          <div
+            className={`fixed top-20 left-1/2 transform -translate-x-1/2 z-50 px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 animate-fade-in ${
+              toast.type === 'success'
+                ? 'bg-green-600 text-white'
+                : 'bg-red-600 text-white'
+            }`}
+          >
+            {toast.type === 'success' ? (
+              <CheckCircle className="w-5 h-5" />
+            ) : (
+              <XCircle className="w-5 h-5" />
+            )}
+            <span className="font-medium">{toast.message}</span>
           </div>
+        )}
 
-          {/* 勤務状態カード */}
-          <Card className="mb-6">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold">今日の勤務状況</h2>
-                <span className={`px-3 py-1 rounded-full text-sm font-medium ${statusInfo.color}`}>
-                  {statusInfo.label}
-                </span>
-              </div>
-
-              {/* 勤務先拠点 */}
-              {state?.status !== 'not_started' && state?.status !== 'completed' && (
-                <div className="bg-blue-50 rounded-lg p-4 mb-4">
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2 text-sm text-gray-500">
-                      <MapPin className="w-4 h-4" />
-                      勤務先拠点
-                    </div>
-                    {!isEditingBranch && (
-                      <button
-                        onClick={startEditingBranch}
-                        className="text-blue-600 hover:text-blue-800 p-1"
-                        title="拠点を変更"
-                      >
-                        <Edit2 className="w-4 h-4" />
-                      </button>
-                    )}
-                  </div>
-                  {isEditingBranch ? (
-                    <div className="space-y-2">
-                      <select
-                        value={editBranchId}
-                        onChange={(e) => setEditBranchId(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                      >
-                        {BRANCHES_SEED.map((branch) => (
-                          <option key={branch.id} value={branch.id}>
-                            {branch.name}
-                          </option>
-                        ))}
-                      </select>
-                      <div className="flex gap-2">
-                        <Button
-                          onClick={handleChangeBranch}
-                          disabled={actionLoading || !editBranchId}
-                          className="flex-1 py-2 text-sm bg-blue-600 hover:bg-blue-700"
-                        >
-                          {actionLoading ? '変更中...' : '変更'}
-                        </Button>
-                        <Button
-                          onClick={() => setIsEditingBranch(false)}
-                          variant="secondary"
-                          className="flex-1 py-2 text-sm"
-                        >
-                          キャンセル
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="font-bold text-blue-700 text-lg">
-                      {state?.branchName || '未設定'}
-                    </div>
+        {/* 確認ダイアログ */}
+        {showConfirmDialog && (
+          <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+            <Card className="w-full max-w-sm">
+              <div className="p-6">
+                <h3 className="text-lg font-bold text-gray-900 mb-2">退勤確認</h3>
+                <p className="text-gray-600 mb-6">
+                  退勤してよろしいですか？
+                  {state?.totalWorkMinutes && state.totalWorkMinutes > 0 && (
+                    <span className="block mt-2 text-sm">
+                      本日の勤務時間: {formatMinutesToHHMM(state.totalWorkMinutes)}
+                    </span>
                   )}
+                </p>
+                <div className="flex gap-3">
+                  <Button
+                    onClick={() => {
+                      setShowConfirmDialog(false);
+                      setConfirmAction(null);
+                    }}
+                    variant="secondary"
+                    className="flex-1 py-3"
+                  >
+                    キャンセル
+                  </Button>
+                  <Button
+                    onClick={handleClockOut}
+                    disabled={actionLoading}
+                    className="flex-1 py-3 bg-blue-600 hover:bg-blue-700"
+                  >
+                    {actionLoading ? '処理中...' : '退勤する'}
+                  </Button>
                 </div>
-              )}
+              </div>
+            </Card>
+          </div>
+        )}
 
-              {/* 退勤済みの場合は表示のみ */}
-              {state?.status === 'completed' && state?.branchName && (
-                <div className="bg-gray-50 rounded-lg p-4 mb-4">
-                  <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
-                    <MapPin className="w-4 h-4" />
-                    勤務先拠点
-                  </div>
-                  <div className="font-medium text-gray-700">
-                    {state.branchName}
+        <main className="max-w-lg mx-auto px-4 py-6 safe-area-inset-bottom pb-24">
+          {/* A: ステータスカード */}
+          <Card className="mb-6 overflow-hidden">
+            <div className={`px-6 py-4 ${statusInfo.bgColor}`}>
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm text-gray-600">今の状態</div>
+                  <div className={`text-2xl font-bold ${statusInfo.color}`}>
+                    {statusInfo.label}
                   </div>
                 </div>
-              )}
-
-              {/* シフト情報 */}
-              {state?.shift && (
-                <div className="bg-gray-50 rounded-lg p-4 mb-4">
-                  <div className="text-sm text-gray-500 mb-1">予定シフト</div>
-                  <div className="font-medium">
-                    {state.shift.shiftType}：{state.shift.plannedStart} - {state.shift.plannedEnd}
+                <div className="text-right">
+                  <div className="text-3xl font-bold text-gray-800">
+                    {currentTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
                   </div>
                   <div className="text-sm text-gray-500">
-                    休憩 {state.shift.breakMinutes}分
+                    {currentTime.toLocaleDateString('ja-JP', {
+                      month: 'short',
+                      day: 'numeric',
+                      weekday: 'short',
+                    })}
                   </div>
                 </div>
-              )}
+              </div>
+            </div>
 
-              {/* 打刻情報 */}
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">出勤</div>
-                  <div className="text-xl font-bold">
+            <div className="p-4">
+              {/* 勤務時間サマリー */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-gray-50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-gray-500 mb-1">出勤</div>
+                  <div className="text-lg font-bold text-gray-800">
                     {state?.clockIn ? formatTimeJST(state.clockIn) : '--:--'}
                   </div>
                 </div>
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">退勤</div>
-                  <div className="text-xl font-bold">
+                <div className="bg-gray-50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-gray-500 mb-1">退勤</div>
+                  <div className="text-lg font-bold text-gray-800">
                     {state?.clockOut ? formatTimeJST(state.clockOut) : '--:--'}
                   </div>
                 </div>
               </div>
 
-              {/* 休憩情報 */}
-              {(state?.breakStart || state?.status === 'on_break') && (
-                <div className="grid grid-cols-2 gap-4 mb-4">
-                  <div className="bg-yellow-50 rounded-lg p-4">
-                    <div className="text-sm text-gray-500">休憩開始</div>
-                    <div className="text-lg font-medium">
-                      {state?.breakStart ? formatTimeJST(state.breakStart) : '--:--'}
-                    </div>
-                  </div>
-                  <div className="bg-yellow-50 rounded-lg p-4">
-                    <div className="text-sm text-gray-500">休憩終了</div>
-                    <div className="text-lg font-medium">
-                      {state?.breakEnd ? formatTimeJST(state.breakEnd) : '--:--'}
-                    </div>
-                  </div>
-                </div>
-              )}
-
               {/* 勤務時間 */}
               {state?.totalWorkMinutes !== undefined && state.totalWorkMinutes > 0 && (
-                <div className="bg-blue-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">本日の勤務時間</div>
-                  <div className="text-2xl font-bold text-blue-600">
+                <div className="mt-3 bg-blue-50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-blue-600 mb-1">本日の勤務時間</div>
+                  <div className="text-xl font-bold text-blue-700">
                     {formatMinutesToHHMM(state.totalWorkMinutes)}
                   </div>
                 </div>
@@ -434,105 +524,260 @@ export default function AttendancePage() {
 
           {/* エラーメッセージ */}
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4">
-              {error}
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl mb-4 flex items-center gap-2">
+              <AlertCircle className="w-5 h-5 flex-shrink-0" />
+              <span>{error}</span>
             </div>
           )}
 
-          {/* 打刻ボタン */}
-          <div className="space-y-3">
-            {/* 出勤前：拠点選択 */}
+          {/* B: 大きい打刻ボタン */}
+          <div className="space-y-4 mb-6">
+            {/* 出勤前: 拠点選択 + 出勤ボタン */}
             {state?.status === 'not_started' && (
               <>
-                <Card className="mb-2">
+                {/* C: 勤務地セレクタ（チップUI） */}
+                <Card>
                   <div className="p-4">
-                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-3">
                       <MapPin className="w-4 h-4" />
-                      勤務先拠点を選択
+                      勤務先を選択
                     </label>
-                    <select
-                      value={selectedBranchId}
-                      onChange={(e) => setSelectedBranchId(e.target.value)}
-                      className="w-full px-3 py-3 border border-gray-300 rounded-lg text-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    >
-                      <option value="">-- 選択してください --</option>
-                      {BRANCHES_SEED.map((branch) => (
-                        <option key={branch.id} value={branch.id}>
-                          {branch.name}
-                        </option>
-                      ))}
-                    </select>
+                    <div className="flex flex-wrap gap-2">
+                      {BRANCHES_SEED.map((branch) => {
+                        const isRemote = branch.id === 'remote';
+                        const isSelected = selectedBranchId === branch.id;
+                        return (
+                          <button
+                            key={branch.id}
+                            onClick={() => setSelectedBranchId(branch.id)}
+                            className={`
+                              inline-flex items-center gap-1.5 px-4 py-2.5 rounded-full text-sm font-medium
+                              transition-all duration-200 border-2
+                              ${
+                                isSelected
+                                  ? isRemote
+                                    ? 'bg-purple-100 border-purple-400 text-purple-700'
+                                    : 'bg-blue-100 border-blue-400 text-blue-700'
+                                  : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+                              }
+                            `}
+                          >
+                            {isRemote ? (
+                              <Home className="w-4 h-4" />
+                            ) : (
+                              <Building2 className="w-4 h-4" />
+                            )}
+                            {branch.name}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
                 </Card>
+
                 <Button
                   onClick={handleClockIn}
                   disabled={actionLoading || !selectedBranchId}
-                  className="w-full py-4 text-lg bg-green-600 hover:bg-green-700 disabled:bg-gray-400"
+                  className="w-full py-5 text-xl font-bold bg-green-600 hover:bg-green-700 disabled:bg-gray-300 rounded-2xl shadow-lg active:scale-98 transition-transform"
                 >
-                  {actionLoading ? '処理中...' : '出勤'}
+                  {actionLoading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <span className="animate-spin rounded-full h-5 w-5 border-b-2 border-white" />
+                      処理中...
+                    </span>
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Play className="w-6 h-6" />
+                      出勤
+                    </span>
+                  )}
                 </Button>
               </>
             )}
 
-            {/* 休憩開始ボタン */}
+            {/* 勤務中: 休憩開始 + 退勤ボタン */}
             {state?.status === 'working' && (
               <>
+                {/* 現在の勤務先表示 */}
+                <Card className="bg-blue-50 border-blue-200">
+                  <div className="p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        {state.branchId === 'remote' ? (
+                          <Home className="w-5 h-5 text-purple-600" />
+                        ) : (
+                          <Building2 className="w-5 h-5 text-blue-600" />
+                        )}
+                        <div>
+                          <div className="text-xs text-gray-500">勤務先</div>
+                          <div className="font-bold text-gray-800">{state.branchName || '未設定'}</div>
+                        </div>
+                      </div>
+                      {!isEditingBranch && (
+                        <button
+                          onClick={startEditingBranch}
+                          className="text-blue-600 hover:text-blue-800 p-2"
+                          title="拠点を変更"
+                        >
+                          <Edit2 className="w-5 h-5" />
+                        </button>
+                      )}
+                    </div>
+                    {isEditingBranch && (
+                      <div className="mt-3 space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                          {BRANCHES_SEED.map((branch) => {
+                            const isRemote = branch.id === 'remote';
+                            const isSelected = editBranchId === branch.id;
+                            return (
+                              <button
+                                key={branch.id}
+                                onClick={() => setEditBranchId(branch.id)}
+                                className={`
+                                  inline-flex items-center gap-1.5 px-3 py-2 rounded-full text-sm font-medium
+                                  transition-all duration-200 border-2
+                                  ${
+                                    isSelected
+                                      ? isRemote
+                                        ? 'bg-purple-100 border-purple-400 text-purple-700'
+                                        : 'bg-blue-100 border-blue-400 text-blue-700'
+                                      : 'bg-white border-gray-200 text-gray-600 hover:border-gray-300'
+                                  }
+                                `}
+                              >
+                                {isRemote ? (
+                                  <Home className="w-3 h-3" />
+                                ) : (
+                                  <Building2 className="w-3 h-3" />
+                                )}
+                                {branch.name}
+                              </button>
+                            );
+                          })}
+                        </div>
+                        <div className="flex gap-2">
+                          <Button
+                            onClick={handleChangeBranch}
+                            disabled={actionLoading || !editBranchId}
+                            className="flex-1 py-2 text-sm bg-blue-600 hover:bg-blue-700"
+                          >
+                            {actionLoading ? '変更中...' : '変更'}
+                          </Button>
+                          <Button
+                            onClick={() => setIsEditingBranch(false)}
+                            variant="secondary"
+                            className="flex-1 py-2 text-sm"
+                          >
+                            キャンセル
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </Card>
+
                 <Button
                   onClick={handleBreakStart}
                   disabled={actionLoading}
                   variant="secondary"
-                  className="w-full py-4 text-lg"
+                  className="w-full py-4 text-lg font-semibold rounded-xl"
                 >
-                  {actionLoading ? '処理中...' : '休憩開始'}
+                  {actionLoading ? (
+                    '処理中...'
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Coffee className="w-5 h-5" />
+                      休憩開始
+                    </span>
+                  )}
                 </Button>
+
                 <Button
-                  onClick={handleClockOut}
+                  onClick={requestClockOut}
                   disabled={actionLoading}
-                  className="w-full py-4 text-lg bg-blue-600 hover:bg-blue-700"
+                  className="w-full py-5 text-xl font-bold bg-blue-600 hover:bg-blue-700 rounded-2xl shadow-lg active:scale-98 transition-transform"
                 >
-                  {actionLoading ? '処理中...' : '退勤'}
-                </Button>
-                <Button
-                  onClick={startEditingTime}
-                  variant="secondary"
-                  className="w-full py-3 flex items-center justify-center gap-2 text-sm"
-                >
-                  <Clock className="w-4 h-4" />
-                  出勤時刻を修正
+                  {actionLoading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <span className="animate-spin rounded-full h-5 w-5 border-b-2 border-white" />
+                      処理中...
+                    </span>
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Square className="w-6 h-6" />
+                      退勤
+                    </span>
+                  )}
                 </Button>
               </>
             )}
 
-            {/* 休憩終了ボタン */}
+            {/* 休憩中: 休憩終了ボタン */}
             {state?.status === 'on_break' && (
-              <Button
-                onClick={handleBreakEnd}
-                disabled={actionLoading}
-                className="w-full py-4 text-lg bg-yellow-600 hover:bg-yellow-700"
-              >
-                {actionLoading ? '処理中...' : '休憩終了'}
-              </Button>
+              <>
+                <Card className="bg-amber-50 border-amber-200">
+                  <div className="p-4 text-center">
+                    <Coffee className="w-8 h-8 text-amber-600 mx-auto mb-2" />
+                    <div className="text-amber-800 font-medium">休憩中です</div>
+                    {state.breakStart && (
+                      <div className="text-sm text-amber-600 mt-1">
+                        {formatTimeJST(state.breakStart)} から
+                      </div>
+                    )}
+                  </div>
+                </Card>
+
+                <Button
+                  onClick={handleBreakEnd}
+                  disabled={actionLoading}
+                  className="w-full py-5 text-xl font-bold bg-amber-600 hover:bg-amber-700 rounded-2xl shadow-lg active:scale-98 transition-transform"
+                >
+                  {actionLoading ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <span className="animate-spin rounded-full h-5 w-5 border-b-2 border-white" />
+                      処理中...
+                    </span>
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Play className="w-6 h-6" />
+                      休憩終了
+                    </span>
+                  )}
+                </Button>
+
+                <p className="text-center text-sm text-gray-500">
+                  ※ 退勤するには先に休憩を終了してください
+                </p>
+              </>
             )}
 
-            {/* 退勤済みメッセージと修正ボタン */}
+            {/* 退勤済み */}
             {state?.status === 'completed' && (
-              <div className="space-y-3">
-                <div className="text-center py-4 text-gray-600">
-                  本日の勤務は終了しました。お疲れさまでした。
+              <Card className="bg-blue-50 border-blue-200">
+                <div className="p-6 text-center">
+                  <CheckCircle className="w-12 h-12 text-blue-600 mx-auto mb-3" />
+                  <div className="text-lg font-bold text-blue-800 mb-1">
+                    本日の勤務は終了しました
+                  </div>
+                  <div className="text-blue-600">お疲れさまでした！</div>
                 </div>
-                <Button
-                  onClick={startEditingTime}
-                  variant="secondary"
-                  className="w-full py-3 flex items-center justify-center gap-2"
-                >
-                  <Clock className="w-4 h-4" />
-                  打刻を修正する
-                </Button>
-              </div>
+              </Card>
             )}
           </div>
 
-          {/* 打刻修正モーダル */}
+          {/* 打刻修正ボタン（勤務中 or 退勤済み） */}
+          {(state?.status === 'working' || state?.status === 'completed') && !isEditingTime && (
+            <Button
+              onClick={startEditingTime}
+              variant="secondary"
+              className="w-full py-3 flex items-center justify-center gap-2 text-sm mb-6"
+            >
+              <Clock className="w-4 h-4" />
+              打刻を修正する
+            </Button>
+          )}
+
+          {/* 打刻修正フォーム */}
           {isEditingTime && (
             <Card className="mb-6 border-2 border-orange-200">
               <div className="p-6">
@@ -545,7 +790,6 @@ export default function AttendancePage() {
                 </p>
 
                 <div className="space-y-4">
-                  {/* 出勤時刻 */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       出勤時刻
@@ -558,7 +802,6 @@ export default function AttendancePage() {
                     />
                   </div>
 
-                  {/* 退勤時刻 */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       退勤時刻
@@ -571,7 +814,6 @@ export default function AttendancePage() {
                     />
                   </div>
 
-                  {/* 休憩開始 */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       休憩開始
@@ -584,7 +826,6 @@ export default function AttendancePage() {
                     />
                   </div>
 
-                  {/* 休憩終了 */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       休憩終了
@@ -597,7 +838,6 @@ export default function AttendancePage() {
                     />
                   </div>
 
-                  {/* 修正理由 */}
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       修正理由 <span className="text-red-500">*</span>
@@ -632,8 +872,37 @@ export default function AttendancePage() {
             </Card>
           )}
 
+          {/* E: 今日の履歴 */}
+          {punchHistory.length > 0 && (
+            <Card className="mb-6">
+              <div className="p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <History className="w-4 h-4 text-gray-500" />
+                  <h3 className="text-sm font-medium text-gray-700">今日の打刻履歴</h3>
+                </div>
+                <div className="space-y-2">
+                  {punchHistory.map((item, index) => {
+                    const Icon = item.icon;
+                    return (
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 py-2 border-b border-gray-100 last:border-0"
+                      >
+                        <Icon className={`w-4 h-4 ${item.color}`} />
+                        <span className="text-sm text-gray-700 flex-1">{item.label}</span>
+                        <span className="text-sm font-medium text-gray-900">
+                          {formatTimeJST(item.time)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </Card>
+          )}
+
           {/* ナビゲーション */}
-          <div className="mt-8 pt-6 border-t">
+          <div className="pt-4 border-t">
             <div className="grid grid-cols-2 gap-3">
               <Button
                 variant="secondary"
@@ -653,6 +922,26 @@ export default function AttendancePage() {
           </div>
         </main>
       </div>
+
+      {/* トーストアニメーション用のスタイル */}
+      <style jsx global>{`
+        @keyframes fade-in {
+          from {
+            opacity: 0;
+            transform: translate(-50%, -10px);
+          }
+          to {
+            opacity: 1;
+            transform: translate(-50%, 0);
+          }
+        }
+        .animate-fade-in {
+          animation: fade-in 0.3s ease-out;
+        }
+        .active\\:scale-98:active {
+          transform: scale(0.98);
+        }
+      `}</style>
     </AuthGuard>
   );
 }


### PR DESCRIPTION
- 打刻ページを今風のUIに改善
  - チップUIで勤務地選択（在宅ワーク対応）
  - 退勤時に確認ダイアログ表示
  - 成功/失敗トースト通知
  - 今日の打刻履歴表示
  - モバイル最適化（大きいボタン、角丸）
  - 前回選択した勤務地をlocalStorageで記憶
- E2Eテスト追加
  - attendance.spec.ts: 打刻ページの存在確認
  - self-check.spec.ts: セルフチェック・ヘルスAPI検証

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
