### PR TITLE
feat: 入居希望者の自動付番とKPIスコープを実装

### DIFF
--- a/__tests__/prospect-internal-no.test.ts
+++ b/__tests__/prospect-internal-no.test.ts
@@ -1,0 +1,172 @@
+/**
+ * 入居希望者 internal_no 自動付番・KPIスコープのUnit test
+ *
+ * テスト対象:
+ * 1. isKpiTargetInternalNo: internal_noがKPI対象（252以上）かの判定
+ * 2. isProspectKpiTarget: ProspectがKPI対象かの判定
+ * 3. applyProspectKpiScope: Prospect配列にKPIスコープを適用
+ */
+
+import {
+  isKpiTargetInternalNo,
+  isProspectKpiTarget,
+  applyProspectKpiScope,
+  KPI_MIN_INTERNAL_NO,
+} from '@/lib/prospect';
+import type { Prospect, ProspectStatus } from '@/types/prospect';
+
+// テスト用のProspectを作成するヘルパー
+function createMockProspect(internalNo: string | number | undefined | null): Prospect {
+  return {
+    id: 'test-id',
+    tenantId: 'defaultTenant',
+    status: '新規受付' as ProspectStatus,
+    receivedAt: new Date(),
+    createdAt: new Date(),
+    internalNo: internalNo as string | undefined,
+  } as Prospect;
+}
+
+describe('KPI_MIN_INTERNAL_NO', () => {
+  test('KPI_MIN_INTERNAL_NOは252', () => {
+    expect(KPI_MIN_INTERNAL_NO).toBe(252);
+  });
+});
+
+describe('isKpiTargetInternalNo', () => {
+  test('undefined はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(undefined)).toBe(false);
+  });
+
+  test('null はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(null)).toBe(false);
+  });
+
+  test('空文字 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo('')).toBe(false);
+  });
+
+  test('251 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(251)).toBe(false);
+    expect(isKpiTargetInternalNo('251')).toBe(false);
+  });
+
+  test('100 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(100)).toBe(false);
+    expect(isKpiTargetInternalNo('100')).toBe(false);
+  });
+
+  test('0 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(0)).toBe(false);
+    expect(isKpiTargetInternalNo('0')).toBe(false);
+  });
+
+  test('252 はKPI対象', () => {
+    expect(isKpiTargetInternalNo(252)).toBe(true);
+    expect(isKpiTargetInternalNo('252')).toBe(true);
+  });
+
+  test('253 はKPI対象', () => {
+    expect(isKpiTargetInternalNo(253)).toBe(true);
+    expect(isKpiTargetInternalNo('253')).toBe(true);
+  });
+
+  test('500 はKPI対象', () => {
+    expect(isKpiTargetInternalNo(500)).toBe(true);
+    expect(isKpiTargetInternalNo('500')).toBe(true);
+  });
+
+  test('数値でない文字列 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo('abc')).toBe(false);
+    expect(isKpiTargetInternalNo('IMPORT-123')).toBe(false);
+  });
+});
+
+describe('isProspectKpiTarget', () => {
+  test('internal_no=252 のProspectはKPI対象', () => {
+    const prospect = createMockProspect('252');
+    expect(isProspectKpiTarget(prospect)).toBe(true);
+  });
+
+  test('internal_no=251 のProspectはKPI対象外', () => {
+    const prospect = createMockProspect('251');
+    expect(isProspectKpiTarget(prospect)).toBe(false);
+  });
+
+  test('internal_no=undefined のProspectはKPI対象外', () => {
+    const prospect = createMockProspect(undefined);
+    expect(isProspectKpiTarget(prospect)).toBe(false);
+  });
+});
+
+describe('applyProspectKpiScope', () => {
+  test('空配列は空配列を返す', () => {
+    const result = applyProspectKpiScope([]);
+    expect(result).toEqual([]);
+  });
+
+  test('KPI対象のみをフィルタリング', () => {
+    const prospects = [
+      createMockProspect('250'),
+      createMockProspect('251'),
+      createMockProspect('252'),
+      createMockProspect('253'),
+      createMockProspect(undefined),
+    ];
+
+    const result = applyProspectKpiScope(prospects);
+
+    expect(result.length).toBe(2);
+    expect(result[0].internalNo).toBe('252');
+    expect(result[1].internalNo).toBe('253');
+  });
+
+  test('全てKPI対象の場合はすべて返す', () => {
+    const prospects = [
+      createMockProspect('252'),
+      createMockProspect('300'),
+      createMockProspect('500'),
+    ];
+
+    const result = applyProspectKpiScope(prospects);
+
+    expect(result.length).toBe(3);
+  });
+
+  test('全てKPI対象外の場合は空配列を返す', () => {
+    const prospects = [
+      createMockProspect('100'),
+      createMockProspect('200'),
+      createMockProspect('251'),
+      createMockProspect(undefined),
+    ];
+
+    const result = applyProspectKpiScope(prospects);
+
+    expect(result.length).toBe(0);
+  });
+
+  test('元の配列は変更されない（イミュータブル）', () => {
+    const prospects = [
+      createMockProspect('251'),
+      createMockProspect('252'),
+    ];
+    const originalLength = prospects.length;
+
+    applyProspectKpiScope(prospects);
+
+    expect(prospects.length).toBe(originalLength);
+  });
+});
+
+describe('自動付番ルール', () => {
+  test('KPI_MIN_INTERNAL_NO - 1 = 251 が境界値', () => {
+    // カウンタが251以下なら、次は252から開始する
+    expect(KPI_MIN_INTERNAL_NO - 1).toBe(251);
+  });
+
+  test('252が最初のKPI対象番号', () => {
+    expect(isKpiTargetInternalNo(KPI_MIN_INTERNAL_NO)).toBe(true);
+    expect(isKpiTargetInternalNo(KPI_MIN_INTERNAL_NO - 1)).toBe(false);
+  });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { DEFAULT_TENANT_ID } from '@/lib/firebase';
 import { getCheckinHistory, getChaosDashboardMetrics, getInterventions } from '@/lib/chaos';
 import { getSalesDeals, getSalesAccounts } from '@/lib/sales';
-import { getProspects } from '@/lib/prospect';
+import { getProspects, applyProspectKpiScope } from '@/lib/prospect';
 import { getFacilitiesWithVacancy } from '@/lib/vacancy';
 import { getRingisByUser, getPendingRingis } from '@/lib/ringi';
 import { AuthGuard } from '@/components/AuthGuard';
@@ -225,10 +225,12 @@ function DashboardContent() {
           errors.push(toDashboardError(err));
         }
 
-        // 入居希望データ（スコアリング）
+        // 入居希望データ（スコアリング）- KPI対象はinternal_no >= 252のみ
         try {
           const prospectsData = await getProspects(DEFAULT_TENANT_ID);
-          const activeProspects = prospectsData.filter(
+          // KPIスコープ適用: internal_no >= 252 のみ
+          const kpiTargetProspects = applyProspectKpiScope(prospectsData);
+          const activeProspects = kpiTargetProspects.filter(
             p => p.status !== '見送り' && p.status !== 'クローズ' && p.status !== '入居決定'
           );
           const scoringResults = calculateBatchMoveInProbability(activeProspects);

--- a/src/app/dashboard/prospects/page.tsx
+++ b/src/app/dashboard/prospects/page.tsx
@@ -7,7 +7,7 @@ import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { Card, CardHeader, CardTitle, CardContent, Badge, Button, Input, Select } from '@/components/ui';
 import { Loading } from '@/components/Loading';
-import { getProspects, getProspectStats } from '@/lib/prospect';
+import { getProspects, getProspectStats, applyProspectKpiScope, isProspectKpiTarget, KPI_MIN_INTERNAL_NO } from '@/lib/prospect';
 import { hasMinRole } from '@/lib/auth';
 import {
   Prospect,
@@ -56,6 +56,8 @@ function ProspectsContent() {
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | ''>('');
   const [facilityFilter, setFacilityFilter] = useState('');
   const [sortBy, setSortBy] = useState<'receivedAt' | 'daysElapsed' | 'interviewDateTime'>('receivedAt');
+  // 過去データ表示（internal_no < 252）- デフォルト非表示
+  const [showLegacyData, setShowLegacyData] = useState(false);
 
   const canManage = hasMinRole(user?.role, 'leader');
 
@@ -80,9 +82,16 @@ function ProspectsContent() {
     fetchData();
   }, [fetchData]);
 
+  // 過去データ（internal_no < 252）の件数
+  const legacyCount = prospects.filter((p) => !isProspectKpiTarget(p)).length;
+
   // フィルタリングとソート
   const filteredProspects = prospects
     .filter((p) => {
+      // 過去データフィルター（デフォルト: internal_no >= 252 のみ表示）
+      if (!showLegacyData && !isProspectKpiTarget(p)) {
+        return false;
+      }
       // 検索
       if (searchQuery) {
         const q = searchQuery.toLowerCase();
@@ -278,6 +287,30 @@ function ProspectsContent() {
                 />
               </div>
             </div>
+            {/* 管理者向け: 過去データ表示トグル */}
+            {canManage && legacyCount > 0 && (
+              <div className="mt-3 pt-3 border-t flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={showLegacyData}
+                      onChange={(e) => setShowLegacyData(e.target.checked)}
+                      className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="text-sm text-gray-600">
+                      過去データを表示（No.{KPI_MIN_INTERNAL_NO}未満）
+                    </span>
+                  </label>
+                  <Badge variant="default" className="text-xs">
+                    {legacyCount}件
+                  </Badge>
+                </div>
+                <p className="text-xs text-gray-400">
+                  ※ KPIにはNo.{KPI_MIN_INTERNAL_NO}以上のみ含まれます
+                </p>
+              </div>
+            )}
           </Card>
 
           {/* 一覧 */}

--- a/src/lib/google-sheets.ts
+++ b/src/lib/google-sheets.ts
@@ -7,6 +7,12 @@ import type { Prospect, ProspectStatus, CareLevel, Gender } from '@/types/prospe
 
 const DEFAULT_TENANT_ID = 'defaultTenant';
 
+// KPI対象の最小internal_no（252以上のみKPI対象）
+const KPI_MIN_INTERNAL_NO = 252;
+
+// カウンタードキュメントパス
+const COUNTER_DOC_PATH = 'counters/prospects_internal_no';
+
 // 対象スプレッドシートID
 const PROSPECT_SHEET_ID = process.env.PROSPECT_SHEET_ID || '1y00PmqtKRCsyrvaH8ydO3QbzVbFXGEVA2dpKOUDJMaY';
 
@@ -15,6 +21,85 @@ const PROSPECT_SHEET_ID = process.env.PROSPECT_SHEET_ID || '1y00PmqtKRCsyrvaH8yd
  */
 export function isGoogleSheetsConfigured(): boolean {
   return true; // 公開シートはAPI認証不要
+}
+
+/**
+ * 次のinternal_noを取得（Admin SDK用・トランザクションで重複防止）
+ */
+async function getNextInternalNoAdmin(): Promise<number> {
+  const db = getAdminDb();
+  const counterRef = db.doc(COUNTER_DOC_PATH);
+
+  return await db.runTransaction(async (transaction) => {
+    const counterSnap = await transaction.get(counterRef);
+
+    let current: number;
+
+    if (!counterSnap.exists) {
+      // カウンタ未設定の場合、既存prospectsの最大internal_noを計算
+      const prospectsSnap = await db
+        .collection('prospects')
+        .where('tenantId', '==', DEFAULT_TENANT_ID)
+        .get();
+
+      let maxInternalNo = 0;
+      prospectsSnap.docs.forEach((d) => {
+        const data = d.data();
+        if (data.internalNo) {
+          const num = typeof data.internalNo === 'number'
+            ? data.internalNo
+            : parseInt(String(data.internalNo), 10);
+          if (!isNaN(num) && num > maxInternalNo) {
+            maxInternalNo = num;
+          }
+        }
+      });
+
+      // 251以下なら251にセット（次は252になる）
+      current = maxInternalNo < KPI_MIN_INTERNAL_NO - 1 ? KPI_MIN_INTERNAL_NO - 1 : maxInternalNo;
+    } else {
+      current = counterSnap.data()?.current || 0;
+      // 251以下なら251に補正
+      if (current < KPI_MIN_INTERNAL_NO - 1) {
+        current = KPI_MIN_INTERNAL_NO - 1;
+      }
+    }
+
+    // インクリメント
+    const nextNo = current + 1;
+
+    // カウンタを更新
+    transaction.set(counterRef, {
+      current: nextNo,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    return nextNo;
+  });
+}
+
+/**
+ * 監査ログを記録（Admin SDK用）
+ */
+async function createAuditLogAdmin(data: {
+  tenantId: string;
+  actor: string;
+  actorName: string;
+  action: string;
+  entity: string;
+  entityId: string;
+  diff?: {
+    before?: Record<string, unknown>;
+    after?: Record<string, unknown>;
+  };
+  note?: string;
+}): Promise<void> {
+  await getAdminDb().collection('auditLogs').add({
+    ...data,
+    diff: data.diff || null,
+    note: data.note || null,
+    createdAt: FieldValue.serverTimestamp(),
+  });
 }
 
 /**
@@ -541,18 +626,43 @@ export async function importProspectsFromSheet(
         }
 
         if (!dryRun) {
+          // internal_noが未設定または"IMPORT-"で始まる場合は自動付番
+          let finalInternalNo = prospect.internalNo;
+          const needsAutoNumber = !finalInternalNo || finalInternalNo.startsWith('IMPORT-');
+          if (needsAutoNumber) {
+            const nextNo = await getNextInternalNoAdmin();
+            finalInternalNo = nextNo.toString();
+          }
+
           // Firestoreに保存（undefined値を除去）
           const cleanedProspect = removeUndefined(prospect as Record<string, unknown>);
           const docData = {
             tenantId: DEFAULT_TENANT_ID,
             prospectKey,
             ...cleanedProspect,
+            internalNo: finalInternalNo,
             createdAt: FieldValue.serverTimestamp(),
             receivedAt: prospect.receivedAt || new Date(),
           };
 
-          await getAdminDb().collection('prospects').add(docData);
+          const docRef = await getAdminDb().collection('prospects').add(docData);
           existingKeys.set(prospectKey, 'new');
+
+          // 自動付番した場合は監査ログを記録
+          if (needsAutoNumber) {
+            await createAuditLogAdmin({
+              tenantId: DEFAULT_TENANT_ID,
+              actor: 'system',
+              actorName: 'System (Import)',
+              action: 'create',
+              entity: 'prospect',
+              entityId: docRef.id,
+              diff: {
+                after: { internalNo: finalInternalNo },
+              },
+              note: `PROSPECT_AUTO_NUMBER_ASSIGNED: ${finalInternalNo}`,
+            });
+          }
         }
 
         result.imported++;

--- a/src/lib/prospect.ts
+++ b/src/lib/prospect.ts
@@ -12,6 +12,8 @@ import {
   where,
   Timestamp,
   writeBatch,
+  runTransaction,
+  setDoc,
 } from 'firebase/firestore';
 import { db, DEFAULT_TENANT_ID } from './firebase';
 import {
@@ -38,6 +40,12 @@ export const PROSPECTS_CUTOFF_DATE = new Date('2026-01-01T00:00:00.000Z');
 
 // KPI集計対象年（2026年以降）
 export const KPI_START_YEAR = 2026;
+
+// KPI対象の最小internal_no（252以上のみKPI対象、251以前は対象外）
+export const KPI_MIN_INTERNAL_NO = 252;
+
+// カウンタードキュメントパス
+const COUNTER_DOC_PATH = 'counters/prospects_internal_no';
 
 /**
  * プロスペクトの判定日を取得（優先順位: inquiryDate > receivedAt > createdAt）
@@ -71,15 +79,135 @@ export function isKpiTargetDate(date: Date): boolean {
   return date.getFullYear() >= KPI_START_YEAR;
 }
 
+/**
+ * internal_noがKPI対象（252以上）かどうかを判定
+ */
+export function isKpiTargetInternalNo(internalNo: string | number | undefined | null): boolean {
+  if (internalNo === undefined || internalNo === null || internalNo === '') {
+    return false;
+  }
+  const num = typeof internalNo === 'number' ? internalNo : parseInt(String(internalNo), 10);
+  return !isNaN(num) && num >= KPI_MIN_INTERNAL_NO;
+}
+
+/**
+ * ProspectがKPI対象かどうかを判定（internal_no >= 252）
+ */
+export function isProspectKpiTarget(prospect: Prospect): boolean {
+  return isKpiTargetInternalNo(prospect.internalNo);
+}
+
+/**
+ * Prospect配列にKPIスコープを適用（internal_no >= 252 のみ返す）
+ */
+export function applyProspectKpiScope(prospects: Prospect[]): Prospect[] {
+  return prospects.filter(isProspectKpiTarget);
+}
+
 function getDb() {
   if (!db) throw new Error('Firestore not initialized');
   return db;
+}
+
+// ======== 自動付番 ========
+
+/**
+ * 次のinternal_noを取得（トランザクションで重複防止）
+ * - カウンタが未設定の場合は、既存prospectsの最大値から初期化
+ * - カウンタが251以下の場合は252から開始
+ */
+export async function getNextInternalNo(
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<number> {
+  const firestore = getDb();
+  const counterRef = doc(firestore, COUNTER_DOC_PATH);
+
+  return await runTransaction(firestore, async (transaction) => {
+    const counterSnap = await transaction.get(counterRef);
+
+    let current: number;
+
+    if (!counterSnap.exists()) {
+      // カウンタ未設定の場合、既存prospectsの最大internal_noを計算
+      const prospectsSnap = await getDocs(
+        query(collection(firestore, 'prospects'), where('tenantId', '==', tenantId))
+      );
+
+      let maxInternalNo = 0;
+      prospectsSnap.docs.forEach((d) => {
+        const data = d.data();
+        if (data.internalNo) {
+          const num = typeof data.internalNo === 'number'
+            ? data.internalNo
+            : parseInt(String(data.internalNo), 10);
+          if (!isNaN(num) && num > maxInternalNo) {
+            maxInternalNo = num;
+          }
+        }
+      });
+
+      // 251以下なら251にセット（次は252になる）
+      current = maxInternalNo < KPI_MIN_INTERNAL_NO - 1 ? KPI_MIN_INTERNAL_NO - 1 : maxInternalNo;
+    } else {
+      current = counterSnap.data().current || 0;
+      // 251以下なら251に補正
+      if (current < KPI_MIN_INTERNAL_NO - 1) {
+        current = KPI_MIN_INTERNAL_NO - 1;
+      }
+    }
+
+    // インクリメント
+    const nextNo = current + 1;
+
+    // カウンタを更新
+    transaction.set(counterRef, {
+      current: nextNo,
+      updatedAt: Timestamp.now(),
+    });
+
+    return nextNo;
+  });
+}
+
+/**
+ * 自動付番を割り当てて監査ログを記録
+ */
+export async function assignInternalNo(
+  prospectId: string,
+  tenantId: string = DEFAULT_TENANT_ID
+): Promise<number> {
+  const firestore = getDb();
+  const nextNo = await getNextInternalNo(tenantId);
+
+  // Prospectを更新
+  await updateDoc(doc(firestore, 'prospects', prospectId), {
+    internalNo: nextNo.toString(),
+    updatedAt: Timestamp.now(),
+  });
+
+  // 監査ログを記録
+  await createAuditLog({
+    tenantId,
+    actor: 'system',
+    actorName: 'System',
+    action: 'update',
+    entity: 'prospect',
+    entityId: prospectId,
+    diff: {
+      before: { internalNo: null },
+      after: { internalNo: nextNo },
+    },
+    note: `PROSPECT_AUTO_NUMBER_ASSIGNED: ${nextNo}`,
+  });
+
+  return nextNo;
 }
 
 // ======== 入居希望者 CRUD ========
 
 /**
  * 入居希望者を作成
+ * internal_noが未設定の場合は自動付番する
  */
 export async function createProspect(
   data: Partial<Prospect>,
@@ -98,6 +226,14 @@ export async function createProspect(
     salesRepName: data.salesRepName,
   });
 
+  // internal_noが未設定の場合は自動付番
+  let internalNo = data.internalNo || null;
+  const needsAutoNumber = !internalNo;
+  if (needsAutoNumber) {
+    const nextNo = await getNextInternalNo(tenantId);
+    internalNo = nextNo.toString();
+  }
+
   const prospectData = {
     tenantId,
     status: data.status || '新規受付',
@@ -107,7 +243,7 @@ export async function createProspect(
     createdBy: createdBy || null,
     createdByName: createdByName || null,
     // 基本情報
-    internalNo: data.internalNo || null,
+    internalNo,
     statusNote: data.statusNote || null,
     assigneeId: data.assigneeId || null,
     assigneeName: data.assigneeName || null,
@@ -155,6 +291,22 @@ export async function createProspect(
   };
 
   const docRef = await addDoc(collection(firestore, 'prospects'), prospectData);
+
+  // 自動付番を行った場合は監査ログを記録
+  if (needsAutoNumber) {
+    await createAuditLog({
+      tenantId,
+      actor: 'system',
+      actorName: 'System',
+      action: 'create',
+      entity: 'prospect',
+      entityId: docRef.id,
+      diff: {
+        after: { internalNo },
+      },
+      note: `PROSPECT_AUTO_NUMBER_ASSIGNED: ${internalNo}`,
+    });
+  }
 
   return {
     id: docRef.id,
@@ -1072,13 +1224,15 @@ export async function unlockRoom(
 
 /**
  * ダッシュボード統計を取得
- * KPIは2026年以降のデータのみで算出
+ * KPIはinternal_no >= 252のデータのみで算出
  */
 export async function getProspectStats(
   tenantId: string = DEFAULT_TENANT_ID
 ): Promise<{
   total: number;
+  totalKpi: number;
   byStatus: Record<ProspectStatus, number>;
+  byStatusKpi: Record<ProspectStatus, number>;
   newThisWeek: number;
   newThisMonth: number;
   avgDaysElapsed: number;
@@ -1090,19 +1244,25 @@ export async function getProspectStats(
   const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-  // KPI対象は2026年以降のデータのみ
-  const kpiTargetProspects = prospects.filter((p) => isKpiTargetDate(p.receivedAt));
+  // KPI対象はinternal_no >= 252のみ（厳格）
+  const kpiTargetProspects = applyProspectKpiScope(prospects);
 
   const byStatus: Record<string, number> = {};
+  const byStatusKpi: Record<string, number> = {};
   let totalDays = 0;
   let activeCount = 0;
 
-  // ステータス集計は全件（アクティブな社内No 252以降）
+  // ステータス集計（全件）
   prospects.forEach((p) => {
     byStatus[p.status] = (byStatus[p.status] || 0) + 1;
   });
 
-  // KPIは2026以降のみ
+  // ステータス集計（KPI対象のみ）
+  kpiTargetProspects.forEach((p) => {
+    byStatusKpi[p.status] = (byStatusKpi[p.status] || 0) + 1;
+  });
+
+  // KPIはinternal_no >= 252のみ
   kpiTargetProspects.forEach((p) => {
     if (!['クローズ', '見送り', '入居決定'].includes(p.status)) {
       const days = Math.floor((now.getTime() - p.receivedAt.getTime()) / (1000 * 60 * 60 * 24));
@@ -1113,10 +1273,12 @@ export async function getProspectStats(
 
   return {
     total: prospects.length,
+    totalKpi: kpiTargetProspects.length,
     byStatus: byStatus as Record<ProspectStatus, number>,
+    byStatusKpi: byStatusKpi as Record<ProspectStatus, number>,
     newThisWeek: kpiTargetProspects.filter((p) => p.receivedAt > weekAgo).length,
     newThisMonth: kpiTargetProspects.filter((p) => p.receivedAt > monthAgo).length,
     avgDaysElapsed: activeCount > 0 ? Math.round(totalDays / activeCount) : 0,
-    kpiNote: `KPIは${KPI_START_YEAR}年以降のデータで算出`,
+    kpiNote: `KPIはinternal_no >= ${KPI_MIN_INTERNAL_NO}のデータで算出`,
   };
 }


### PR DESCRIPTION
## 変更内容

### 1. 自動付番（internal_no）
- getNextInternalNo: カウンター方式（counters/prospects_internal_no）でトランザクション採番
- current が 251以下なら 252 から開始
- createProspect、createProspectFromWebhook、Google Sheetsインポートすべてに適用
- 監査ログに PROSPECT_AUTO_NUMBER_ASSIGNED を記録

### 2. KPIスコープ
- KPI_MIN_INTERNAL_NO = 252 を定数化
- isKpiTargetInternalNo: internal_no >= 252 判定
- isProspectKpiTarget: Prospect単体の判定
- applyProspectKpiScope: Prospect配列フィルタリング

### 3. KPI適用箇所
- getProspectStats: internal_no >= 252 のみで集計
- Dashboard営業OS: KPIスコープ適用済み
- 一覧ページ: デフォルト非表示 + 管理者トグル

### 4. ユニットテスト
- __tests__/prospect-internal-no.test.ts: 21件のテストケース

## 受け入れ基準
- [x] internal_noが無い入居希望が作られた時、必ず自動で番号が入る
- [x] 採番が重複しない（トランザクション）
- [x] KPIはinternal_no >= 252のみで算出（251以前は混ざらない）

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
