### PR TITLE
feat: /sales APIベース化とKPIスコープ適用

### DIFF
--- a/__tests__/sales-metrics.test.ts
+++ b/__tests__/sales-metrics.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 営業メトリクス関連のUnit test
+ *
+ * テスト対象:
+ * 1. safeRate: 分母0でnull
+ * 2. formatPercent: null/undefinedで'--'
+ * 3. formatNumber: null/undefinedで'--'
+ */
+
+import {
+  safeRate,
+  formatPercent,
+  formatNumber,
+  formatFraction,
+  calcCvRate,
+} from '@/lib/dashboard/calc';
+
+describe('safeRate', () => {
+  test('正常な計算', () => {
+    expect(safeRate(1, 2)).toBe(50);
+    expect(safeRate(3, 4)).toBe(75);
+    expect(safeRate(10, 10)).toBe(100);
+    expect(safeRate(0, 10)).toBe(0);
+  });
+
+  test('分母0でnull', () => {
+    expect(safeRate(5, 0)).toBeNull();
+    expect(safeRate(0, 0)).toBeNull();
+  });
+
+  test('分母が無限大でnull', () => {
+    expect(safeRate(5, Infinity)).toBeNull();
+  });
+});
+
+describe('formatPercent', () => {
+  test('正常な表示', () => {
+    expect(formatPercent(50)).toBe('50%');
+    expect(formatPercent(100)).toBe('100%');
+    expect(formatPercent(0)).toBe('0%');
+  });
+
+  test('nullで--', () => {
+    expect(formatPercent(null)).toBe('--');
+  });
+
+  test('undefinedで--', () => {
+    expect(formatPercent(undefined)).toBe('--');
+  });
+
+  test('Infinityで--', () => {
+    expect(formatPercent(Infinity)).toBe('--');
+  });
+});
+
+describe('formatNumber', () => {
+  test('正常な表示', () => {
+    expect(formatNumber(10)).toBe('10');
+    expect(formatNumber(0)).toBe('0');
+    expect(formatNumber(999)).toBe('999');
+  });
+
+  test('nullで--', () => {
+    expect(formatNumber(null)).toBe('--');
+  });
+
+  test('undefinedで--', () => {
+    expect(formatNumber(undefined)).toBe('--');
+  });
+});
+
+describe('formatFraction', () => {
+  test('正常な表示', () => {
+    expect(formatFraction(3, 5)).toBe('3/5');
+    expect(formatFraction(0, 10)).toBe('0/10');
+  });
+
+  test('分母0で--', () => {
+    expect(formatFraction(5, 0)).toBe('--');
+  });
+});
+
+describe('calcCvRate', () => {
+  test('正常なCV率計算', () => {
+    expect(calcCvRate(10, 100)).toBe(10);
+    expect(calcCvRate(50, 100)).toBe(50);
+  });
+
+  test('分母0でnull', () => {
+    expect(calcCvRate(0, 0)).toBeNull();
+    expect(calcCvRate(10, 0)).toBeNull();
+  });
+});
+
+describe('KPIスコープとの統合', () => {
+  test('0件の場合はCV率がnull（0%ではない）', () => {
+    // prospects.kpiTotal = 0 の場合、CV率は null であるべき
+    const kpiTotal = 0;
+    const decided = 0;
+    const cvRate = kpiTotal === 0 ? null : safeRate(decided, kpiTotal);
+    expect(cvRate).toBeNull();
+  });
+
+  test('internal_no >= 252のみがKPI対象', () => {
+    // 251以下は対象外
+    const KPI_MIN_INTERNAL_NO = 252;
+    expect(251 >= KPI_MIN_INTERNAL_NO).toBe(false);
+    expect(252 >= KPI_MIN_INTERNAL_NO).toBe(true);
+    expect(300 >= KPI_MIN_INTERNAL_NO).toBe(true);
+  });
+});

--- a/src/app/api/sales/metrics/route.ts
+++ b/src/app/api/sales/metrics/route.ts
@@ -1,0 +1,297 @@
+// /api/sales/metrics - 営業メトリクスAPI
+// キャッシュ禁止、エラーハンドリング付き
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
+import { hasMinRole } from '@/lib/auth';
+
+const DEFAULT_TENANT_ID = 'defaultTenant';
+
+// KPI対象の最小internal_no
+const KPI_MIN_INTERNAL_NO = 252;
+
+// キャッシュを完全に無効化
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+interface Warning {
+  label: string;
+  code: string;
+  message: string;
+}
+
+interface SalesMetricsResponse {
+  success: boolean;
+  // salesDeals集計
+  deals: {
+    total: number;
+    active: number;
+    completed: number;
+    lost: number;
+    byStatus: Record<string, number>;
+    bySource: Record<string, { total: number; completed: number }>;
+  };
+  // CV率（分母0はnull）
+  rates: {
+    totalCv: number | null;
+    teleapoCv: number | null;
+    shiryouCv: number | null;
+  };
+  // 入居希望者（prospects）KPI - internal_no >= 252のみ
+  prospects: {
+    total: number;
+    kpiTotal: number; // internal_no >= 252
+    byStatus: Record<string, number>;
+    expectedMoveIns: number;
+    rankDistribution: { A: number; B: number; C: number; D: number };
+  };
+  // パイプライン（LD/V/M）
+  pipeline: {
+    ld: number; // リード（新規受付）
+    v: number;  // 訪問・見学設定済
+    m: number;  // 申込中〜入居待ち
+    cvRate: number | null; // M/LD
+  };
+  // メタ情報
+  updatedAt: string;
+  warnings: Warning[];
+  // デバッグ情報（debug=1時のみ）
+  debug?: {
+    queryScope: string;
+    prospectsQueried: number;
+    prospectsFiltered: number;
+    dealsQueried: number;
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const startTime = Date.now();
+  const warnings: Warning[] = [];
+
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    // ユーザー情報取得
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(decodedToken.uid).get();
+    const userData = userDoc.data();
+    const userRole = userData?.role || 'user';
+
+    // デバッグモード判定（execのみ）
+    const debugMode = request.nextUrl.searchParams.get('debug') === '1' && hasMinRole(userRole, 'admin');
+
+    // ===== salesDeals取得（シンプルなクエリ）=====
+    let dealsData: { total: number; active: number; completed: number; lost: number; byStatus: Record<string, number>; bySource: Record<string, { total: number; completed: number }> } = {
+      total: 0,
+      active: 0,
+      completed: 0,
+      lost: 0,
+      byStatus: {},
+      bySource: {},
+    };
+    let dealsQueried = 0;
+
+    try {
+      const dealsSnap = await db
+        .collection('salesDeals')
+        .where('tenantId', '==', DEFAULT_TENANT_ID)
+        .orderBy('createdAt', 'desc')
+        .limit(1000)
+        .get();
+
+      dealsQueried = dealsSnap.size;
+
+      dealsSnap.docs.forEach((doc) => {
+        const deal = doc.data();
+        const status = deal.status as string;
+        const source = deal.source as string || 'その他';
+
+        dealsData.total++;
+        dealsData.byStatus[status] = (dealsData.byStatus[status] || 0) + 1;
+
+        if (status === '請求書到着') {
+          dealsData.completed++;
+        } else if (status === '失注') {
+          dealsData.lost++;
+        } else {
+          dealsData.active++;
+        }
+
+        // ソース別集計
+        if (!dealsData.bySource[source]) {
+          dealsData.bySource[source] = { total: 0, completed: 0 };
+        }
+        dealsData.bySource[source].total++;
+        if (status === '請求書到着') {
+          dealsData.bySource[source].completed++;
+        }
+      });
+    } catch (err) {
+      warnings.push({
+        label: 'deals',
+        code: 'FETCH_ERROR',
+        message: err instanceof Error ? err.message : 'salesDeals取得エラー',
+      });
+    }
+
+    // ===== prospects取得（internal_no >= 252のみ）=====
+    let prospectsData = {
+      total: 0,
+      kpiTotal: 0,
+      byStatus: {} as Record<string, number>,
+      expectedMoveIns: 0,
+      rankDistribution: { A: 0, B: 0, C: 0, D: 0 },
+    };
+    let pipelineData = {
+      ld: 0,
+      v: 0,
+      m: 0,
+      cvRate: null as number | null,
+    };
+    let prospectsQueried = 0;
+    let prospectsFiltered = 0;
+
+    try {
+      // シンプルなクエリ: tenantIdのみでフィルタ、集計はアプリ側
+      const prospectsSnap = await db
+        .collection('prospects')
+        .where('tenantId', '==', DEFAULT_TENANT_ID)
+        .limit(2000)
+        .get();
+
+      prospectsQueried = prospectsSnap.size;
+
+      prospectsSnap.docs.forEach((doc) => {
+        const prospect = doc.data();
+        const internalNo = prospect.internalNo;
+        const status = prospect.status as string;
+
+        prospectsData.total++;
+
+        // KPIスコープ: internal_no >= 252 のみ
+        const internalNoNum = typeof internalNo === 'number' ? internalNo : parseInt(String(internalNo || ''), 10);
+        const isKpiTarget = !isNaN(internalNoNum) && internalNoNum >= KPI_MIN_INTERNAL_NO;
+
+        if (!isKpiTarget) {
+          return; // このレコードはKPI対象外
+        }
+
+        prospectsFiltered++;
+        prospectsData.kpiTotal++;
+        prospectsData.byStatus[status] = (prospectsData.byStatus[status] || 0) + 1;
+
+        // パイプライン集計（LD/V/M）
+        if (status === '新規受付' || status === '折返し待ち') {
+          pipelineData.ld++;
+        } else if (status === '面談設定済' || status === '見学設定済') {
+          pipelineData.v++;
+        } else if (['申込中', '審査中', '入居待ち'].includes(status)) {
+          pipelineData.m++;
+        }
+
+        // 入居決定をカウント（CV計算用）
+        if (status === '入居決定') {
+          // CVはM→入居決定
+        }
+      });
+
+      // CV率計算（M / LD）
+      const totalFunnel = pipelineData.ld + pipelineData.v + pipelineData.m;
+      if (totalFunnel > 0) {
+        const decided = prospectsData.byStatus['入居決定'] || 0;
+        pipelineData.cvRate = Math.round((decided / totalFunnel) * 100);
+      }
+
+      // ランク分布（簡易版 - スコアリング関数は別途）
+      // 本来はscoringを使うが、ここではステータスベースで簡易集計
+      const activeCount = prospectsData.kpiTotal - (prospectsData.byStatus['クローズ'] || 0) - (prospectsData.byStatus['見送り'] || 0) - (prospectsData.byStatus['入居決定'] || 0);
+      prospectsData.rankDistribution = {
+        A: prospectsData.byStatus['入居待ち'] || 0,
+        B: (prospectsData.byStatus['申込中'] || 0) + (prospectsData.byStatus['審査中'] || 0),
+        C: (prospectsData.byStatus['面談設定済'] || 0) + (prospectsData.byStatus['見学設定済'] || 0),
+        D: (prospectsData.byStatus['新規受付'] || 0) + (prospectsData.byStatus['折返し待ち'] || 0),
+      };
+
+      // 見込み数（簡易版）
+      prospectsData.expectedMoveIns = prospectsData.rankDistribution.A * 0.9 +
+        prospectsData.rankDistribution.B * 0.5 +
+        prospectsData.rankDistribution.C * 0.2 +
+        prospectsData.rankDistribution.D * 0.05;
+      prospectsData.expectedMoveIns = Math.round(prospectsData.expectedMoveIns * 10) / 10;
+
+    } catch (err) {
+      warnings.push({
+        label: 'prospects',
+        code: 'FETCH_ERROR',
+        message: err instanceof Error ? err.message : 'prospects取得エラー',
+      });
+    }
+
+    // ===== CV率計算（safeRate） =====
+    const safeRate = (n: number, d: number): number | null => {
+      if (d === 0) return null;
+      return Math.round((n / d) * 100);
+    };
+
+    const rates = {
+      totalCv: safeRate(dealsData.completed, dealsData.completed + dealsData.lost),
+      teleapoCv: dealsData.bySource['テレアポ']
+        ? safeRate(dealsData.bySource['テレアポ'].completed, dealsData.bySource['テレアポ'].total)
+        : null,
+      shiryouCv: dealsData.bySource['資料送付']
+        ? safeRate(dealsData.bySource['資料送付'].completed, dealsData.bySource['資料送付'].total)
+        : null,
+    };
+
+    // ===== レスポンス構築 =====
+    const response: SalesMetricsResponse = {
+      success: true,
+      deals: dealsData,
+      rates,
+      prospects: prospectsData,
+      pipeline: pipelineData,
+      updatedAt: new Date().toISOString(),
+      warnings,
+    };
+
+    // デバッグ情報
+    if (debugMode) {
+      response.debug = {
+        queryScope: `internal_no >= ${KPI_MIN_INTERNAL_NO}`,
+        prospectsQueried,
+        prospectsFiltered,
+        dealsQueried,
+      };
+    }
+
+    return NextResponse.json(response, {
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+      },
+    });
+
+  } catch (error) {
+    console.error('Sales metrics API error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+        warnings,
+        updatedAt: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -1,17 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { Card, CardContent, Badge, Button } from '@/components/ui';
 import { Loading } from '@/components/Loading';
-import { getSalesDeals, getSalesAccounts, getPipelineSummary } from '@/lib/sales';
+import { getSalesDeals, getSalesAccounts } from '@/lib/sales';
+import { formatPercent } from '@/lib/dashboard/calc';
+import { hasMinRole } from '@/lib/auth';
 import {
   SalesDeal,
   SalesAccount,
-  PipelineSummary,
   SALES_DEAL_STATUS_CONFIG,
   SALES_DEAL_STATUSES,
 } from '@/types/sales';
@@ -27,7 +29,49 @@ import {
   Handshake,
   Home,
   Receipt,
+  RefreshCw,
+  Clock,
+  AlertTriangle,
 } from 'lucide-react';
+
+// メトリクスAPIのレスポンス型
+interface SalesMetrics {
+  success: boolean;
+  deals: {
+    total: number;
+    active: number;
+    completed: number;
+    lost: number;
+    byStatus: Record<string, number>;
+    bySource: Record<string, { total: number; completed: number }>;
+  };
+  rates: {
+    totalCv: number | null;
+    teleapoCv: number | null;
+    shiryouCv: number | null;
+  };
+  prospects: {
+    total: number;
+    kpiTotal: number;
+    byStatus: Record<string, number>;
+    expectedMoveIns: number;
+    rankDistribution: { A: number; B: number; C: number; D: number };
+  };
+  pipeline: {
+    ld: number;
+    v: number;
+    m: number;
+    cvRate: number | null;
+  };
+  updatedAt: string;
+  warnings: { label: string; code: string; message: string }[];
+  debug?: {
+    queryScope: string;
+    prospectsQueried: number;
+    prospectsFiltered: number;
+    dealsQueried: number;
+  };
+}
 
 export default function SalesDashboardPage() {
   return (
@@ -38,31 +82,94 @@ export default function SalesDashboardPage() {
 }
 
 function SalesDashboardContent() {
-  const { user } = useAuth();
+  const { user, firebaseUser } = useAuth();
+  const searchParams = useSearchParams();
+  const debugMode = searchParams.get('debug') === '1';
+
   const [accounts, setAccounts] = useState<SalesAccount[]>([]);
   const [deals, setDeals] = useState<SalesDeal[]>([]);
-  const [pipeline, setPipeline] = useState<PipelineSummary[]>([]);
+  const [metrics, setMetrics] = useState<SalesMetrics | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const [accountsData, dealsData, pipelineData] = await Promise.all([
-          getSalesAccounts(),
-          getSalesDeals(),
-          getPipelineSummary(),
-        ]);
-        setAccounts(accountsData);
-        setDeals(dealsData);
-        setPipeline(pipelineData);
-      } catch (error) {
-        console.error('Failed to fetch data:', error);
-      } finally {
-        setLoading(false);
+  const isExec = hasMinRole(user?.role, 'admin');
+
+  // メトリクスAPIからデータ取得
+  const fetchMetrics = useCallback(async (isManualRefresh = false) => {
+    if (!firebaseUser) return;
+
+    if (isManualRefresh) {
+      setRefreshing(true);
+    }
+    setFetchError(null);
+
+    try {
+      const token = await firebaseUser.getIdToken();
+      const debugParam = debugMode && isExec ? '&debug=1' : '';
+      const res = await fetch(`/api/sales/metrics?_=${Date.now()}${debugParam}`, {
+        cache: 'no-store',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error(`API error: ${res.status}`);
       }
-    };
-    fetchData();
+
+      const data = await res.json();
+      if (data.success) {
+        setMetrics(data);
+        setLastUpdated(new Date());
+      } else {
+        throw new Error(data.error || 'データ取得に失敗しました');
+      }
+    } catch (error) {
+      console.error('Failed to fetch metrics:', error);
+      setFetchError(error instanceof Error ? error.message : 'データ取得に失敗しました');
+    } finally {
+      setRefreshing(false);
+    }
+  }, [firebaseUser, debugMode, isExec]);
+
+  // ローカルデータ取得（案件詳細用）
+  const fetchLocalData = useCallback(async () => {
+    try {
+      const [accountsData, dealsData] = await Promise.all([
+        getSalesAccounts(),
+        getSalesDeals(),
+      ]);
+      setAccounts(accountsData);
+      setDeals(dealsData);
+    } catch (error) {
+      console.error('Failed to fetch local data:', error);
+    }
   }, []);
+
+  // 初回ロード
+  useEffect(() => {
+    const init = async () => {
+      await Promise.all([fetchMetrics(), fetchLocalData()]);
+      setLoading(false);
+    };
+    init();
+  }, [fetchMetrics, fetchLocalData]);
+
+  // 60秒ごとの自動更新
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchMetrics();
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [fetchMetrics]);
+
+  // 手動更新
+  const handleRefresh = () => {
+    fetchMetrics(true);
+    fetchLocalData();
+  };
 
   if (loading) {
     return (
@@ -73,37 +180,11 @@ function SalesDashboardContent() {
     );
   }
 
-  const activeDeals = deals.filter((d) => !['請求書到着', '失注'].includes(d.status));
-  const completedDeals = deals.filter((d) => d.status === '請求書到着');
-  const lostDeals = deals.filter((d) => d.status === '失注');
   const myDeals = deals.filter((d) => d.assignedToId === user?.id);
-
-  // CV率計算（流入元別）
-  const teleapoDeals = deals.filter((d) => d.source === 'テレアポ');
-  const teleapoCompleted = teleapoDeals.filter((d) => d.status === '請求書到着');
-  const teleapoCvRate = teleapoDeals.length > 0
-    ? Math.round((teleapoCompleted.length / teleapoDeals.length) * 100)
-    : 0;
-
-  const shiryouDeals = deals.filter((d) => d.source === '資料送付');
-  const shiryouCompleted = shiryouDeals.filter((d) => d.status === '請求書到着');
-  const shiryouCvRate = shiryouDeals.length > 0
-    ? Math.round((shiryouCompleted.length / shiryouDeals.length) * 100)
-    : 0;
-
-  // 全体CV率
-  const totalCvRate = deals.length > 0
-    ? Math.round((completedDeals.length / (completedDeals.length + lostDeals.length || 1)) * 100)
-    : 0;
-
-  // 停滞案件（7日以上更新なし）
   const now = new Date();
 
-  // フォローアップ必要な案件（次回フォローアップ日が過ぎている or 未設定）
-  const needsFollowUp = activeDeals.filter((deal) => {
-    if (!deal.nextFollowUpDate) return true;
-    return new Date(deal.nextFollowUpDate) <= now;
-  });
+  // 停滞案件（7日以上更新なし）
+  const activeDeals = deals.filter((d) => !['請求書到着', '失注'].includes(d.status));
   const staleDeals = activeDeals.filter((deal) => {
     const lastActivity = deal.updatedAt || deal.createdAt;
     const daysSince = Math.floor((now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60 * 24));
@@ -131,14 +212,60 @@ function SalesDashboardContent() {
     }
   };
 
+  // 安全な表示（null → '--'）
+  const displayRate = (rate: number | null | undefined): string => {
+    if (rate === null || rate === undefined) return '--';
+    return `${rate}%`;
+  };
+
+  const displayCount = (count: number | null | undefined): string => {
+    if (count === null || count === undefined) return '--';
+    return count.toString();
+  };
+
   return (
     <>
       <Header />
       <main className="pb-8">
         <div className="max-w-6xl mx-auto px-4 py-6">
+          {/* エラーバナー */}
+          {fetchError && (
+            <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center justify-between">
+              <div className="flex items-center gap-2 text-red-700">
+                <AlertTriangle className="w-5 h-5" />
+                <span>データ取得に失敗しました: {fetchError}</span>
+              </div>
+              <Button variant="outline" size="sm" onClick={handleRefresh} disabled={refreshing}>
+                {refreshing ? <RefreshCw className="w-4 h-4 animate-spin" /> : '再試行'}
+              </Button>
+            </div>
+          )}
+
+          {/* 警告バナー */}
+          {metrics?.warnings && metrics.warnings.length > 0 && (
+            <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+              <div className="flex items-center gap-2 text-yellow-700 text-sm">
+                <AlertCircle className="w-4 h-4" />
+                <span>一部のデータ取得で問題が発生しました</span>
+              </div>
+            </div>
+          )}
+
           <div className="flex items-center justify-between mb-6">
-            <h1 className="text-2xl font-bold text-gray-900">営業進捗管理</h1>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">営業進捗管理</h1>
+              {lastUpdated && (
+                <p className="text-xs text-gray-400 flex items-center gap-1 mt-1">
+                  <Clock className="w-3 h-3" />
+                  最終更新: {lastUpdated.toLocaleTimeString('ja-JP')}
+                  {refreshing && <RefreshCw className="w-3 h-3 animate-spin ml-1" />}
+                </p>
+              )}
+            </div>
             <div className="flex gap-2">
+              <Button variant="ghost" size="sm" onClick={handleRefresh} disabled={refreshing}>
+                <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+              </Button>
               <Link href="/sales/accounts">
                 <Button variant="outline" size="sm">
                   <Building2 className="w-4 h-4 mr-1" />
@@ -173,7 +300,7 @@ function SalesDashboardContent() {
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm text-gray-500">進行中案件</p>
-                    <p className="text-2xl font-bold">{activeDeals.length}</p>
+                    <p className="text-2xl font-bold">{displayCount(metrics?.deals.active)}</p>
                   </div>
                   <TrendingUp className="w-8 h-8 text-green-500" />
                 </div>
@@ -185,7 +312,7 @@ function SalesDashboardContent() {
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm text-gray-500">成約</p>
-                    <p className="text-2xl font-bold">{completedDeals.length}</p>
+                    <p className="text-2xl font-bold">{displayCount(metrics?.deals.completed)}</p>
                   </div>
                   <Receipt className="w-8 h-8 text-purple-500" />
                 </div>
@@ -205,6 +332,56 @@ function SalesDashboardContent() {
             </Card>
           </div>
 
+          {/* 入居希望パイプライン（KPI） */}
+          {metrics?.prospects && (
+            <Card className="mb-6 border-indigo-200 bg-gradient-to-r from-indigo-50 to-purple-50">
+              <CardContent>
+                <h2 className="font-semibold text-gray-900 mb-4 flex items-center">
+                  <Users className="w-5 h-5 mr-2 text-indigo-600" />
+                  入居希望パイプライン
+                  <span className="text-xs text-gray-400 ml-2">（No.252以上のみ）</span>
+                </h2>
+                <div className="grid grid-cols-4 gap-4">
+                  <div className="text-center p-4 bg-white rounded-xl shadow-sm">
+                    <p className="text-sm text-gray-500 mb-1">LD（リード）</p>
+                    <p className="text-3xl font-bold text-blue-600">{displayCount(metrics.pipeline.ld)}</p>
+                    <p className="text-xs text-gray-400">新規受付・折返し</p>
+                  </div>
+                  <div className="text-center p-4 bg-white rounded-xl shadow-sm">
+                    <p className="text-sm text-gray-500 mb-1">V（訪問）</p>
+                    <p className="text-3xl font-bold text-green-600">{displayCount(metrics.pipeline.v)}</p>
+                    <p className="text-xs text-gray-400">面談・見学設定</p>
+                  </div>
+                  <div className="text-center p-4 bg-white rounded-xl shadow-sm">
+                    <p className="text-sm text-gray-500 mb-1">M（申込）</p>
+                    <p className="text-3xl font-bold text-purple-600">{displayCount(metrics.pipeline.m)}</p>
+                    <p className="text-xs text-gray-400">申込〜入居待ち</p>
+                  </div>
+                  <div className="text-center p-4 bg-white rounded-xl shadow-sm">
+                    <p className="text-sm text-gray-500 mb-1">CV率</p>
+                    <p className="text-3xl font-bold text-orange-600">{displayRate(metrics.pipeline.cvRate)}</p>
+                    <p className="text-xs text-gray-400">入居決定/全体</p>
+                  </div>
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-4">
+                  <div className="p-3 bg-white rounded-lg">
+                    <p className="text-sm text-gray-500">入居見込み</p>
+                    <p className="text-xl font-bold text-green-600">{metrics.prospects.expectedMoveIns}</p>
+                  </div>
+                  <div className="p-3 bg-white rounded-lg">
+                    <p className="text-sm text-gray-500">ランク分布</p>
+                    <div className="flex gap-2 text-sm">
+                      <span className="text-red-600">A:{metrics.prospects.rankDistribution.A}</span>
+                      <span className="text-orange-600">B:{metrics.prospects.rankDistribution.B}</span>
+                      <span className="text-yellow-600">C:{metrics.prospects.rankDistribution.C}</span>
+                      <span className="text-gray-600">D:{metrics.prospects.rankDistribution.D}</span>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           {/* CV率（成約率）- 電話の大事さを強調 */}
           <Card className="mb-6 border-blue-200 bg-gradient-to-r from-blue-50 to-indigo-50">
             <CardContent>
@@ -218,9 +395,11 @@ function SalesDashboardContent() {
                     <Phone className="w-6 h-6 text-blue-600 mr-2" />
                     <span className="text-sm font-medium text-gray-700">テレアポ</span>
                   </div>
-                  <p className="text-3xl font-bold text-blue-600">{teleapoCvRate}%</p>
+                  <p className="text-3xl font-bold text-blue-600">{displayRate(metrics?.rates.teleapoCv)}</p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {teleapoCompleted.length} / {teleapoDeals.length} 件
+                    {metrics?.deals.bySource['テレアポ']
+                      ? `${metrics.deals.bySource['テレアポ'].completed} / ${metrics.deals.bySource['テレアポ'].total} 件`
+                      : '--'}
                   </p>
                 </div>
                 <div className="text-center p-4 bg-white rounded-xl shadow-sm">
@@ -228,9 +407,11 @@ function SalesDashboardContent() {
                     <FileText className="w-6 h-6 text-gray-500 mr-2" />
                     <span className="text-sm font-medium text-gray-700">資料送付</span>
                   </div>
-                  <p className="text-3xl font-bold text-gray-600">{shiryouCvRate}%</p>
+                  <p className="text-3xl font-bold text-gray-600">{displayRate(metrics?.rates.shiryouCv)}</p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {shiryouCompleted.length} / {shiryouDeals.length} 件
+                    {metrics?.deals.bySource['資料送付']
+                      ? `${metrics.deals.bySource['資料送付'].completed} / ${metrics.deals.bySource['資料送付'].total} 件`
+                      : '--'}
                   </p>
                 </div>
                 <div className="text-center p-4 bg-white rounded-xl shadow-sm">
@@ -238,31 +419,36 @@ function SalesDashboardContent() {
                     <TrendingUp className="w-6 h-6 text-green-500 mr-2" />
                     <span className="text-sm font-medium text-gray-700">全体</span>
                   </div>
-                  <p className="text-3xl font-bold text-green-600">{totalCvRate}%</p>
+                  <p className="text-3xl font-bold text-green-600">{displayRate(metrics?.rates.totalCv)}</p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {completedDeals.length} 件成約
+                    {displayCount(metrics?.deals.completed)} 件成約
                   </p>
                 </div>
               </div>
-              {teleapoCvRate > shiryouCvRate && teleapoDeals.length >= 3 && (
-                <div className="mt-4 p-3 bg-blue-100 rounded-lg">
-                  <p className="text-sm text-blue-800 font-medium flex items-center">
-                    <Phone className="w-4 h-4 mr-2" />
-                    テレアポは資料送付より成約率が{teleapoCvRate - shiryouCvRate}%高い！電話でのアプローチを強化しましょう。
-                  </p>
-                </div>
-              )}
+              {metrics?.rates.teleapoCv !== null &&
+                metrics?.rates.shiryouCv !== null &&
+                metrics?.rates.teleapoCv !== undefined &&
+                metrics?.rates.shiryouCv !== undefined &&
+                metrics.rates.teleapoCv > metrics.rates.shiryouCv &&
+                (metrics.deals.bySource['テレアポ']?.total || 0) >= 3 && (
+                  <div className="mt-4 p-3 bg-blue-100 rounded-lg">
+                    <p className="text-sm text-blue-800 font-medium flex items-center">
+                      <Phone className="w-4 h-4 mr-2" />
+                      テレアポは資料送付より成約率が{metrics.rates.teleapoCv - metrics.rates.shiryouCv}%高い！電話でのアプローチを強化しましょう。
+                    </p>
+                  </div>
+                )}
             </CardContent>
           </Card>
 
-          {/* パイプライン */}
+          {/* パイプライン（salesDeals） */}
           <Card className="mb-6">
             <CardContent>
-              <h2 className="font-semibold text-gray-900 mb-4">パイプライン</h2>
+              <h2 className="font-semibold text-gray-900 mb-4">案件パイプライン</h2>
               <div className="grid grid-cols-4 md:grid-cols-8 gap-2">
                 {SALES_DEAL_STATUSES.map((status) => {
                   const config = SALES_DEAL_STATUS_CONFIG[status];
-                  const count = pipeline.find((p) => p.status === status)?.count || 0;
+                  const count = metrics?.deals.byStatus[status] || 0;
                   return (
                     <Link
                       key={status}
@@ -367,6 +553,46 @@ function SalesDashboardContent() {
               </CardContent>
             </Card>
           </div>
+
+          {/* デバッグ情報（exec + debug=1 のみ） */}
+          {debugMode && isExec && metrics?.debug && (
+            <Card className="mt-6 border-gray-300 bg-gray-50">
+              <CardContent>
+                <h2 className="font-semibold text-gray-700 mb-3 flex items-center">
+                  <AlertCircle className="w-4 h-4 mr-2" />
+                  デバッグ情報
+                </h2>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <p className="text-gray-500">スコープ</p>
+                    <p className="font-mono">{metrics.debug.queryScope}</p>
+                  </div>
+                  <div>
+                    <p className="text-gray-500">prospects取得数</p>
+                    <p className="font-mono">{metrics.debug.prospectsQueried}</p>
+                  </div>
+                  <div>
+                    <p className="text-gray-500">KPI対象数</p>
+                    <p className="font-mono">{metrics.debug.prospectsFiltered}</p>
+                  </div>
+                  <div>
+                    <p className="text-gray-500">deals取得数</p>
+                    <p className="font-mono">{metrics.debug.dealsQueried}</p>
+                  </div>
+                </div>
+                {metrics.warnings.length > 0 && (
+                  <div className="mt-3 pt-3 border-t">
+                    <p className="text-gray-500 mb-1">Warnings:</p>
+                    <ul className="text-xs text-red-600 space-y-1">
+                      {metrics.warnings.map((w, i) => (
+                        <li key={i}>[{w.label}] {w.code}: {w.message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
         </div>
       </main>
     </>


### PR DESCRIPTION
## 変更内容

### 1. /api/sales/metrics API追加
- salesDeals集計（パイプライン、CV率）
- prospects KPI集計（internal_no >= 252のみ）
- cache: no-store でキャッシュ無効化
- エラー時はwarnings配列で返却
- debug=1でデバッグ情報表示（admin only）

### 2. /sales ページ更新
- API駆動に変更（直接Firestore → API経由）
- 60秒自動更新 + 手動更新ボタン
- 最終更新時刻表示
- 分母0/取得失敗 → '--' 表示（0や100で誤認させない）
- エラーバナー + 再試行UI
- 入居希望パイプライン（LD/V/M/CV率）追加
- debug=1でデバッグ情報表示

### 3. safeRate/formatPercent
- 既存の dashboard/calc.ts を活用
- テスト追加

## 受け入れ基準
- [x] /sales の数字が新規データ取り込みに応じて増減
- [x] 取得失敗時に0や100で誤認させず、-- と再試行が出る
- [x] internal_no未設定でも自動付番されKPIに入る（前コミット）
- [x] キャッシュで固定化されず、60秒間隔で更新

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
