### PR TITLE
fix: 管理メニューの稟議管理リンクを正規URLに変更

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -55,7 +55,7 @@ export function Header() {
   const adminItems = [
     { href: '/admin/incidents', label: '報告管理', icon: BarChart3 },
     { href: '/admin/attendance/dashboard', label: '勤怠管理', icon: Clock },
-    { href: '/admin/ringi', label: '稟議承認', icon: ClipboardList },
+    { href: '/dashboard/admin/ringi', label: '稟議管理', icon: ClipboardList },
     { href: '/admin/improvements', label: '改善管理', icon: Lightbulb },
     { href: '/admin/insights', label: '連携提案', icon: Megaphone },
     { href: '/admin/points', label: 'ポイント', icon: Star },


### PR DESCRIPTION
- /admin/ringi → /dashboard/admin/ringi（直接リンク）
- リダイレクトホップを回避
- ラベルを「稟議承認」→「稟議管理」に変更

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
