### PR TITLE
fix: 承認経路Firestore indexエラー解消 + 初期テンプレ自動作成

### DIFF
--- a/__tests__/approval-routes.test.ts
+++ b/__tests__/approval-routes.test.ts
@@ -251,3 +251,108 @@ describe('RingiApprovalRouteStep', () => {
     expect(step.required).toBe(false);
   });
 });
+
+// ======== 初期テンプレート関連テスト ========
+
+describe('初期テンプレート設計', () => {
+  // テンプレート定義（lib/approval-routes.ts の seedApprovalRouteTemplates と同等）
+  const SEED_TEMPLATES = [
+    {
+      name: '通常稟議',
+      description: '一般的な稟議（デフォルト経路）',
+      category: null,
+      branchId: null,
+      minAmount: null,
+      maxAmount: null,
+      isActive: true,
+      isDefault: true,
+      priority: 100,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+    {
+      name: '高額稟議',
+      description: '50万円以上の高額稟議',
+      category: null,
+      branchId: null,
+      minAmount: 500000,
+      maxAmount: null,
+      isActive: true,
+      isDefault: false,
+      priority: 10,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+    {
+      name: '人事稟議',
+      description: '人事関連の稟議（経営層のみ）',
+      category: '人事関連',
+      branchId: null,
+      minAmount: null,
+      maxAmount: null,
+      isActive: true,
+      isDefault: false,
+      priority: 5,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+  ];
+
+  test('テンプレートは3つ', () => {
+    expect(SEED_TEMPLATES.length).toBe(3);
+  });
+
+  test('デフォルト経路は1つだけ', () => {
+    const defaults = SEED_TEMPLATES.filter(t => t.isDefault);
+    expect(defaults.length).toBe(1);
+    expect(defaults[0].name).toBe('通常稟議');
+  });
+
+  test('高額稟議は50万円以上が条件', () => {
+    const highAmount = SEED_TEMPLATES.find(t => t.name === '高額稟議');
+    expect(highAmount).toBeDefined();
+    expect(highAmount!.minAmount).toBe(500000);
+    expect(highAmount!.maxAmount).toBeNull();
+  });
+
+  test('人事稟議はカテゴリ条件付き', () => {
+    const hr = SEED_TEMPLATES.find(t => t.name === '人事稟議');
+    expect(hr).toBeDefined();
+    expect(hr!.category).toBe('人事関連');
+    expect(hr!.steps.length).toBe(1);
+    expect(hr!.steps[0].approverValue).toBe('exec');
+  });
+
+  test('通常稟議は2段階承認', () => {
+    const normal = SEED_TEMPLATES.find(t => t.name === '通常稟議');
+    expect(normal).toBeDefined();
+    expect(normal!.steps.length).toBe(2);
+    expect(normal!.steps[0].approverValue).toBe('manager');
+    expect(normal!.steps[1].approverValue).toBe('exec');
+  });
+
+  test('優先度順: 人事(5) < 高額(10) < 通常(100)', () => {
+    const sorted = [...SEED_TEMPLATES].sort((a, b) => a.priority - b.priority);
+    expect(sorted[0].name).toBe('人事稟議');
+    expect(sorted[1].name).toBe('高額稟議');
+    expect(sorted[2].name).toBe('通常稟議');
+  });
+
+  test('全テンプレートがアクティブ', () => {
+    const inactive = SEED_TEMPLATES.filter(t => !t.isActive);
+    expect(inactive.length).toBe(0);
+  });
+
+  test('全ステップが必須', () => {
+    for (const template of SEED_TEMPLATES) {
+      for (const step of template.steps) {
+        expect(step.required).toBe(true);
+      }
+    }
+  });
+});

--- a/src/app/api/admin/approval-routes/seed/route.ts
+++ b/src/app/api/admin/approval-routes/seed/route.ts
@@ -1,0 +1,70 @@
+// /api/admin/approval-routes/seed - 承認経路初期テンプレ作成API
+// 0件の場合のみ実行、二重作成防止
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
+import { hasMinRole } from '@/lib/auth';
+import { seedApprovalRouteTemplates } from '@/lib/approval-routes';
+
+const DEFAULT_TENANT_ID = 'defaultTenant';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+/**
+ * POST: 初期承認経路テンプレを作成
+ * - approval_routes が 0件のときのみ実行
+ * - 二重作成防止
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    // ユーザー情報取得
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(decodedToken.uid).get();
+    const userData = userDoc.data();
+    const userRole = userData?.role || 'user';
+
+    // admin権限チェック
+    if (!hasMinRole(userRole, 'admin')) {
+      return NextResponse.json(
+        { error: '管理者権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const tenantId = userData?.tenantId || DEFAULT_TENANT_ID;
+
+    // 初期テンプレを作成
+    const result = await seedApprovalRouteTemplates(
+      tenantId,
+      decodedToken.uid,
+      userData?.name || 'Unknown'
+    );
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    console.error('Seed approval routes API error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/admin/ringi/page.tsx
+++ b/src/app/dashboard/admin/ringi/page.tsx
@@ -75,8 +75,10 @@ function AdminRingiContent() {
   // 承認経路用ローディング・エラー
   const [routesLoading, setRoutesLoading] = useState(true);
   const [routesError, setRoutesError] = useState<string | null>(null);
+  const [routesFetched, setRoutesFetched] = useState(false); // 取得完了フラグ
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [seeding, setSeeding] = useState(false);
 
   // 稟議却下モーダル
   const [rejectModal, setRejectModal] = useState<{ ringiId: string; title: string } | null>(null);
@@ -159,13 +161,49 @@ function AdminRingiContent() {
       }));
 
       setRoutes(routesWithDates);
+      setRoutesFetched(true);
+      setRoutesError(null);
     } catch (err) {
       console.error('Failed to load routes:', err);
       setRoutesError(err instanceof Error ? err.message : '承認経路の取得に失敗しました');
+      setRoutesFetched(false);
     } finally {
       setRoutesLoading(false);
     }
   }, [firebaseUser]);
+
+  // 初期テンプレ作成
+  const seedTemplates = async () => {
+    if (!firebaseUser) return;
+    setSeeding(true);
+    try {
+      const token = await firebaseUser.getIdToken();
+      const res = await fetch('/api/admin/approval-routes/seed', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || '作成に失敗しました');
+      }
+
+      if (data.seeded) {
+        // 作成成功 → リロード
+        await loadRoutes(false);
+      } else {
+        // 既に存在する場合
+        alert(data.message);
+      }
+    } catch (err) {
+      console.error('Failed to seed templates:', err);
+      alert(err instanceof Error ? err.message : '作成に失敗しました');
+    } finally {
+      setSeeding(false);
+    }
+  };
 
   useEffect(() => {
     if (activeTab === 'pending' || activeTab === 'all') {
@@ -526,8 +564,8 @@ function AdminRingiContent() {
                 </div>
               </div>
 
-              {/* 経路エラー表示 */}
-              {routesError && (
+              {/* エラー表示（取得失敗時のみ） */}
+              {routesError && !routesFetched && (
                 <ErrorBanner
                   message={routesError}
                   onRetry={() => loadRoutes()}
@@ -536,17 +574,37 @@ function AdminRingiContent() {
               )}
 
               {/* ローディング */}
-              {routesLoading && routes.length === 0 ? (
+              {routesLoading && routes.length === 0 && !routesFetched ? (
                 <div className="flex items-center justify-center py-12">
                   <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
                 </div>
-              ) : routes.length === 0 ? (
+              ) : routesFetched && routes.length === 0 ? (
+                // 取得成功 & 0件の場合
                 <Card className="p-8 text-center">
                   <Route className="w-12 h-12 text-zinc-300 mx-auto mb-3" />
-                  <p className="text-zinc-500">承認経路がありません</p>
-                  <p className="text-xs text-zinc-400 mt-1">新規作成ボタンから追加してください</p>
+                  <p className="text-zinc-500 mb-2">承認経路がありません</p>
+                  <p className="text-xs text-zinc-400 mb-4">
+                    初期テンプレートを作成するか、新規作成ボタンから追加してください
+                  </p>
+                  <Button
+                    onClick={seedTemplates}
+                    disabled={seeding}
+                    className="mx-auto"
+                  >
+                    {seeding ? (
+                      <>
+                        <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                        作成中...
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="w-4 h-4 mr-2" />
+                        初期テンプレートを作成
+                      </>
+                    )}
+                  </Button>
                 </Card>
-              ) : (
+              ) : routes.length > 0 ? (
                 <div className="space-y-3">
                   {routes.map((route) => (
                     <Card
@@ -623,7 +681,7 @@ function AdminRingiContent() {
                     </Card>
                   ))}
                 </div>
-              )}
+              ) : null}
             </div>
 
             {/* 右: 経路編集 */}

--- a/src/lib/approval-routes.ts
+++ b/src/lib/approval-routes.ts
@@ -1,8 +1,9 @@
 // ======== 承認経路モジュール ========
 // Firestore Admin SDK使用（サーバーサイド専用）
+// index不要：クエリはシンプルに、フィルタ/ソートはJS側で実施
 
 import { getAdminDb } from './firebase-admin';
-import { Timestamp, FieldValue } from 'firebase-admin/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 import {
   RingiApprovalRoute,
   RingiApprovalRouteStep,
@@ -15,45 +16,48 @@ const DEFAULT_TENANT_ID = 'defaultTenant';
 // ======== 承認経路 CRUD ========
 
 /**
- * 全承認経路を取得
+ * 全承認経路を取得（index不要版）
+ * - tenantIdでフィルタはJS側
+ * - priorityでソートもJS側
  */
 export async function getApprovalRoutes(
   tenantId: string = DEFAULT_TENANT_ID
 ): Promise<RingiApprovalRoute[]> {
   const db = getAdminDb();
 
-  const routesSnap = await db
-    .collection('approval_routes')
-    .where('tenantId', '==', tenantId)
-    .orderBy('priority', 'asc')
-    .get();
+  // シンプルなクエリ（index不要）
+  const routesSnap = await db.collection('approval_routes').get();
 
   const routes: RingiApprovalRoute[] = [];
 
   for (const doc of routesSnap.docs) {
     const data = doc.data();
 
-    // ステップを取得
+    // JS側でtenantIdフィルタ
+    if (data.tenantId !== tenantId) continue;
+
+    // ステップを取得（index不要：シンプルget + JS sort）
     const stepsSnap = await db
       .collection('approval_routes')
       .doc(doc.id)
       .collection('steps')
-      .orderBy('stepOrder', 'asc')
       .get();
 
-    const steps: RingiApprovalRouteStep[] = stepsSnap.docs.map(stepDoc => {
-      const stepData = stepDoc.data();
-      return {
-        id: stepDoc.id,
-        routeId: doc.id,
-        stepOrder: stepData.stepOrder,
-        approverType: stepData.approverType,
-        approverValue: stepData.approverValue,
-        approverName: stepData.approverName,
-        required: stepData.required !== false,
-        createdAt: stepData.createdAt?.toDate() || new Date(),
-      };
-    });
+    const steps: RingiApprovalRouteStep[] = stepsSnap.docs
+      .map(stepDoc => {
+        const stepData = stepDoc.data();
+        return {
+          id: stepDoc.id,
+          routeId: doc.id,
+          stepOrder: stepData.stepOrder,
+          approverType: stepData.approverType,
+          approverValue: stepData.approverValue,
+          approverName: stepData.approverName,
+          required: stepData.required !== false,
+          createdAt: stepData.createdAt?.toDate() || new Date(),
+        };
+      })
+      .sort((a, b) => a.stepOrder - b.stepOrder); // JS側でソート
 
     routes.push({
       id: doc.id,
@@ -76,6 +80,9 @@ export async function getApprovalRoutes(
     });
   }
 
+  // JS側でpriorityソート
+  routes.sort((a, b) => a.priority - b.priority);
+
   return routes;
 }
 
@@ -92,27 +99,28 @@ export async function getApprovalRoute(
 
   const data = doc.data()!;
 
-  // ステップを取得
+  // ステップを取得（index不要：シンプルget + JS sort）
   const stepsSnap = await db
     .collection('approval_routes')
     .doc(routeId)
     .collection('steps')
-    .orderBy('stepOrder', 'asc')
     .get();
 
-  const steps: RingiApprovalRouteStep[] = stepsSnap.docs.map(stepDoc => {
-    const stepData = stepDoc.data();
-    return {
-      id: stepDoc.id,
-      routeId: routeId,
-      stepOrder: stepData.stepOrder,
-      approverType: stepData.approverType,
-      approverValue: stepData.approverValue,
-      approverName: stepData.approverName,
-      required: stepData.required !== false,
-      createdAt: stepData.createdAt?.toDate() || new Date(),
-    };
-  });
+  const steps: RingiApprovalRouteStep[] = stepsSnap.docs
+    .map(stepDoc => {
+      const stepData = stepDoc.data();
+      return {
+        id: stepDoc.id,
+        routeId: routeId,
+        stepOrder: stepData.stepOrder,
+        approverType: stepData.approverType,
+        approverValue: stepData.approverValue,
+        approverName: stepData.approverName,
+        required: stepData.required !== false,
+        createdAt: stepData.createdAt?.toDate() || new Date(),
+      };
+    })
+    .sort((a, b) => a.stepOrder - b.stepOrder); // JS側でソート
 
   return {
     id: doc.id,
@@ -344,7 +352,7 @@ export async function deleteApprovalRoute(routeId: string): Promise<void> {
 }
 
 /**
- * 承認経路をデフォルトに設定
+ * 承認経路をデフォルトに設定（index不要版）
  */
 export async function setDefaultApprovalRoute(
   routeId: string,
@@ -352,16 +360,15 @@ export async function setDefaultApprovalRoute(
 ): Promise<void> {
   const db = getAdminDb();
 
-  // 既存のデフォルトを解除
-  const existingDefaults = await db
-    .collection('approval_routes')
-    .where('tenantId', '==', tenantId)
-    .where('isDefault', '==', true)
-    .get();
+  // 既存のデフォルトを解除（index不要：全件取得してJS側でフィルタ）
+  const allRoutes = await db.collection('approval_routes').get();
 
   const batch = db.batch();
-  existingDefaults.docs.forEach(doc => {
-    batch.update(doc.ref, { isDefault: false, updatedAt: Timestamp.now() });
+  allRoutes.docs.forEach(doc => {
+    const data = doc.data();
+    if (data.tenantId === tenantId && data.isDefault === true) {
+      batch.update(doc.ref, { isDefault: false, updatedAt: Timestamp.now() });
+    }
   });
 
   // 新しいデフォルトを設定
@@ -418,4 +425,154 @@ export async function findMatchingApprovalRoute(
   // デフォルト経路を返す
   const defaultRoute = activeRoutes.find(r => r.isDefault);
   return defaultRoute || null;
+}
+
+// ======== 初期テンプレ作成 ========
+
+/**
+ * 初期承認経路テンプレを作成
+ * approval_routes が 0件のときのみ実行
+ *
+ * 作成する経路:
+ * 1. 通常稟議: manager → exec（デフォルト）
+ * 2. 高額稟議: manager → exec（50万円以上）
+ * 3. 人事稟議: execのみ（人事関連カテゴリ）
+ */
+export interface SeedResult {
+  seeded: boolean;
+  message: string;
+  routesCreated: number;
+  routeIds: string[];
+}
+
+export async function seedApprovalRouteTemplates(
+  tenantId: string = DEFAULT_TENANT_ID,
+  performedBy: string = 'system',
+  performedByName: string = 'システム'
+): Promise<SeedResult> {
+  const db = getAdminDb();
+
+  // 既存の経路数を確認
+  const existingRoutes = await getApprovalRoutes(tenantId);
+  if (existingRoutes.length > 0) {
+    return {
+      seeded: false,
+      message: `既に${existingRoutes.length}件の承認経路が存在します`,
+      routesCreated: 0,
+      routeIds: [],
+    };
+  }
+
+  const now = Timestamp.now();
+  const routeIds: string[] = [];
+
+  // テンプレート定義
+  const templates = [
+    {
+      name: '通常稟議',
+      description: '一般的な稟議（デフォルト経路）',
+      category: null,
+      branchId: null,
+      minAmount: null,
+      maxAmount: null,
+      isActive: true,
+      isDefault: true,
+      priority: 100,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+    {
+      name: '高額稟議',
+      description: '50万円以上の高額稟議',
+      category: null,
+      branchId: null,
+      minAmount: 500000,
+      maxAmount: null,
+      isActive: true,
+      isDefault: false,
+      priority: 10, // 高優先度（先にマッチ）
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+    {
+      name: '人事稟議',
+      description: '人事関連の稟議（経営層のみ）',
+      category: '人事関連' as RingiCategory,
+      branchId: null,
+      minAmount: null,
+      maxAmount: null,
+      isActive: true,
+      isDefault: false,
+      priority: 5, // 最高優先度
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+  ];
+
+  // 経路を作成
+  for (const template of templates) {
+    const routeRef = db.collection('approval_routes').doc();
+    const routeData = {
+      tenantId,
+      name: template.name,
+      description: template.description,
+      category: template.category,
+      branchId: template.branchId,
+      minAmount: template.minAmount,
+      maxAmount: template.maxAmount,
+      isActive: template.isActive,
+      isDefault: template.isDefault,
+      priority: template.priority,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: performedBy,
+      createdByName: performedByName,
+    };
+
+    await routeRef.set(routeData);
+
+    // ステップを作成
+    const batch = db.batch();
+    for (let i = 0; i < template.steps.length; i++) {
+      const step = template.steps[i];
+      const stepRef = routeRef.collection('steps').doc();
+      batch.set(stepRef, {
+        stepOrder: i + 1,
+        approverType: step.approverType,
+        approverValue: step.approverValue,
+        required: step.required,
+        createdAt: now,
+      });
+    }
+    await batch.commit();
+
+    routeIds.push(routeRef.id);
+  }
+
+  // 監査ログを記録
+  await db.collection('auditLogs').add({
+    tenantId,
+    action: 'seed_approval_routes',
+    resourceType: 'approval_routes',
+    resourceIds: routeIds,
+    performedBy,
+    performedByName,
+    details: {
+      templatesCreated: templates.map(t => t.name),
+      routeCount: templates.length,
+    },
+    createdAt: now,
+  });
+
+  return {
+    seeded: true,
+    message: `${templates.length}件の承認経路テンプレを作成しました`,
+    routesCreated: templates.length,
+    routeIds,
+  };
 }


### PR DESCRIPTION
### index不要化
- getApprovalRoutes: 全件取得 + JS側でtenantIdフィルタ/priorityソート
- setDefaultApprovalRoute: 全件取得 + JS側でフィルタ
- steps: 全件取得 + JS側でstepOrderソート

### 初期テンプレAPI
- POST /api/admin/approval-routes/seed
- 0件の場合のみ実行（二重作成防止）
- 3テンプレ作成: 通常稟議/高額稟議/人事稟議
- auditLogs記録

### UI改善
- 取得失敗と0件表示を分離
- 0件時に「初期テンプレートを作成」ボタン表示

### テスト
- 初期テンプレ設計テスト追加（8件）

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
