### PR TITLE
fix: KPI対象の最小internal_noを252から251に変更

### DIFF
--- a/__tests__/prospect-internal-no.test.ts
+++ b/__tests__/prospect-internal-no.test.ts
@@ -2,7 +2,7 @@
  * 入居希望者 internal_no 自動付番・KPIスコープのUnit test
  *
  * テスト対象:
- * 1. isKpiTargetInternalNo: internal_noがKPI対象（252以上）かの判定
+ * 1. isKpiTargetInternalNo: internal_noがKPI対象（251以上）かの判定
  * 2. isProspectKpiTarget: ProspectがKPI対象かの判定
  * 3. applyProspectKpiScope: Prospect配列にKPIスコープを適用
  */
@@ -28,8 +28,8 @@ function createMockProspect(internalNo: string | number | undefined | null): Pro
 }
 
 describe('KPI_MIN_INTERNAL_NO', () => {
-  test('KPI_MIN_INTERNAL_NOは252', () => {
-    expect(KPI_MIN_INTERNAL_NO).toBe(252);
+  test('KPI_MIN_INTERNAL_NOは251', () => {
+    expect(KPI_MIN_INTERNAL_NO).toBe(251);
   });
 });
 
@@ -46,9 +46,14 @@ describe('isKpiTargetInternalNo', () => {
     expect(isKpiTargetInternalNo('')).toBe(false);
   });
 
-  test('251 はKPI対象外', () => {
-    expect(isKpiTargetInternalNo(251)).toBe(false);
-    expect(isKpiTargetInternalNo('251')).toBe(false);
+  test('250 はKPI対象外', () => {
+    expect(isKpiTargetInternalNo(250)).toBe(false);
+    expect(isKpiTargetInternalNo('250')).toBe(false);
+  });
+
+  test('251 はKPI対象', () => {
+    expect(isKpiTargetInternalNo(251)).toBe(true);
+    expect(isKpiTargetInternalNo('251')).toBe(true);
   });
 
   test('100 はKPI対象外', () => {
@@ -66,11 +71,6 @@ describe('isKpiTargetInternalNo', () => {
     expect(isKpiTargetInternalNo('252')).toBe(true);
   });
 
-  test('253 はKPI対象', () => {
-    expect(isKpiTargetInternalNo(253)).toBe(true);
-    expect(isKpiTargetInternalNo('253')).toBe(true);
-  });
-
   test('500 はKPI対象', () => {
     expect(isKpiTargetInternalNo(500)).toBe(true);
     expect(isKpiTargetInternalNo('500')).toBe(true);
@@ -83,13 +83,18 @@ describe('isKpiTargetInternalNo', () => {
 });
 
 describe('isProspectKpiTarget', () => {
+  test('internal_no=251 のProspectはKPI対象', () => {
+    const prospect = createMockProspect('251');
+    expect(isProspectKpiTarget(prospect)).toBe(true);
+  });
+
   test('internal_no=252 のProspectはKPI対象', () => {
     const prospect = createMockProspect('252');
     expect(isProspectKpiTarget(prospect)).toBe(true);
   });
 
-  test('internal_no=251 のProspectはKPI対象外', () => {
-    const prospect = createMockProspect('251');
+  test('internal_no=250 のProspectはKPI対象外', () => {
+    const prospect = createMockProspect('250');
     expect(isProspectKpiTarget(prospect)).toBe(false);
   });
 
@@ -107,23 +112,23 @@ describe('applyProspectKpiScope', () => {
 
   test('KPI対象のみをフィルタリング', () => {
     const prospects = [
+      createMockProspect('249'),
       createMockProspect('250'),
       createMockProspect('251'),
       createMockProspect('252'),
-      createMockProspect('253'),
       createMockProspect(undefined),
     ];
 
     const result = applyProspectKpiScope(prospects);
 
     expect(result.length).toBe(2);
-    expect(result[0].internalNo).toBe('252');
-    expect(result[1].internalNo).toBe('253');
+    expect(result[0].internalNo).toBe('251');
+    expect(result[1].internalNo).toBe('252');
   });
 
   test('全てKPI対象の場合はすべて返す', () => {
     const prospects = [
-      createMockProspect('252'),
+      createMockProspect('251'),
       createMockProspect('300'),
       createMockProspect('500'),
     ];
@@ -137,7 +142,7 @@ describe('applyProspectKpiScope', () => {
     const prospects = [
       createMockProspect('100'),
       createMockProspect('200'),
-      createMockProspect('251'),
+      createMockProspect('250'),
       createMockProspect(undefined),
     ];
 
@@ -148,8 +153,8 @@ describe('applyProspectKpiScope', () => {
 
   test('元の配列は変更されない（イミュータブル）', () => {
     const prospects = [
+      createMockProspect('250'),
       createMockProspect('251'),
-      createMockProspect('252'),
     ];
     const originalLength = prospects.length;
 
@@ -160,12 +165,12 @@ describe('applyProspectKpiScope', () => {
 });
 
 describe('自動付番ルール', () => {
-  test('KPI_MIN_INTERNAL_NO - 1 = 251 が境界値', () => {
-    // カウンタが251以下なら、次は252から開始する
-    expect(KPI_MIN_INTERNAL_NO - 1).toBe(251);
+  test('KPI_MIN_INTERNAL_NO - 1 = 250 が境界値', () => {
+    // カウンタが250以下なら、次は251から開始する
+    expect(KPI_MIN_INTERNAL_NO - 1).toBe(250);
   });
 
-  test('252が最初のKPI対象番号', () => {
+  test('251が最初のKPI対象番号', () => {
     expect(isKpiTargetInternalNo(KPI_MIN_INTERNAL_NO)).toBe(true);
     expect(isKpiTargetInternalNo(KPI_MIN_INTERNAL_NO - 1)).toBe(false);
   });

--- a/__tests__/sales-metrics.test.ts
+++ b/__tests__/sales-metrics.test.ts
@@ -101,11 +101,11 @@ describe('KPIスコープとの統合', () => {
     expect(cvRate).toBeNull();
   });
 
-  test('internal_no >= 252のみがKPI対象', () => {
-    // 251以下は対象外
-    const KPI_MIN_INTERNAL_NO = 252;
-    expect(251 >= KPI_MIN_INTERNAL_NO).toBe(false);
-    expect(252 >= KPI_MIN_INTERNAL_NO).toBe(true);
+  test('internal_no >= 251のみがKPI対象', () => {
+    // 250以下は対象外
+    const KPI_MIN_INTERNAL_NO = 251;
+    expect(250 >= KPI_MIN_INTERNAL_NO).toBe(false);
+    expect(251 >= KPI_MIN_INTERNAL_NO).toBe(true);
     expect(300 >= KPI_MIN_INTERNAL_NO).toBe(true);
   });
 });

--- a/src/app/dashboard/prospects/page.tsx
+++ b/src/app/dashboard/prospects/page.tsx
@@ -56,7 +56,7 @@ function ProspectsContent() {
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | ''>('');
   const [facilityFilter, setFacilityFilter] = useState('');
   const [sortBy, setSortBy] = useState<'receivedAt' | 'daysElapsed' | 'interviewDateTime'>('receivedAt');
-  // 過去データ表示（internal_no < 252）- デフォルト非表示
+  // 過去データ表示（internal_no < 251）- デフォルト非表示
   const [showLegacyData, setShowLegacyData] = useState(false);
 
   const canManage = hasMinRole(user?.role, 'leader');
@@ -82,13 +82,13 @@ function ProspectsContent() {
     fetchData();
   }, [fetchData]);
 
-  // 過去データ（internal_no < 252）の件数
+  // 過去データ（internal_no < 251）の件数
   const legacyCount = prospects.filter((p) => !isProspectKpiTarget(p)).length;
 
   // フィルタリングとソート
   const filteredProspects = prospects
     .filter((p) => {
-      // 過去データフィルター（デフォルト: internal_no >= 252 のみ表示）
+      // 過去データフィルター（デフォルト: internal_no >= 251 のみ表示）
       if (!showLegacyData && !isProspectKpiTarget(p)) {
         return false;
       }

--- a/src/lib/prospect.ts
+++ b/src/lib/prospect.ts
@@ -41,8 +41,9 @@ export const PROSPECTS_CUTOFF_DATE = new Date('2026-01-01T00:00:00.000Z');
 // KPI集計対象年（2026年以降）
 export const KPI_START_YEAR = 2026;
 
-// KPI対象の最小internal_no（252以上のみKPI対象、251以前は対象外）
-export const KPI_MIN_INTERNAL_NO = 252;
+// KPI対象の最小internal_no（251以上のみKPI対象、250以前は対象外）
+// ユーザー要件: PROSPECTS_ACTIVE_NO_MIN=251
+export const KPI_MIN_INTERNAL_NO = 251;
 
 // カウンタードキュメントパス
 const COUNTER_DOC_PATH = 'counters/prospects_internal_no';
@@ -80,7 +81,7 @@ export function isKpiTargetDate(date: Date): boolean {
 }
 
 /**
- * internal_noがKPI対象（252以上）かどうかを判定
+ * internal_noがKPI対象（251以上）かどうかを判定
  */
 export function isKpiTargetInternalNo(internalNo: string | number | undefined | null): boolean {
   if (internalNo === undefined || internalNo === null || internalNo === '') {
@@ -91,14 +92,14 @@ export function isKpiTargetInternalNo(internalNo: string | number | undefined | 
 }
 
 /**
- * ProspectがKPI対象かどうかを判定（internal_no >= 252）
+ * ProspectがKPI対象かどうかを判定（internal_no >= 251）
  */
 export function isProspectKpiTarget(prospect: Prospect): boolean {
   return isKpiTargetInternalNo(prospect.internalNo);
 }
 
 /**
- * Prospect配列にKPIスコープを適用（internal_no >= 252 のみ返す）
+ * Prospect配列にKPIスコープを適用（internal_no >= 251 のみ返す）
  */
 export function applyProspectKpiScope(prospects: Prospect[]): Prospect[] {
   return prospects.filter(isProspectKpiTarget);
@@ -114,7 +115,7 @@ function getDb() {
 /**
  * 次のinternal_noを取得（トランザクションで重複防止）
  * - カウンタが未設定の場合は、既存prospectsの最大値から初期化
- * - カウンタが251以下の場合は252から開始
+ * - カウンタが250以下の場合は251から開始
  */
 export async function getNextInternalNo(
   tenantId: string = DEFAULT_TENANT_ID
@@ -146,11 +147,11 @@ export async function getNextInternalNo(
         }
       });
 
-      // 251以下なら251にセット（次は252になる）
+      // 250以下なら250にセット（次は251になる）
       current = maxInternalNo < KPI_MIN_INTERNAL_NO - 1 ? KPI_MIN_INTERNAL_NO - 1 : maxInternalNo;
     } else {
       current = counterSnap.data().current || 0;
-      // 251以下なら251に補正
+      // 250以下なら250に補正
       if (current < KPI_MIN_INTERNAL_NO - 1) {
         current = KPI_MIN_INTERNAL_NO - 1;
       }
@@ -1224,7 +1225,7 @@ export async function unlockRoom(
 
 /**
  * ダッシュボード統計を取得
- * KPIはinternal_no >= 252のデータのみで算出
+ * KPIはinternal_no >= 251のデータのみで算出
  */
 export async function getProspectStats(
   tenantId: string = DEFAULT_TENANT_ID
@@ -1262,7 +1263,7 @@ export async function getProspectStats(
     byStatusKpi[p.status] = (byStatusKpi[p.status] || 0) + 1;
   });
 
-  // KPIはinternal_no >= 252のみ
+  // KPIはinternal_no >= 251のみ
   kpiTargetProspects.forEach((p) => {
     if (!['クローズ', '見送り', '入居決定'].includes(p.status)) {
       const days = Math.floor((now.getTime() - p.receivedAt.getTime()) / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
- KPI_MIN_INTERNAL_NO = 251 に変更（250以前は対象外）
- Firestore自動付番カウンタも250以下なら251から開始するよう修正
- /dashboard/prospectsの表示フィルタも251基準に更新
- 関連テストを251境界に更新（285件全テスト通過）

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
