### PR TITLE
feat: 入居希望者に時間ベーススコープを追加（2026-01-12 13:49以降）

### DIFF
--- a/__tests__/prospect-time-scope.test.ts
+++ b/__tests__/prospect-time-scope.test.ts
@@ -1,0 +1,262 @@
+/**
+ * 入居希望者 時間ベーススコープのUnit test
+ *
+ * テスト対象:
+ * 1. isActiveProspectByTime: 受信日時が2026-01-12 13:49以降かの判定
+ * 2. applyProspectTimeScope: 時間スコープを配列に適用
+ * 3. isProspectInFullScope: 時間 + internal_no の完全スコープ判定
+ * 4. applyFullProspectScope: 完全スコープを配列に適用
+ */
+
+import {
+  isActiveProspectByTime,
+  applyProspectTimeScope,
+  isProspectInFullScope,
+  applyFullProspectScope,
+  getProspectBaseDate,
+  PROSPECTS_ACTIVE_FROM,
+  PROSPECTS_ACTIVE_FROM_DISPLAY,
+} from '@/lib/prospect';
+import type { Prospect, ProspectStatus } from '@/types/prospect';
+
+// テスト用のProspectを作成するヘルパー
+function createMockProspectWithDate(
+  receivedAt: Date,
+  internalNo?: string
+): Prospect {
+  return {
+    id: 'test-id',
+    tenantId: 'defaultTenant',
+    status: '新規受付' as ProspectStatus,
+    receivedAt,
+    createdAt: receivedAt,
+    internalNo,
+  } as Prospect;
+}
+
+describe('PROSPECTS_ACTIVE_FROM', () => {
+  test('PROSPECTS_ACTIVE_FROMは2026-01-12 04:49 UTC', () => {
+    expect(PROSPECTS_ACTIVE_FROM.toISOString()).toBe('2026-01-12T04:49:00.000Z');
+  });
+
+  test('PROSPECTS_ACTIVE_FROM_DISPLAYは2026-01-12 13:49', () => {
+    expect(PROSPECTS_ACTIVE_FROM_DISPLAY).toBe('2026-01-12 13:49');
+  });
+});
+
+describe('getProspectBaseDate', () => {
+  test('receivedAtが最優先', () => {
+    const receivedAt = new Date('2026-01-15T00:00:00Z');
+    const createdAt = new Date('2026-01-01T00:00:00Z');
+    const prospect = {
+      ...createMockProspectWithDate(receivedAt),
+      createdAt,
+      inquiryDate: '2026-01-05',
+    } as Prospect;
+
+    const result = getProspectBaseDate(prospect);
+    expect(result).toEqual(receivedAt);
+  });
+
+  test('receivedAtがない場合はinquiryDateを使用', () => {
+    const prospect = {
+      id: 'test-id',
+      tenantId: 'defaultTenant',
+      status: '新規受付' as ProspectStatus,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      inquiryDate: '2026-01-10',
+    } as Prospect;
+
+    const result = getProspectBaseDate(prospect);
+    expect(result.toISOString().slice(0, 10)).toBe('2026-01-10');
+  });
+
+  test('receivedAtもinquiryDateもない場合はcreatedAtを使用', () => {
+    const createdAt = new Date('2026-01-01T00:00:00Z');
+    const prospect = {
+      id: 'test-id',
+      tenantId: 'defaultTenant',
+      status: '新規受付' as ProspectStatus,
+      createdAt,
+    } as Prospect;
+
+    const result = getProspectBaseDate(prospect);
+    expect(result).toEqual(createdAt);
+  });
+});
+
+describe('isActiveProspectByTime', () => {
+  test('2026-01-12 13:49 JSTちょうどは有効', () => {
+    // 2026-01-12 13:49 JST = 2026-01-12 04:49 UTC
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-12T04:49:00.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(true);
+  });
+
+  test('2026-01-12 13:49 JST以降は有効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-12T05:00:00.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(true);
+  });
+
+  test('2026-01-12 13:48 JSTは無効', () => {
+    // 2026-01-12 13:48 JST = 2026-01-12 04:48 UTC
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-12T04:48:00.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(false);
+  });
+
+  test('2026-01-01は無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-01T00:00:00.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(false);
+  });
+
+  test('2026-01-15は有効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-15T00:00:00.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(true);
+  });
+
+  test('2025年のデータは無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2025-12-31T23:59:59.000Z')
+    );
+    expect(isActiveProspectByTime(prospect)).toBe(false);
+  });
+});
+
+describe('applyProspectTimeScope', () => {
+  test('空配列は空配列を返す', () => {
+    const result = applyProspectTimeScope([]);
+    expect(result).toEqual([]);
+  });
+
+  test('時間スコープ内のみをフィルタリング', () => {
+    const prospects = [
+      createMockProspectWithDate(new Date('2026-01-01T00:00:00Z')), // 無効
+      createMockProspectWithDate(new Date('2026-01-12T04:48:00Z')), // 無効
+      createMockProspectWithDate(new Date('2026-01-12T04:49:00Z')), // 有効
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z')), // 有効
+    ];
+
+    const result = applyProspectTimeScope(prospects);
+
+    expect(result.length).toBe(2);
+  });
+});
+
+describe('isProspectInFullScope', () => {
+  test('時間スコープ内 + internal_no >= 251 は有効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-15T00:00:00Z'),
+      '251'
+    );
+    expect(isProspectInFullScope(prospect)).toBe(true);
+  });
+
+  test('時間スコープ内 + internal_no < 251 は無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-15T00:00:00Z'),
+      '250'
+    );
+    expect(isProspectInFullScope(prospect)).toBe(false);
+  });
+
+  test('時間スコープ外 + internal_no >= 251 は無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-01T00:00:00Z'),
+      '251'
+    );
+    expect(isProspectInFullScope(prospect)).toBe(false);
+  });
+
+  test('時間スコープ外 + internal_no未設定 は無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-01T00:00:00Z')
+    );
+    expect(isProspectInFullScope(prospect)).toBe(false);
+  });
+
+  test('時間スコープ内 + internal_no未設定 は無効', () => {
+    const prospect = createMockProspectWithDate(
+      new Date('2026-01-15T00:00:00Z')
+    );
+    expect(isProspectInFullScope(prospect)).toBe(false);
+  });
+});
+
+describe('applyFullProspectScope', () => {
+  test('空配列は空配列を返す', () => {
+    const result = applyFullProspectScope([]);
+    expect(result).toEqual([]);
+  });
+
+  test('完全スコープを適用', () => {
+    const prospects = [
+      // 時間外 + 番号OK → 無効
+      createMockProspectWithDate(new Date('2026-01-01T00:00:00Z'), '251'),
+      // 時間OK + 番号NG → 無効
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z'), '250'),
+      // 時間OK + 番号OK → 有効
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z'), '251'),
+      // 時間OK + 番号OK → 有効
+      createMockProspectWithDate(new Date('2026-01-20T00:00:00Z'), '300'),
+      // 時間OK + 番号なし → 無効
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z')),
+    ];
+
+    const result = applyFullProspectScope(prospects);
+
+    expect(result.length).toBe(2);
+    expect(result[0].internalNo).toBe('251');
+    expect(result[1].internalNo).toBe('300');
+  });
+
+  test('全て完全スコープ対象の場合はすべて返す', () => {
+    const prospects = [
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z'), '251'),
+      createMockProspectWithDate(new Date('2026-01-20T00:00:00Z'), '252'),
+      createMockProspectWithDate(new Date('2026-02-01T00:00:00Z'), '300'),
+    ];
+
+    const result = applyFullProspectScope(prospects);
+
+    expect(result.length).toBe(3);
+  });
+
+  test('全てスコープ外の場合は空配列を返す', () => {
+    const prospects = [
+      createMockProspectWithDate(new Date('2026-01-01T00:00:00Z'), '251'),
+      createMockProspectWithDate(new Date('2026-01-15T00:00:00Z'), '100'),
+      createMockProspectWithDate(new Date('2026-01-05T00:00:00Z')),
+    ];
+
+    const result = applyFullProspectScope(prospects);
+
+    expect(result.length).toBe(0);
+  });
+});
+
+describe('スコープ境界テスト', () => {
+  test('2026-01-12 13:49:00 JST はスコープ内', () => {
+    const borderDate = new Date('2026-01-12T04:49:00.000Z');
+    const prospect = createMockProspectWithDate(borderDate, '251');
+
+    expect(isActiveProspectByTime(prospect)).toBe(true);
+    expect(isProspectInFullScope(prospect)).toBe(true);
+  });
+
+  test('2026-01-12 13:48:59 JST はスコープ外', () => {
+    const borderDate = new Date('2026-01-12T04:48:59.000Z');
+    const prospect = createMockProspectWithDate(borderDate, '251');
+
+    expect(isActiveProspectByTime(prospect)).toBe(false);
+    expect(isProspectInFullScope(prospect)).toBe(false);
+  });
+});

--- a/src/app/dashboard/prospects/page.tsx
+++ b/src/app/dashboard/prospects/page.tsx
@@ -7,7 +7,14 @@ import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { Card, CardHeader, CardTitle, CardContent, Badge, Button, Input, Select } from '@/components/ui';
 import { Loading } from '@/components/Loading';
-import { getProspects, getProspectStats, applyProspectKpiScope, isProspectKpiTarget, KPI_MIN_INTERNAL_NO } from '@/lib/prospect';
+import {
+  getProspects,
+  getProspectStats,
+  isProspectKpiTarget,
+  isProspectInFullScope,
+  KPI_MIN_INTERNAL_NO,
+  PROSPECTS_ACTIVE_FROM_DISPLAY,
+} from '@/lib/prospect';
 import { hasMinRole } from '@/lib/auth';
 import {
   Prospect,
@@ -56,7 +63,7 @@ function ProspectsContent() {
   const [statusFilter, setStatusFilter] = useState<ProspectStatus | ''>('');
   const [facilityFilter, setFacilityFilter] = useState('');
   const [sortBy, setSortBy] = useState<'receivedAt' | 'daysElapsed' | 'interviewDateTime'>('receivedAt');
-  // 過去データ表示（internal_no < 251）- デフォルト非表示
+  // 過去データ表示（スコープ外）- デフォルト非表示
   const [showLegacyData, setShowLegacyData] = useState(false);
 
   const canManage = hasMinRole(user?.role, 'leader');
@@ -82,14 +89,14 @@ function ProspectsContent() {
     fetchData();
   }, [fetchData]);
 
-  // 過去データ（internal_no < 251）の件数
-  const legacyCount = prospects.filter((p) => !isProspectKpiTarget(p)).length;
+  // スコープ外データの件数（時間スコープ外 または internal_no < 251）
+  const legacyCount = prospects.filter((p) => !isProspectInFullScope(p)).length;
 
   // フィルタリングとソート
   const filteredProspects = prospects
     .filter((p) => {
-      // 過去データフィルター（デフォルト: internal_no >= 251 のみ表示）
-      if (!showLegacyData && !isProspectKpiTarget(p)) {
+      // スコープフィルター（デフォルト: 完全スコープ内のみ表示）
+      if (!showLegacyData && !isProspectInFullScope(p)) {
         return false;
       }
       // 検索
@@ -146,6 +153,14 @@ function ProspectsContent() {
       <Header />
       <main className="pb-20 md:pb-8">
         <div className="max-w-7xl mx-auto px-4 py-6">
+          {/* スコープ通知 */}
+          <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg flex items-center gap-2">
+            <Filter className="w-4 h-4 text-blue-600 flex-shrink-0" />
+            <p className="text-sm text-blue-700">
+              表示対象：{PROSPECTS_ACTIVE_FROM_DISPLAY} 以降の受信データ（internal_no &gt;= {KPI_MIN_INTERNAL_NO}）
+            </p>
+          </div>
+
           {/* ヘッダー */}
           <div className="flex items-center justify-between mb-6">
             <div>
@@ -299,7 +314,7 @@ function ProspectsContent() {
                       className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                     />
                     <span className="text-sm text-gray-600">
-                      過去データを表示（No.{KPI_MIN_INTERNAL_NO}未満）
+                      スコープ外データを表示
                     </span>
                   </label>
                   <Badge variant="default" className="text-xs">
@@ -307,7 +322,7 @@ function ProspectsContent() {
                   </Badge>
                 </div>
                 <p className="text-xs text-gray-400">
-                  ※ KPIにはNo.{KPI_MIN_INTERNAL_NO}以上のみ含まれます
+                  ※ KPIは{PROSPECTS_ACTIVE_FROM_DISPLAY}以降・No.{KPI_MIN_INTERNAL_NO}以上のみ
                 </p>
               </div>
             )}

--- a/src/lib/prospect.ts
+++ b/src/lib/prospect.ts
@@ -45,6 +45,11 @@ export const KPI_START_YEAR = 2026;
 // ユーザー要件: PROSPECTS_ACTIVE_NO_MIN=251
 export const KPI_MIN_INTERNAL_NO = 251;
 
+// 有効データ開始日時（この日時以降のみ表示・集計・KPI対象）
+// 2026-01-12 13:49 JST = 2026-01-12 04:49 UTC
+export const PROSPECTS_ACTIVE_FROM = new Date('2026-01-12T04:49:00.000Z');
+export const PROSPECTS_ACTIVE_FROM_DISPLAY = '2026-01-12 13:49';
+
 // カウンタードキュメントパス
 const COUNTER_DOC_PATH = 'counters/prospects_internal_no';
 
@@ -81,6 +86,40 @@ export function isKpiTargetDate(date: Date): boolean {
 }
 
 /**
+ * Prospectの基準日時を取得（優先順位: receivedAt > inquiryDate > createdAt）
+ * ※ 時間ベーススコープ用
+ */
+export function getProspectBaseDate(prospect: Prospect): Date {
+  // 1. receivedAt（最優先）
+  if (prospect.receivedAt) {
+    return prospect.receivedAt;
+  }
+  // 2. inquiryDate（文字列なのでパース）
+  if (prospect.inquiryDate) {
+    const parsed = new Date(prospect.inquiryDate);
+    if (!isNaN(parsed.getTime())) return parsed;
+  }
+  // 3. createdAt
+  return prospect.createdAt;
+}
+
+/**
+ * Prospectが時間ベースのスコープ内かどうかを判定
+ * 2026-01-12 13:49 (JST) 以降のみ有効
+ */
+export function isActiveProspectByTime(prospect: Prospect): boolean {
+  const baseDate = getProspectBaseDate(prospect);
+  return baseDate >= PROSPECTS_ACTIVE_FROM;
+}
+
+/**
+ * Prospect配列に時間ベーススコープを適用
+ */
+export function applyProspectTimeScope(prospects: Prospect[]): Prospect[] {
+  return prospects.filter(isActiveProspectByTime);
+}
+
+/**
  * internal_noがKPI対象（251以上）かどうかを判定
  */
 export function isKpiTargetInternalNo(internalNo: string | number | undefined | null): boolean {
@@ -103,6 +142,25 @@ export function isProspectKpiTarget(prospect: Prospect): boolean {
  */
 export function applyProspectKpiScope(prospects: Prospect[]): Prospect[] {
   return prospects.filter(isProspectKpiTarget);
+}
+
+/**
+ * ProspectがKPI集計対象かどうかを判定（厳格版）
+ * - 時間スコープ: 2026-01-12 13:49 以降
+ * - 番号スコープ: internal_no >= 251
+ * 両方を満たす必要がある
+ */
+export function isProspectInFullScope(prospect: Prospect): boolean {
+  return isActiveProspectByTime(prospect) && isProspectKpiTarget(prospect);
+}
+
+/**
+ * Prospect配列に完全スコープを適用
+ * - 時間スコープ: 2026-01-12 13:49 以降
+ * - 番号スコープ: internal_no >= 251
+ */
+export function applyFullProspectScope(prospects: Prospect[]): Prospect[] {
+  return prospects.filter(isProspectInFullScope);
 }
 
 function getDb() {
@@ -339,7 +397,7 @@ export async function getProspect(id: string): Promise<Prospect | null> {
 
 /**
  * 入居希望者一覧を取得
- * デフォルトで2026-01-01以降のデータのみ返す
+ * デフォルトで2026-01-12 13:49以降のデータのみ返す（時間スコープ適用）
  */
 export async function getProspects(
   tenantId: string = DEFAULT_TENANT_ID,
@@ -348,7 +406,7 @@ export async function getProspects(
     assigneeId?: string;
     desiredFacility?: string;
     salesCompanyName?: string;
-    includeOldData?: boolean; // 2026年以前のデータを含めるか（パージ用）
+    includeOldData?: boolean; // 時間スコープ外のデータを含めるか（パージ用・過去データ表示用）
   }
 ): Promise<Prospect[]> {
   const firestore = getDb();
@@ -371,9 +429,9 @@ export async function getProspects(
     } as Prospect;
   });
 
-  // デフォルトで2026年以前のデータを除外（カットオフ日ベース）
+  // デフォルトで時間スコープを適用（2026-01-12 13:49以降のみ）
   if (!filters?.includeOldData) {
-    results = results.filter((p) => isProspectValid(p));
+    results = results.filter((p) => isActiveProspectByTime(p));
   }
 
   // クライアントサイドフィルタ
@@ -1041,9 +1099,9 @@ export async function closeOldProspects(
   // 全件取得（旧データ含む）
   const allProspects = await getProspects(tenantId, { includeOldData: true });
 
-  // 2026年以前でまだクローズでないものを抽出
+  // 時間スコープ外でまだクローズでないものを抽出
   const oldProspects = allProspects.filter((p) => {
-    return !isProspectValid(p) && p.status !== 'クローズ';
+    return !isActiveProspectByTime(p) && p.status !== 'クローズ';
   });
 
   if (oldProspects.length === 0) {
@@ -1057,7 +1115,7 @@ export async function closeOldProspects(
   oldProspects.forEach((p) => {
     batch.update(doc(firestore, 'prospects', p.id), {
       status: 'クローズ' as ProspectStatus,
-      statusNote: '2026年以前の旧データのため一括クローズ',
+      statusNote: `${PROSPECTS_ACTIVE_FROM_DISPLAY}より前の旧データのため一括クローズ`,
       updatedAt: now,
     });
   });
@@ -1072,7 +1130,7 @@ export async function closeOldProspects(
     action: 'update',
     entity: 'prospect',
     entityId: 'batch',
-    note: `${PROSPECTS_CUTOFF_DATE.toISOString()}以前の旧データ ${oldProspects.length}件を一括クローズ`,
+    note: `${PROSPECTS_ACTIVE_FROM_DISPLAY}より前の旧データ ${oldProspects.length}件を一括クローズ`,
   });
 
   return { closedCount: oldProspects.length };
@@ -1225,7 +1283,7 @@ export async function unlockRoom(
 
 /**
  * ダッシュボード統計を取得
- * KPIはinternal_no >= 251のデータのみで算出
+ * KPIは時間スコープ（2026-01-12 13:49以降）+ internal_no >= 251 で算出
  */
 export async function getProspectStats(
   tenantId: string = DEFAULT_TENANT_ID
@@ -1239,31 +1297,32 @@ export async function getProspectStats(
   avgDaysElapsed: number;
   kpiNote: string;
 }> {
+  // 時間スコープ適用済みのデータを取得
   const prospects = await getProspects(tenantId);
 
   const now = new Date();
   const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
   const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
-  // KPI対象はinternal_no >= 252のみ（厳格）
-  const kpiTargetProspects = applyProspectKpiScope(prospects);
+  // KPI対象は完全スコープ（時間 + internal_no）
+  const kpiTargetProspects = applyFullProspectScope(prospects);
 
   const byStatus: Record<string, number> = {};
   const byStatusKpi: Record<string, number> = {};
   let totalDays = 0;
   let activeCount = 0;
 
-  // ステータス集計（全件）
+  // ステータス集計（時間スコープ適用後の全件）
   prospects.forEach((p) => {
     byStatus[p.status] = (byStatus[p.status] || 0) + 1;
   });
 
-  // ステータス集計（KPI対象のみ）
+  // ステータス集計（完全スコープ適用後）
   kpiTargetProspects.forEach((p) => {
     byStatusKpi[p.status] = (byStatusKpi[p.status] || 0) + 1;
   });
 
-  // KPIはinternal_no >= 251のみ
+  // 完全スコープ対象で平均経過日数を計算
   kpiTargetProspects.forEach((p) => {
     if (!['クローズ', '見送り', '入居決定'].includes(p.status)) {
       const days = Math.floor((now.getTime() - p.receivedAt.getTime()) / (1000 * 60 * 60 * 24));
@@ -1280,6 +1339,6 @@ export async function getProspectStats(
     newThisWeek: kpiTargetProspects.filter((p) => p.receivedAt > weekAgo).length,
     newThisMonth: kpiTargetProspects.filter((p) => p.receivedAt > monthAgo).length,
     avgDaysElapsed: activeCount > 0 ? Math.round(totalDays / activeCount) : 0,
-    kpiNote: `KPIはinternal_no >= ${KPI_MIN_INTERNAL_NO}のデータで算出`,
+    kpiNote: `KPIは${PROSPECTS_ACTIVE_FROM_DISPLAY}以降・internal_no >= ${KPI_MIN_INTERNAL_NO}で算出`,
   };
 }


### PR DESCRIPTION
- PROSPECTS_ACTIVE_FROM = 2026-01-12 04:49 UTC (13:49 JST) 定数追加
- isActiveProspectByTime(): 時間スコープ判定関数
- applyProspectTimeScope(): 時間スコープを配列に適用
- isProspectInFullScope(): 時間 + internal_no の完全スコープ判定
- applyFullProspectScope(): 完全スコープを配列に適用
- getProspects(): 時間スコープをデフォルト適用に変更
- getProspectStats(): KPI算出を完全スコープ（時間 + internal_no）に更新
- /dashboard/prospects にスコープ通知バナーを追加
- prospect-time-scope.test.ts で24テスト追加（計309テスト通過）

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
