### PR TITLE
fix: 書類自動生成のFirestoreエラーを修正（undefined除去）

### DIFF
--- a/__tests__/document-normalize.test.ts
+++ b/__tests__/document-normalize.test.ts
@@ -1,0 +1,247 @@
+/**
+ * 書類管理 Firestore正規化のUnit test
+ *
+ * テスト対象:
+ * 1. normalizeForFirestore: undefinedをFirestoreに渡さない
+ * 2. ネストされたオブジェクトの正規化
+ * 3. 配列内のundefinedの除去
+ */
+
+import { normalizeForFirestore } from '@/lib/document';
+
+describe('normalizeForFirestore', () => {
+  test('undefinedフィールドを除去する', () => {
+    const input = {
+      name: 'テスト',
+      note: undefined,
+      status: 'MISSING',
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      name: 'テスト',
+      status: 'MISSING',
+    });
+    expect('note' in result).toBe(false);
+  });
+
+  test('nullは保持する', () => {
+    const input = {
+      name: 'テスト',
+      note: null,
+      dueDate: null,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      name: 'テスト',
+      note: null,
+      dueDate: null,
+    });
+  });
+
+  test('空文字は保持する', () => {
+    const input = {
+      name: 'テスト',
+      note: '',
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      name: 'テスト',
+      note: '',
+    });
+  });
+
+  test('0は保持する', () => {
+    const input = {
+      count: 0,
+      version: 1,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      count: 0,
+      version: 1,
+    });
+  });
+
+  test('falseは保持する', () => {
+    const input = {
+      required: false,
+      active: true,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      required: false,
+      active: true,
+    });
+  });
+
+  test('ネストされたオブジェクトのundefinedも除去する', () => {
+    const input = {
+      name: 'テスト',
+      metadata: {
+        key: 'value',
+        optional: undefined,
+        nested: {
+          a: 1,
+          b: undefined,
+        },
+      },
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      name: 'テスト',
+      metadata: {
+        key: 'value',
+        nested: {
+          a: 1,
+        },
+      },
+    });
+  });
+
+  test('配列内のundefinedを除去する', () => {
+    const input = {
+      tags: ['a', undefined, 'b', undefined, 'c'],
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      tags: ['a', 'b', 'c'],
+    });
+  });
+
+  test('配列内のオブジェクトのundefinedも除去する', () => {
+    const input = {
+      items: [
+        { id: 1, note: undefined },
+        { id: 2, note: 'test' },
+      ],
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      items: [
+        { id: 1 },
+        { id: 2, note: 'test' },
+      ],
+    });
+  });
+
+  test('Dateオブジェクトは保持する', () => {
+    const date = new Date('2026-01-15T00:00:00Z');
+    const input = {
+      createdAt: date,
+      name: 'テスト',
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result.createdAt).toBe(date);
+    expect(result.name).toBe('テスト');
+  });
+
+  test('空オブジェクトは空オブジェクトを返す', () => {
+    const result = normalizeForFirestore({});
+    expect(result).toEqual({});
+  });
+
+  test('全てundefinedの場合は空オブジェクトを返す', () => {
+    const input = {
+      a: undefined,
+      b: undefined,
+      c: undefined,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('書類自動生成のペイロード正規化', () => {
+  test('書類生成時の典型的なペイロードを正規化', () => {
+    const input = {
+      tenantId: 'tenant1',
+      ownerType: 'RESIDENT',
+      ownerId: 'prospect123',
+      ownerName: '山田太郎',
+      docType: 'RESIDENT_CONTRACT',
+      docTypeName: '入居契約書',
+      status: 'MISSING',
+      dueDate: undefined,
+      signedRequired: true,
+      note: undefined,
+      fileUrl: undefined,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      tenantId: 'tenant1',
+      ownerType: 'RESIDENT',
+      ownerId: 'prospect123',
+      ownerName: '山田太郎',
+      docType: 'RESIDENT_CONTRACT',
+      docTypeName: '入居契約書',
+      status: 'MISSING',
+      signedRequired: true,
+    });
+
+    // undefinedフィールドが除去されていることを確認
+    expect('dueDate' in result).toBe(false);
+    expect('note' in result).toBe(false);
+    expect('fileUrl' in result).toBe(false);
+  });
+
+  test('APIからnullが渡された場合は保持する', () => {
+    const input = {
+      tenantId: 'tenant1',
+      ownerType: 'RESIDENT',
+      ownerId: 'prospect123',
+      ownerName: null,  // APIがnullを明示的に渡す場合
+      docType: 'RESIDENT_CONTRACT',
+      status: 'MISSING',
+      dueDate: null,    // 期限なし
+      signedRequired: false,
+    };
+
+    const result = normalizeForFirestore(input);
+
+    expect(result).toEqual({
+      tenantId: 'tenant1',
+      ownerType: 'RESIDENT',
+      ownerId: 'prospect123',
+      ownerName: null,
+      docType: 'RESIDENT_CONTRACT',
+      status: 'MISSING',
+      dueDate: null,
+      signedRequired: false,
+    });
+  });
+});
+
+describe('イベント記録のJSON正規化', () => {
+  test('prevJson/nextJsonのundefinedをnullに変換', () => {
+    const sanitizeForJson = (obj: unknown): unknown => {
+      if (obj === null || obj === undefined) return null;
+      return JSON.parse(JSON.stringify(obj, (_, v) => v === undefined ? null : v));
+    };
+
+    expect(sanitizeForJson(undefined)).toBe(null);
+    expect(sanitizeForJson(null)).toBe(null);
+    expect(sanitizeForJson({ a: 1, b: undefined })).toEqual({ a: 1, b: null });
+  });
+});

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -56,15 +56,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // undefinedではなくnullを使用（Firestoreはundefinedを許可しない）
     const document = await createDocument(
       {
         tenantId,
         ownerType,
         ownerId,
-        ownerName,
+        ownerName: ownerName || null,
         docType,
         status,
-        dueDate: dueDate ? new Date(dueDate) : undefined,
+        dueDate: dueDate ? new Date(dueDate) : null,
         signedRequired,
       },
       actorId,

--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -32,6 +32,39 @@ function ensureDb() {
   return db;
 }
 
+/**
+ * Firestoreに渡す前にundefinedを除去する
+ * Firestoreはundefinedを許可しないため、nullまたは値のあるフィールドのみ保持
+ * @exported for testing
+ */
+export function normalizeForFirestore<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  // Firestore Timestampクラスのチェック（テスト環境でも動作するように）
+  const isTimestamp = (v: unknown): boolean => {
+    return v !== null && typeof v === 'object' && 'toDate' in v && typeof (v as { toDate: unknown }).toDate === 'function';
+  };
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) {
+      // ネストされたオブジェクトも再帰的に処理
+      if (value !== null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date) && !isTimestamp(value)) {
+        result[key] = normalizeForFirestore(value as Record<string, unknown>);
+      } else if (Array.isArray(value)) {
+        // 配列内のundefinedも除去
+        result[key] = value.filter(v => v !== undefined).map(v => {
+          if (v !== null && typeof v === 'object' && !(v instanceof Date) && !isTimestamp(v)) {
+            return normalizeForFirestore(v as Record<string, unknown>);
+          }
+          return v;
+        });
+      } else {
+        result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
 // ======== テンプレート ========
 
 // 静的データから取得（フォールバック用）
@@ -200,12 +233,14 @@ export async function createDocument(
 
   const template = getTemplateByKey(data.docType);
 
-  const docData = {
+  // undefinedを除去してFirestoreに渡す
+  const rawDocData = {
     ...data,
     docTypeName: template?.name || data.docType,
     version: 1,
     createdAt: Timestamp.now(),
   };
+  const docData = normalizeForFirestore(rawDocData);
 
   const docRef = await addDoc(collection(firestore, 'documents'), docData);
 
@@ -229,10 +264,12 @@ export async function updateDocument(
   const existing = await getDocument(id);
   if (!existing) throw new Error('書類が見つかりません');
 
-  const updateData = {
+  // undefinedを除去してFirestoreに渡す
+  const rawUpdateData = {
     ...updates,
     updatedAt: Timestamp.now(),
   };
+  const updateData = normalizeForFirestore(rawUpdateData);
 
   await updateDoc(doc(firestore, 'documents', id), updateData);
 
@@ -372,15 +409,23 @@ async function createDocumentEvent(
 ): Promise<void> {
   const firestore = ensureDb();
 
-  await addDoc(collection(firestore, 'documentEvents'), {
+  // JSON.stringifyでundefinedが自動的に除去されるが、明示的にnullに変換
+  const sanitizeForJson = (obj: unknown): unknown => {
+    if (obj === null || obj === undefined) return null;
+    return JSON.parse(JSON.stringify(obj, (_, v) => v === undefined ? null : v));
+  };
+
+  const eventData = normalizeForFirestore({
     documentId,
     eventType,
-    prevJson: prev ? JSON.parse(JSON.stringify(prev)) : null,
-    nextJson: next ? JSON.parse(JSON.stringify(next)) : null,
+    prevJson: sanitizeForJson(prev),
+    nextJson: sanitizeForJson(next),
     actorId,
-    actorName,
+    actorName: actorName || '',
     createdAt: Timestamp.now(),
   });
+
+  await addDoc(collection(firestore, 'documentEvents'), eventData);
 }
 
 export async function getDocumentEvents(documentId: string): Promise<DocumentEvent[]> {


### PR DESCRIPTION
- normalizeForFirestore関数を追加：undefinedをFirestore書き込み前に除去
- createDocument/updateDocument/createDocumentEventで正規化を適用
- API /documents route でundefinedの代わりにnullを使用
- 配列・ネストオブジェクト内のundefinedも再帰的に除去
- 14テスト追加（計323テスト通過）

Firestoreはundefinedを許可しないため、書類生成時に
「Element at index 0 is not a valid array element」
「Cannot use "undefined" as a Firestore value」
エラーが発生していた問題を解消。

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
