### PR TITLE
fix: 書類自動生成のエラーハンドリングとログを強化

### DIFF
--- a/src/app/api/documents/generate-required/route.ts
+++ b/src/app/api/documents/generate-required/route.ts
@@ -3,6 +3,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { generateRequiredDocuments, getDocuments } from '@/lib/document';
+import { getRequiredTemplates } from '@/data/document-templates';
 import { DocumentOwnerType } from '@/types/document';
 import { DEFAULT_TENANT_ID } from '@/lib/firebase';
 
@@ -19,7 +20,9 @@ export async function POST(request: NextRequest) {
       skipExisting = true, // 既存書類がある場合はスキップ
     } = body;
 
+    // 必須フィールド検証
     if (!ownerType || !ownerId || !actorId) {
+      console.error('[generate-required] Missing required fields:', { ownerType, ownerId, actorId });
       return NextResponse.json(
         { error: 'Missing required fields: ownerType, ownerId, actorId' },
         { status: 400 }
@@ -29,16 +32,33 @@ export async function POST(request: NextRequest) {
     // 対象の所有者タイプを検証
     const validOwnerTypes: DocumentOwnerType[] = ['RESIDENT', 'EMPLOYEE', 'PARTNER', 'ORG'];
     if (!validOwnerTypes.includes(ownerType)) {
+      console.error('[generate-required] Invalid ownerType:', ownerType);
       return NextResponse.json(
         { error: `Invalid ownerType. Must be one of: ${validOwnerTypes.join(', ')}` },
         { status: 400 }
       );
     }
 
+    // テンプレート数を事前確認（デバッグ用）
+    const templates = getRequiredTemplates(ownerType);
+    console.log(`[generate-required] ownerType=${ownerType}, ownerId=${ownerId}, templates=${templates.length}`);
+
+    if (templates.length === 0) {
+      console.warn(`[generate-required] No templates found for ownerType=${ownerType}`);
+      return NextResponse.json({
+        success: true,
+        message: 'No required document templates defined for this owner type',
+        created: 0,
+        existing: 0,
+        documents: [],
+      });
+    }
+
     // 既存書類を確認（スキップオプション）
     if (skipExisting) {
       const existingDocs = await getDocuments(tenantId, { ownerType, ownerId });
       if (existingDocs.length > 0) {
+        console.log(`[generate-required] Documents already exist: ${existingDocs.length}`);
         return NextResponse.json({
           success: true,
           message: 'Documents already exist for this owner',
@@ -53,11 +73,13 @@ export async function POST(request: NextRequest) {
     const documents = await generateRequiredDocuments(
       ownerType,
       ownerId,
-      ownerName || ownerId,
+      ownerName || ownerId || '',
       tenantId,
       actorId,
-      actorName || actorId
+      actorName || actorId || ''
     );
+
+    console.log(`[generate-required] Successfully generated ${documents.length} documents`);
 
     return NextResponse.json({
       success: true,
@@ -72,6 +94,10 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('[generate-required] POST Error:', error);
+    // エラーの詳細をログに出力
+    if (error instanceof Error) {
+      console.error('[generate-required] Error stack:', error.stack);
+    }
     return NextResponse.json(
       { error: 'Failed to generate required documents', details: String(error) },
       { status: 500 }

--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -319,26 +319,50 @@ export async function generateRequiredDocuments(
   actorId: string,
   actorName: string
 ): Promise<Document[]> {
+  // テンプレート取得
   const required = getRequiredTemplates(ownerType);
+
+  // ログ出力（デバッグ用）
+  console.log(`[generateRequiredDocuments] ownerType=${ownerType}, ownerId=${ownerId}, templates=${required.length}`);
+
+  // テンプレートが0件の場合は早期リターン（エラーではない）
+  if (required.length === 0) {
+    console.warn(`[generateRequiredDocuments] No required templates found for ownerType=${ownerType}`);
+    return [];
+  }
+
+  // 有効なテンプレートのみフィルタ（undefinedや不正データ防止）
+  const validTemplates = required.filter(t => t && t.key && t.name);
+  if (validTemplates.length !== required.length) {
+    console.warn(`[generateRequiredDocuments] Filtered ${required.length - validTemplates.length} invalid templates`);
+  }
+
   const created: Document[] = [];
 
-  for (const template of required) {
-    const doc = await createDocument(
-      {
-        tenantId,
-        ownerType,
-        ownerId,
-        ownerName,
-        docType: template.key,
-        docTypeName: template.name,
-        status: 'MISSING',
-        signedRequired: template.signedRequired,
-      },
-      actorId,
-      actorName
-    );
-    created.push(doc);
+  for (const template of validTemplates) {
+    try {
+      const doc = await createDocument(
+        {
+          tenantId,
+          ownerType,
+          ownerId,
+          ownerName: ownerName || '', // 空文字で初期化（undefined防止）
+          docType: template.key,
+          docTypeName: template.name,
+          status: 'MISSING',
+          signedRequired: template.signedRequired ?? false,
+        },
+        actorId,
+        actorName
+      );
+      created.push(doc);
+    } catch (error) {
+      // 個別のエラーをログに出力し、他の書類生成を継続
+      console.error(`[generateRequiredDocuments] Failed to create document: ${template.key}`, error);
+    }
   }
+
+  console.log(`[generateRequiredDocuments] Successfully created ${created.length}/${validTemplates.length} documents`);
 
   return created;
 }


### PR DESCRIPTION
- generateRequiredDocuments: テンプレート検証と個別エラーハンドリング追加
- generate-required API: 詳細なログ出力と事前検証を追加
- ownerName/actorNameの空文字フォールバック（undefined防止）
- signedRequiredのnullish coalescing（undefined防止）
- テンプレートが0件の場合も正常レスポンスを返す
- 個別の書類生成エラーでも他の書類生成を継続

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
