### PR TITLE
feat: 空室画面に部屋マスタ管理機能を追加

### DIFF
--- a/src/app/api/rooms/[id]/status/route.ts
+++ b/src/app/api/rooms/[id]/status/route.ts
@@ -1,0 +1,184 @@
+// ======== 部屋ステータス変更API ========
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
+import { hasMinRole } from '@/lib/auth';
+import { RoomStatus, ROOM_STATUSES } from '@/types/prospect';
+import { Timestamp } from 'firebase-admin/firestore';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// 許可される状態遷移
+// - 空室 → 修繕中, 入居中
+// - 修繕中 → 空室
+// - 入居中 → 空室（退去）, 退去予定
+// - 退去予定 → 空室, 入居中
+// - 予約（LOCKED）は申込連動で自動設定、手動不可
+const ALLOWED_TRANSITIONS: Record<RoomStatus, RoomStatus[]> = {
+  '空室': ['メンテナンス', '入居中'],
+  'メンテナンス': ['空室'],
+  '入居中': ['空室', '退去予定'],
+  '退去予定': ['空室', '入居中'],
+  '予約': [], // 手動変更不可
+};
+
+/**
+ * PATCH /api/rooms/:id/status
+ * 部屋ステータスを変更（manager以上）
+ * Body:
+ *   - status: 新しいステータス（必須）
+ *   - note: 備考（任意）
+ *   - occupantId: 入居者ID（入居中に変更時）
+ *   - occupantName: 入居者名（入居中に変更時）
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { id: roomId } = await params;
+
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    // ユーザー情報取得・権限チェック
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(decodedToken.uid).get();
+    const userData = userDoc.data();
+    const userRole = userData?.role || 'user';
+
+    // leader 以上
+    if (!hasMinRole(userRole, 'leader')) {
+      return NextResponse.json(
+        { error: '状態変更には leader 以上の権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { status: newStatus, note, occupantId, occupantName } = body;
+
+    // ステータスチェック
+    if (!newStatus || !ROOM_STATUSES.includes(newStatus as RoomStatus)) {
+      return NextResponse.json(
+        { error: `無効なステータスです: ${newStatus}` },
+        { status: 400 }
+      );
+    }
+
+    // 部屋取得
+    const roomDoc = await db.collection('rooms').doc(roomId).get();
+    if (!roomDoc.exists) {
+      return NextResponse.json(
+        { error: '部屋が見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    const roomData = roomDoc.data()!;
+    const currentStatus = roomData.status as RoomStatus;
+
+    // 予約（LOCKED）は手動変更不可
+    if (currentStatus === '予約') {
+      return NextResponse.json(
+        { error: '予約中の部屋は申込解除後に状態変更してください' },
+        { status: 400 }
+      );
+    }
+
+    if (newStatus === '予約') {
+      return NextResponse.json(
+        { error: '予約状態は申込連動で自動設定されます' },
+        { status: 400 }
+      );
+    }
+
+    // 状態遷移チェック
+    const allowedNextStates = ALLOWED_TRANSITIONS[currentStatus] || [];
+    if (!allowedNextStates.includes(newStatus as RoomStatus)) {
+      return NextResponse.json(
+        {
+          error: `${currentStatus} から ${newStatus} への変更は許可されていません`,
+          allowedTransitions: allowedNextStates,
+        },
+        { status: 400 }
+      );
+    }
+
+    // 更新データ準備
+    const updateData: Record<string, unknown> = {
+      status: newStatus,
+      updatedAt: Timestamp.now(),
+      updatedBy: decodedToken.uid,
+      updatedByName: userData?.displayName || decodedToken.email || 'Unknown',
+    };
+
+    // 備考更新
+    if (note !== undefined) {
+      updateData.note = note || null;
+    }
+
+    // 入居中に変更時
+    if (newStatus === '入居中') {
+      updateData.occupantId = occupantId || null;
+      updateData.occupantName = occupantName || null;
+    }
+
+    // 空室に変更時（退去）
+    if (newStatus === '空室') {
+      updateData.occupantId = null;
+      updateData.occupantName = null;
+      updateData.lockedCaseId = null;
+      updateData.lockedAt = null;
+      updateData.lockedBy = null;
+      updateData.lockedByName = null;
+    }
+
+    // 更新実行
+    await db.collection('rooms').doc(roomId).update(updateData);
+
+    // 監査ログ作成
+    await db.collection('auditLogs').add({
+      tenantId: roomData.tenantId,
+      actor: decodedToken.uid,
+      actorName: userData?.displayName || decodedToken.email || 'Unknown',
+      action: 'status_change',
+      entity: 'room',
+      entityId: roomId,
+      diff: {
+        before: { status: currentStatus },
+        after: { status: newStatus },
+      },
+      note: note || null,
+      createdAt: Timestamp.now(),
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: `${roomData.buildingName} ${roomData.roomNumber} を ${newStatus} に変更しました`,
+      room: {
+        id: roomId,
+        buildingName: roomData.buildingName,
+        roomNumber: roomData.roomNumber,
+        previousStatus: currentStatus,
+        status: newStatus,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to update room status:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,0 +1,211 @@
+// ======== 部屋マスタAPI ========
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
+import { hasMinRole } from '@/lib/auth';
+import { RoomStatus, ROOM_STATUSES } from '@/types/prospect';
+import { Timestamp, FieldValue } from 'firebase-admin/firestore';
+
+const DEFAULT_TENANT_ID = 'defaultTenant';
+
+/**
+ * GET /api/rooms
+ * 部屋一覧を取得
+ * Query params:
+ *   - buildingName: 建物名でフィルター（任意）
+ *   - status: ステータスでフィルター（任意）
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const buildingName = searchParams.get('buildingName') || undefined;
+    const statusFilter = searchParams.get('status') || undefined;
+
+    const db = getAdminDb();
+    let query = db.collection('rooms').where('tenantId', '==', DEFAULT_TENANT_ID);
+
+    if (buildingName) {
+      query = query.where('buildingName', '==', buildingName);
+    }
+
+    const snapshot = await query.get();
+
+    let rooms = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        tenantId: data.tenantId,
+        buildingName: data.buildingName,
+        roomNumber: data.roomNumber,
+        capacity: data.capacity ?? 1,
+        status: data.status || '空室',
+        expectedCareLevel: data.expectedCareLevel || null,
+        note: data.note || null,
+        lockedCaseId: data.lockedCaseId || null,
+        lockedAt: data.lockedAt?.toDate?.()?.toISOString() || null,
+        lockedBy: data.lockedBy || null,
+        lockedByName: data.lockedByName || null,
+        occupantId: data.occupantId || null,
+        occupantName: data.occupantName || null,
+        createdAt: data.createdAt?.toDate?.()?.toISOString() || null,
+        updatedAt: data.updatedAt?.toDate?.()?.toISOString() || null,
+      };
+    });
+
+    // ステータスフィルター
+    if (statusFilter) {
+      rooms = rooms.filter((r) => r.status === statusFilter);
+    }
+
+    // ソート: 建物名 → 部屋番号
+    rooms.sort((a, b) => {
+      if (a.buildingName !== b.buildingName) {
+        return a.buildingName.localeCompare(b.buildingName, 'ja');
+      }
+      return a.roomNumber.localeCompare(b.roomNumber, 'ja');
+    });
+
+    return NextResponse.json({
+      success: true,
+      rooms,
+      count: rooms.length,
+    });
+  } catch (error) {
+    console.error('Failed to fetch rooms:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/rooms
+ * 部屋を追加（admin/execのみ）
+ * Body:
+ *   - buildingName: 建物名（必須）
+ *   - roomNumber: 部屋番号（必須）
+ *   - capacity: 定員（任意、デフォルト1）
+ *   - status: 初期ステータス（任意、デフォルト '空室'）
+ *   - expectedCareLevel: 想定介護度（任意）
+ *   - note: 備考（任意）
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    // ユーザー情報取得・権限チェック
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(decodedToken.uid).get();
+    const userData = userDoc.data();
+    const userRole = userData?.role || 'user';
+
+    // admin のみ
+    if (!hasMinRole(userRole, 'admin')) {
+      return NextResponse.json(
+        { error: '部屋の追加には admin 以上の権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const {
+      buildingName,
+      roomNumber,
+      capacity = 1,
+      status = '空室',
+      expectedCareLevel,
+      note,
+    } = body;
+
+    // バリデーション
+    if (!buildingName || !roomNumber) {
+      return NextResponse.json(
+        { error: '建物名と部屋番号は必須です' },
+        { status: 400 }
+      );
+    }
+
+    // ステータスチェック
+    if (!ROOM_STATUSES.includes(status as RoomStatus)) {
+      return NextResponse.json(
+        { error: `無効なステータスです: ${status}` },
+        { status: 400 }
+      );
+    }
+
+    // 重複チェック
+    const existingQuery = await db
+      .collection('rooms')
+      .where('tenantId', '==', DEFAULT_TENANT_ID)
+      .where('buildingName', '==', buildingName)
+      .where('roomNumber', '==', roomNumber)
+      .get();
+
+    if (!existingQuery.empty) {
+      return NextResponse.json(
+        { error: `${buildingName} ${roomNumber} は既に登録されています` },
+        { status: 409 }
+      );
+    }
+
+    // 部屋を作成
+    const roomData = {
+      tenantId: DEFAULT_TENANT_ID,
+      buildingName,
+      roomNumber,
+      capacity: Number(capacity) || 1,
+      status,
+      expectedCareLevel: expectedCareLevel || null,
+      note: note || null,
+      createdAt: Timestamp.now(),
+      createdBy: decodedToken.uid,
+      createdByName: userData?.displayName || decodedToken.email || 'Unknown',
+    };
+
+    const docRef = await db.collection('rooms').add(roomData);
+
+    return NextResponse.json({
+      success: true,
+      message: `${buildingName} ${roomNumber} を追加しました`,
+      room: {
+        id: docRef.id,
+        ...roomData,
+        createdAt: new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to create room:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -21,6 +21,10 @@ import {
   ChevronUp,
   AlertCircle,
   Filter,
+  Plus,
+  X,
+  Users,
+  DoorOpen,
 } from 'lucide-react';
 import Link from 'next/link';
 
@@ -81,12 +85,58 @@ interface VacancyMetrics {
   };
 }
 
+// 部屋データ型
+interface RoomData {
+  id: string;
+  buildingName: string;
+  roomNumber: string;
+  capacity: number;
+  status: string;
+  note: string | null;
+  lockedCaseId: string | null;
+  lockedByName: string | null;
+  lockedAt: string | null;
+  occupantId: string | null;
+  occupantName: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
 // ===== フィルタタイプ =====
 type StatusFilter = 'all' | 'available' | 'locked' | 'occupied' | 'maintenance' | 'lowOccupancy';
+type ViewMode = 'summary' | 'rooms';
+
+// ===== ステータス設定 =====
+const ROOM_STATUS_CONFIG: Record<string, { label: string; color: string; bgColor: string; icon: React.ReactNode }> = {
+  '空室': { label: '空室', color: 'text-blue-700', bgColor: 'bg-blue-100', icon: <Home className="w-3 h-3" /> },
+  '予約': { label: 'ロック', color: 'text-purple-700', bgColor: 'bg-purple-100', icon: <Lock className="w-3 h-3" /> },
+  '入居中': { label: '入居中', color: 'text-green-700', bgColor: 'bg-green-100', icon: <Users className="w-3 h-3" /> },
+  '退去予定': { label: '退去予定', color: 'text-orange-700', bgColor: 'bg-orange-100', icon: <DoorOpen className="w-3 h-3" /> },
+  'メンテナンス': { label: '修繕中', color: 'text-yellow-700', bgColor: 'bg-yellow-100', icon: <Wrench className="w-3 h-3" /> },
+};
+
+// 状態変更の選択肢
+const STATUS_TRANSITIONS: Record<string, { value: string; label: string }[]> = {
+  '空室': [
+    { value: 'メンテナンス', label: '修繕中にする' },
+    { value: '入居中', label: '入居中にする' },
+  ],
+  'メンテナンス': [
+    { value: '空室', label: '空室にする' },
+  ],
+  '入居中': [
+    { value: '退去予定', label: '退去予定にする' },
+    { value: '空室', label: '退去（空室にする）' },
+  ],
+  '退去予定': [
+    { value: '空室', label: '退去完了（空室にする）' },
+    { value: '入居中', label: '入居継続' },
+  ],
+  '予約': [], // 手動変更不可
+};
 
 // ===== ユーティリティ =====
 
-// 表示用（nullは'--'）
 function displayRate(rate: number | null): string {
   if (rate === null || rate === undefined) return '--';
   return `${rate}%`;
@@ -97,7 +147,6 @@ function displayCount(count: number | null): string {
   return count.toString();
 }
 
-// 稼働率に応じた色
 function getOccupancyColor(rate: number | null): { bg: string; text: string; border: string } {
   if (rate === null) return { bg: 'bg-gray-50', text: 'text-gray-500', border: 'border-gray-200' };
   if (rate >= 95) return { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200' };
@@ -106,7 +155,6 @@ function getOccupancyColor(rate: number | null): { bg: string; text: string; bor
   return { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' };
 }
 
-// 稼働率バー
 function OccupancyBar({ rate }: { rate: number | null }) {
   if (rate === null) {
     return (
@@ -123,7 +171,6 @@ function OccupancyBar({ rate }: { rate: number | null }) {
   );
 }
 
-// 時刻フォーマット
 function formatTime(dateStr: string | null): string {
   if (!dateStr) return '-';
   const date = new Date(dateStr);
@@ -135,31 +182,256 @@ function formatTime(dateStr: string | null): string {
   });
 }
 
+// ===== 部屋追加モーダル =====
+
+interface AddRoomModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: { buildingName: string; roomNumber: string; capacity: number }) => Promise<void>;
+  buildings: string[];
+}
+
+function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProps) {
+  const [buildingName, setBuildingName] = useState('');
+  const [roomNumber, setRoomNumber] = useState('');
+  const [capacity, setCapacity] = useState(1);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await onSubmit({ buildingName, roomNumber, capacity });
+      setBuildingName('');
+      setRoomNumber('');
+      setCapacity(1);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '追加に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Plus className="w-5 h-5" />
+            部屋を追加
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              建物 <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={buildingName}
+              onChange={(e) => setBuildingName(e.target.value)}
+              className="w-full border rounded-lg px-3 py-2"
+              required
+            >
+              <option value="">選択してください</option>
+              {buildings.map((b) => (
+                <option key={b} value={b}>{b}</option>
+              ))}
+              <option value="__other__">その他（新規建物）</option>
+            </select>
+            {buildingName === '__other__' && (
+              <input
+                type="text"
+                placeholder="建物名を入力"
+                className="w-full border rounded-lg px-3 py-2 mt-2"
+                onChange={(e) => setBuildingName(e.target.value)}
+                required
+              />
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              部屋番号 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={roomNumber}
+              onChange={(e) => setRoomNumber(e.target.value)}
+              placeholder="例: 101, 2F-A"
+              className="w-full border rounded-lg px-3 py-2"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              定員
+            </label>
+            <select
+              value={capacity}
+              onChange={(e) => setCapacity(Number(e.target.value))}
+              className="w-full border rounded-lg px-3 py-2"
+            >
+              <option value={1}>1人</option>
+              <option value={2}>2人</option>
+            </select>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              className="flex-1"
+              disabled={submitting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1"
+              disabled={submitting || !buildingName || !roomNumber}
+            >
+              {submitting ? '追加中...' : '追加'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ===== 状態変更ドロップダウン =====
+
+interface StatusChangeDropdownProps {
+  room: RoomData;
+  onStatusChange: (roomId: string, newStatus: string) => Promise<void>;
+  disabled?: boolean;
+}
+
+function StatusChangeDropdown({ room, onStatusChange, disabled }: StatusChangeDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [changing, setChanging] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const transitions = STATUS_TRANSITIONS[room.status] || [];
+  const statusConfig = ROOM_STATUS_CONFIG[room.status] || {
+    label: room.status,
+    color: 'text-gray-700',
+    bgColor: 'bg-gray-100',
+    icon: null,
+  };
+
+  // 外部クリックで閉じる
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleChange = async (newStatus: string) => {
+    setChanging(true);
+    try {
+      await onStatusChange(room.id, newStatus);
+    } finally {
+      setChanging(false);
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => transitions.length > 0 && !disabled && setIsOpen(!isOpen)}
+        disabled={disabled || transitions.length === 0 || changing}
+        className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${statusConfig.bgColor} ${statusConfig.color} ${
+          transitions.length > 0 && !disabled ? 'cursor-pointer hover:opacity-80' : 'cursor-default'
+        }`}
+      >
+        {statusConfig.icon}
+        {statusConfig.label}
+        {transitions.length > 0 && !disabled && (
+          <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+        )}
+      </button>
+
+      {isOpen && transitions.length > 0 && (
+        <div className="absolute top-full left-0 mt-1 bg-white border rounded-lg shadow-lg z-10 min-w-[160px]">
+          {transitions.map((t) => (
+            <button
+              key={t.value}
+              onClick={() => handleChange(t.value)}
+              disabled={changing}
+              className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 first:rounded-t-lg last:rounded-b-lg"
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ===== メインコンポーネント =====
 
 export default function VacancyPage() {
   const { user, firebaseUser } = useAuth();
   const [metrics, setMetrics] = useState<VacancyMetrics | null>(null);
+  const [rooms, setRooms] = useState<RoomData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
+  // 表示モード
+  const [viewMode, setViewMode] = useState<ViewMode>('summary');
+
   // フィルタ
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [buildingFilter, setBuildingFilter] = useState<string>('all');
   const [showLockedRooms, setShowLockedRooms] = useState(true);
+
+  // モーダル
+  const [showAddRoomModal, setShowAddRoomModal] = useState(false);
 
   // デバッグモード
   const [debugMode, setDebugMode] = useState(false);
 
   // 自動更新タイマー
   const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const AUTO_REFRESH_INTERVAL = 60000; // 60秒
+  const AUTO_REFRESH_INTERVAL = 60000;
 
   const isAdmin = hasMinRole(user?.role, 'admin');
+  const isLeader = hasMinRole(user?.role, 'leader');
+
+  // 建物リスト
+  const buildings = Array.from(new Set(rooms.map((r) => r.buildingName))).sort((a, b) =>
+    a.localeCompare(b, 'ja')
+  );
 
   // APIからデータ取得
-  const fetchMetrics = useCallback(async (showLoadingState = true) => {
+  const fetchData = useCallback(async (showLoadingState = true) => {
     if (!firebaseUser) return;
 
     if (showLoadingState) {
@@ -170,32 +442,39 @@ export default function VacancyPage() {
     try {
       const token = await firebaseUser.getIdToken();
 
-      const url = debugMode
-        ? '/api/vacancy/metrics?debug=1'
-        : '/api/vacancy/metrics';
+      // メトリクスと部屋一覧を並列取得
+      const [metricsRes, roomsRes] = await Promise.all([
+        fetch(debugMode ? '/api/vacancy/metrics?debug=1' : '/api/vacancy/metrics', {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
+        }),
+        fetch('/api/rooms', {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: 'no-store',
+        }),
+      ]);
 
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        cache: 'no-store',
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `HTTP ${response.status}`);
+      if (!metricsRes.ok) {
+        const errorData = await metricsRes.json().catch(() => ({}));
+        throw new Error(errorData.error || `HTTP ${metricsRes.status}`);
       }
 
-      const data: VacancyMetrics = await response.json();
+      const metricsData: VacancyMetrics = await metricsRes.json();
+      if (!metricsData.success) {
+        throw new Error('メトリクス取得に失敗しました');
+      }
+      setMetrics(metricsData);
 
-      if (!data.success) {
-        throw new Error('データ取得に失敗しました');
+      if (roomsRes.ok) {
+        const roomsData = await roomsRes.json();
+        if (roomsData.success) {
+          setRooms(roomsData.rooms || []);
+        }
       }
 
-      setMetrics(data);
       setLastUpdated(new Date());
     } catch (err) {
-      console.error('Vacancy metrics fetch error:', err);
+      console.error('Data fetch error:', err);
       setError(err instanceof Error ? err.message : 'データの取得に失敗しました');
     } finally {
       setLoading(false);
@@ -205,13 +484,13 @@ export default function VacancyPage() {
 
   // 初回ロード & デバッグモード変更時
   useEffect(() => {
-    fetchMetrics();
-  }, [fetchMetrics]);
+    fetchData();
+  }, [fetchData]);
 
   // 自動更新
   useEffect(() => {
     timerRef.current = setInterval(() => {
-      fetchMetrics(false);
+      fetchData(false);
     }, AUTO_REFRESH_INTERVAL);
 
     return () => {
@@ -219,7 +498,7 @@ export default function VacancyPage() {
         clearInterval(timerRef.current);
       }
     };
-  }, [fetchMetrics]);
+  }, [fetchData]);
 
   // URLパラメータからデバッグモード検出
   useEffect(() => {
@@ -233,7 +512,53 @@ export default function VacancyPage() {
 
   // 手動更新
   const handleRefresh = () => {
-    fetchMetrics(true);
+    fetchData(true);
+  };
+
+  // 部屋追加
+  const handleAddRoom = async (data: { buildingName: string; roomNumber: string; capacity: number }) => {
+    if (!firebaseUser) throw new Error('認証が必要です');
+
+    const token = await firebaseUser.getIdToken();
+    const res = await fetch('/api/rooms', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    });
+
+    const result = await res.json();
+    if (!res.ok || !result.success) {
+      throw new Error(result.error || '追加に失敗しました');
+    }
+
+    // データを再取得
+    await fetchData(false);
+  };
+
+  // 状態変更
+  const handleStatusChange = async (roomId: string, newStatus: string) => {
+    if (!firebaseUser) throw new Error('認証が必要です');
+
+    const token = await firebaseUser.getIdToken();
+    const res = await fetch(`/api/rooms/${roomId}/status`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status: newStatus }),
+    });
+
+    const result = await res.json();
+    if (!res.ok || !result.success) {
+      throw new Error(result.error || '状態変更に失敗しました');
+    }
+
+    // データを再取得
+    await fetchData(false);
   };
 
   // フィルタされた施設リスト
@@ -254,6 +579,27 @@ export default function VacancyPage() {
     }
   }) || [];
 
+  // フィルタされた部屋リスト
+  const filteredRooms = rooms.filter((r) => {
+    // 建物フィルター
+    if (buildingFilter !== 'all' && r.buildingName !== buildingFilter) {
+      return false;
+    }
+    // ステータスフィルター
+    switch (statusFilter) {
+      case 'available':
+        return r.status === '空室';
+      case 'locked':
+        return r.status === '予約';
+      case 'occupied':
+        return r.status === '入居中' || r.status === '退去予定';
+      case 'maintenance':
+        return r.status === 'メンテナンス';
+      default:
+        return true;
+    }
+  });
+
   // 低稼働施設
   const lowOccupancyFacilities = metrics?.facilities.filter(
     (f) => f.occupancyRate !== null && f.occupancyRate < 70
@@ -268,7 +614,7 @@ export default function VacancyPage() {
       <div className="min-h-screen bg-gray-50">
         <Header />
 
-        <main className="max-w-4xl mx-auto px-4 py-6">
+        <main className="max-w-6xl mx-auto px-4 py-6">
           {/* ヘッダー */}
           <div className="flex items-center justify-between mb-6">
             <div>
@@ -283,15 +629,27 @@ export default function VacancyPage() {
                 </p>
               )}
             </div>
-            <Button
-              variant="secondary"
-              onClick={handleRefresh}
-              disabled={refreshing}
-              className="flex items-center gap-2"
-            >
-              <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-              更新
-            </Button>
+            <div className="flex items-center gap-2">
+              {isAdmin && (
+                <Button
+                  variant="primary"
+                  onClick={() => setShowAddRoomModal(true)}
+                  className="flex items-center gap-2"
+                >
+                  <Plus className="w-4 h-4" />
+                  部屋を追加
+                </Button>
+              )}
+              <Button
+                variant="secondary"
+                onClick={handleRefresh}
+                disabled={refreshing}
+                className="flex items-center gap-2"
+              >
+                <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+                更新
+              </Button>
+            </div>
           </div>
 
           {/* エラーバナー */}
@@ -303,11 +661,7 @@ export default function VacancyPage() {
                   <p className="font-medium text-red-800">データ取得エラー</p>
                   <p className="text-sm text-red-700 mt-1">{error}</p>
                 </div>
-                <Button
-                  variant="secondary"
-                  onClick={handleRefresh}
-                  className="text-sm"
-                >
+                <Button variant="secondary" onClick={handleRefresh} className="text-sm">
                   再試行
                 </Button>
               </div>
@@ -333,7 +687,7 @@ export default function VacancyPage() {
 
           {/* サマリーカード */}
           {metrics && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
               {/* 全体稼働率 */}
               <Card className={`p-4 ${getOccupancyColor(metrics.summary.occupancyRate).bg} border ${getOccupancyColor(metrics.summary.occupancyRate).border}`}>
                 <div className="flex items-center gap-2 mb-2">
@@ -394,18 +748,72 @@ export default function VacancyPage() {
                 </div>
                 <p className="text-xs text-gray-500 mt-1">/ {displayCount(metrics.summary.totalRooms)}室</p>
               </Card>
+
+              {/* 修繕中 */}
+              <Card className="p-4 bg-yellow-50 border border-yellow-200">
+                <div className="flex items-center gap-2 mb-2">
+                  <Wrench className="w-4 h-4 text-yellow-600" />
+                  <span className="text-xs font-medium text-gray-600">修繕中</span>
+                </div>
+                <div className="flex items-baseline gap-1">
+                  <span className="text-2xl font-bold text-yellow-600">
+                    {displayCount(metrics.summary.maintenance)}
+                  </span>
+                  <span className="text-gray-500 text-sm">室</span>
+                </div>
+              </Card>
             </div>
           )}
+
+          {/* 表示モード切替 */}
+          <div className="flex items-center gap-4 mb-4">
+            <div className="flex rounded-lg border overflow-hidden">
+              <button
+                onClick={() => setViewMode('summary')}
+                className={`px-4 py-2 text-sm font-medium ${
+                  viewMode === 'summary'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                施設サマリー
+              </button>
+              <button
+                onClick={() => setViewMode('rooms')}
+                className={`px-4 py-2 text-sm font-medium ${
+                  viewMode === 'rooms'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                部屋一覧
+              </button>
+            </div>
+
+            {/* 建物フィルター（部屋一覧モード時のみ） */}
+            {viewMode === 'rooms' && buildings.length > 0 && (
+              <select
+                value={buildingFilter}
+                onChange={(e) => setBuildingFilter(e.target.value)}
+                className="border rounded-lg px-3 py-2 text-sm"
+              >
+                <option value="all">全建物</option>
+                {buildings.map((b) => (
+                  <option key={b} value={b}>{b}</option>
+                ))}
+              </select>
+            )}
+          </div>
 
           {/* フィルタチップ */}
           <div className="flex items-center gap-2 mb-4 flex-wrap">
             <Filter className="w-4 h-4 text-gray-400" />
             {[
-              { key: 'all', label: '全て', count: metrics?.facilities.length },
-              { key: 'available', label: '空室あり', count: metrics?.facilities.filter(f => f.available > 0).length },
-              { key: 'locked', label: 'ロックあり', count: metrics?.facilities.filter(f => f.locked > 0).length },
-              { key: 'maintenance', label: '修繕中', count: metrics?.facilities.filter(f => f.maintenance > 0).length },
-              { key: 'lowOccupancy', label: '低稼働', count: lowOccupancyFacilities.length },
+              { key: 'all', label: '全て', count: viewMode === 'summary' ? metrics?.facilities.length : rooms.length },
+              { key: 'available', label: '空室', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.available > 0).length : rooms.filter(r => r.status === '空室').length },
+              { key: 'locked', label: 'ロック', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.locked > 0).length : rooms.filter(r => r.status === '予約').length },
+              { key: 'occupied', label: '入居中', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.occupied > 0).length : rooms.filter(r => r.status === '入居中' || r.status === '退去予定').length },
+              { key: 'maintenance', label: '修繕中', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.maintenance > 0).length : rooms.filter(r => r.status === 'メンテナンス').length },
             ].map((chip) => (
               <button
                 key={chip.key}
@@ -425,7 +833,7 @@ export default function VacancyPage() {
           </div>
 
           {/* 低稼働アラート */}
-          {lowOccupancyFacilities.length > 0 && statusFilter === 'all' && (
+          {viewMode === 'summary' && lowOccupancyFacilities.length > 0 && statusFilter === 'all' && (
             <Card className="p-4 mb-6 bg-red-50 border border-red-200">
               <div className="flex items-start gap-3">
                 <AlertTriangle className="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
@@ -439,8 +847,8 @@ export default function VacancyPage() {
             </Card>
           )}
 
-          {/* ロック済み部屋 */}
-          {metrics && metrics.lockedRooms.length > 0 && (
+          {/* ロック済み部屋（サマリーモード） */}
+          {viewMode === 'summary' && metrics && metrics.lockedRooms.length > 0 && (
             <Card className="mb-6 border border-purple-200">
               <button
                 onClick={() => setShowLockedRooms(!showLockedRooms)}
@@ -500,109 +908,185 @@ export default function VacancyPage() {
             </Card>
           )}
 
-          {/* 施設一覧テーブル */}
-          <Card className="overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="bg-gray-50 border-b">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      施設
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      稼働率
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      <Home className="w-3 h-3 inline mr-1" />空室
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      <Lock className="w-3 h-3 inline mr-1" />ロック
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      <Building2 className="w-3 h-3 inline mr-1" />入居
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      <Wrench className="w-3 h-3 inline mr-1" />修繕
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {filteredFacilities.length === 0 ? (
+          {/* 施設一覧テーブル（サマリーモード） */}
+          {viewMode === 'summary' && (
+            <Card className="overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-gray-50 border-b">
                     <tr>
-                      <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
-                        {statusFilter === 'all' ? '施設データがありません' : '該当する施設がありません'}
-                      </td>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        施設
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        稼働率
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <Home className="w-3 h-3 inline mr-1" />空室
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <Lock className="w-3 h-3 inline mr-1" />ロック
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <Building2 className="w-3 h-3 inline mr-1" />入居
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <Wrench className="w-3 h-3 inline mr-1" />修繕
+                      </th>
                     </tr>
-                  ) : (
-                    filteredFacilities.map((facility) => {
-                      const colors = getOccupancyColor(facility.occupancyRate);
-                      return (
-                        <tr key={facility.id} className="hover:bg-gray-50">
-                          <td className="px-4 py-4">
-                            <div className="font-medium text-gray-900">{facility.name}</div>
-                            {facility.area && (
-                              <div className="text-xs text-gray-500">{facility.area}</div>
-                            )}
-                            {facility.lastUpdated && (
-                              <div className="text-xs text-gray-400 mt-1">
-                                更新: {formatTime(facility.lastUpdated)}
-                                {facility.lastUpdatedBy && ` (${facility.lastUpdatedBy})`}
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {filteredFacilities.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
+                          {statusFilter === 'all' ? '施設データがありません' : '該当する施設がありません'}
+                        </td>
+                      </tr>
+                    ) : (
+                      filteredFacilities.map((facility) => {
+                        const colors = getOccupancyColor(facility.occupancyRate);
+                        return (
+                          <tr key={facility.id} className="hover:bg-gray-50">
+                            <td className="px-4 py-4">
+                              <div className="font-medium text-gray-900">{facility.name}</div>
+                              {facility.area && (
+                                <div className="text-xs text-gray-500">{facility.area}</div>
+                              )}
+                              {facility.lastUpdated && (
+                                <div className="text-xs text-gray-400 mt-1">
+                                  更新: {formatTime(facility.lastUpdated)}
+                                  {facility.lastUpdatedBy && ` (${facility.lastUpdatedBy})`}
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-4 py-4 text-center">
+                              <div className="flex flex-col items-center gap-1">
+                                <span className={`text-lg font-bold ${colors.text}`}>
+                                  {displayRate(facility.occupancyRate)}
+                                </span>
+                                <div className="w-16">
+                                  <OccupancyBar rate={facility.occupancyRate} />
+                                </div>
                               </div>
-                            )}
-                          </td>
-                          <td className="px-4 py-4 text-center">
-                            <div className="flex flex-col items-center gap-1">
-                              <span className={`text-lg font-bold ${colors.text}`}>
-                                {displayRate(facility.occupancyRate)}
+                            </td>
+                            <td className="px-4 py-4 text-center">
+                              {facility.available > 0 ? (
+                                <Badge variant="info" className="min-w-[2rem]">
+                                  {facility.available}
+                                </Badge>
+                              ) : (
+                                <span className="text-gray-400">-</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-4 text-center">
+                              {facility.locked > 0 ? (
+                                <Badge variant="default" className="min-w-[2rem]">
+                                  {facility.locked}
+                                </Badge>
+                              ) : (
+                                <span className="text-gray-400">-</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-4 text-center">
+                              <span className="font-medium text-gray-700">
+                                {facility.occupied}
                               </span>
-                              <div className="w-16">
-                                <OccupancyBar rate={facility.occupancyRate} />
-                              </div>
-                            </div>
+                              <span className="text-gray-400 text-xs ml-1">
+                                /{facility.capacity || (facility.available + facility.locked + facility.occupied + facility.maintenance)}
+                              </span>
+                            </td>
+                            <td className="px-4 py-4 text-center">
+                              {facility.maintenance > 0 ? (
+                                <Badge variant="warning" className="min-w-[2rem]">
+                                  {facility.maintenance}
+                                </Badge>
+                              ) : (
+                                <span className="text-gray-400">-</span>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+
+          {/* 部屋一覧テーブル（部屋モード） */}
+          {viewMode === 'rooms' && (
+            <Card className="overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-gray-50 border-b">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        建物
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        部屋番号
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        状態
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        ロック/入居者
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        備考
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {filteredRooms.length === 0 ? (
+                      <tr>
+                        <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
+                          {rooms.length === 0 ? '部屋データがありません' : '該当する部屋がありません'}
+                        </td>
+                      </tr>
+                    ) : (
+                      filteredRooms.map((room) => (
+                        <tr key={room.id} className="hover:bg-gray-50">
+                          <td className="px-4 py-3 font-medium text-gray-900">
+                            {room.buildingName}
                           </td>
-                          <td className="px-4 py-4 text-center">
-                            {facility.available > 0 ? (
-                              <Badge variant="info" className="min-w-[2rem]">
-                                {facility.available}
-                              </Badge>
-                            ) : (
-                              <span className="text-gray-400">-</span>
+                          <td className="px-4 py-3 text-gray-700">
+                            {room.roomNumber}
+                          </td>
+                          <td className="px-4 py-3 text-center">
+                            <StatusChangeDropdown
+                              room={room}
+                              onStatusChange={handleStatusChange}
+                              disabled={!isLeader}
+                            />
+                          </td>
+                          <td className="px-4 py-3 text-sm text-gray-600">
+                            {room.status === '予約' && room.lockedCaseId && (
+                              <Link
+                                href={`/dashboard/prospects/${room.lockedCaseId}`}
+                                className="text-purple-600 hover:underline"
+                              >
+                                {room.lockedByName || '申込中'}
+                              </Link>
                             )}
-                          </td>
-                          <td className="px-4 py-4 text-center">
-                            {facility.locked > 0 ? (
-                              <Badge variant="default" className="min-w-[2rem]">
-                                {facility.locked}
-                              </Badge>
-                            ) : (
-                              <span className="text-gray-400">-</span>
+                            {(room.status === '入居中' || room.status === '退去予定') && room.occupantName && (
+                              <span>{room.occupantName}</span>
                             )}
+                            {room.status === '空室' && '-'}
+                            {room.status === 'メンテナンス' && '-'}
                           </td>
-                          <td className="px-4 py-4 text-center">
-                            <span className="font-medium text-gray-700">
-                              {facility.occupied}
-                            </span>
-                            <span className="text-gray-400 text-xs ml-1">
-                              /{facility.capacity || (facility.available + facility.locked + facility.occupied + facility.maintenance)}
-                            </span>
-                          </td>
-                          <td className="px-4 py-4 text-center">
-                            {facility.maintenance > 0 ? (
-                              <Badge variant="warning" className="min-w-[2rem]">
-                                {facility.maintenance}
-                              </Badge>
-                            ) : (
-                              <span className="text-gray-400">-</span>
-                            )}
+                          <td className="px-4 py-3 text-sm text-gray-500">
+                            {room.note || '-'}
                           </td>
                         </tr>
-                      );
-                    })
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </Card>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
 
           {/* デバッグパネル */}
           {debugMode && metrics?.debug && (
@@ -651,6 +1135,14 @@ export default function VacancyPage() {
             )}
           </div>
         </main>
+
+        {/* 部屋追加モーダル */}
+        <AddRoomModal
+          isOpen={showAddRoomModal}
+          onClose={() => setShowAddRoomModal(false)}
+          onSubmit={handleAddRoom}
+          buildings={buildings}
+        />
       </div>
     </AuthGuard>
   );

--- a/src/lib/prospect.ts
+++ b/src/lib/prospect.ts
@@ -833,6 +833,7 @@ export async function createRoom(
     tenantId,
     buildingName: data.buildingName,
     roomNumber: data.roomNumber,
+    capacity: data.capacity ?? 1,
     status: data.status || '空室',
     expectedCareLevel: data.expectedCareLevel || null,
     note: data.note || null,

--- a/src/types/prospect.ts
+++ b/src/types/prospect.ts
@@ -237,6 +237,7 @@ export interface Room {
   tenantId: string;
   buildingName: string;         // 建物名
   roomNumber: string;           // 部屋番号
+  capacity?: number;            // 定員（1 or 2人部屋など）
   status: RoomStatus;
   expectedCareLevel?: string;   // 入居想定介護度数
   note?: string;                // 備考
@@ -245,6 +246,9 @@ export interface Room {
   lockedAt?: Date;              // ロック日時
   lockedBy?: string;            // ロックしたユーザーID
   lockedByName?: string;        // ロックしたユーザー名
+  // 入居者関連
+  occupantId?: string;          // 入居者ID
+  occupantName?: string;        // 入居者名
   createdAt: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
- POST /api/rooms: 部屋追加API（adminのみ）
- PATCH /api/rooms/:id/status: 状態変更API（leaderのみ）
- /dashboard/vacancy: 施設サマリー/部屋一覧の2モード表示
- 部屋追加モーダル（建物・部屋番号・定員）
- 状態変更ドロップダウン（空室↔修繕中, 入居中→退去等）
- Room型にcapacity, occupantId, occupantNameフィールド追加

権限:
- 部屋追加: admin以上
- 状態変更: leader以上
- 閲覧: 全員
- 予約(LOCKED)は申込連動で自動設定、手動不可

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
