### PR TITLE
feat: 空室管理を施設カード一覧+ドロワーUIに全面改修

### DIFF
--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -1,0 +1,167 @@
+// ======== 施設マスタAPI ========
+import { NextRequest, NextResponse } from 'next/server';
+import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
+import { hasMinRole } from '@/lib/auth';
+import { Timestamp } from 'firebase-admin/firestore';
+
+const DEFAULT_TENANT_ID = 'defaultTenant';
+
+/**
+ * GET /api/facilities
+ * 施設一覧を取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    const db = getAdminDb();
+    const snapshot = await db
+      .collection('facilities')
+      .where('tenantId', '==', DEFAULT_TENANT_ID)
+      .get();
+
+    const facilities = snapshot.docs
+      .map((doc) => {
+        const data = doc.data();
+        return {
+          id: doc.id,
+          name: data.name,
+          address: data.address || null,
+          area: data.area || null,
+          capacity: data.capacity || null,
+          note: data.note || null,
+          isActive: data.isActive !== false,
+          tenantId: data.tenantId,
+          createdAt: data.createdAt?.toDate?.()?.toISOString() || null,
+          updatedAt: data.updatedAt?.toDate?.()?.toISOString() || null,
+        };
+      })
+      .filter((f) => f.isActive)
+      .sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+
+    return NextResponse.json({
+      success: true,
+      facilities,
+      count: facilities.length,
+    });
+  } catch (error) {
+    console.error('Failed to fetch facilities:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/facilities
+ * 施設を追加（admin のみ）
+ * Body:
+ *   - name: 施設名（必須）
+ *   - address: 住所（任意）
+ *   - area: エリア（任意）
+ *   - capacity: 定員（任意）
+ *   - note: 備考（任意）
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authHeader = request.headers.get('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const idToken = authHeader.substring(7);
+    const decodedToken = await verifyIdToken(idToken);
+    if (!decodedToken) {
+      return NextResponse.json({ error: '無効なトークンです' }, { status: 401 });
+    }
+
+    // ユーザー情報取得・権限チェック
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(decodedToken.uid).get();
+    const userData = userDoc.data();
+    const userRole = userData?.role || 'user';
+
+    // admin のみ
+    if (!hasMinRole(userRole, 'admin')) {
+      return NextResponse.json(
+        { error: '施設の追加には admin 以上の権限が必要です' },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { name, address, area, capacity, note } = body;
+
+    // バリデーション
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      return NextResponse.json(
+        { error: '施設名は必須です' },
+        { status: 400 }
+      );
+    }
+
+    // 重複チェック
+    const existingQuery = await db
+      .collection('facilities')
+      .where('tenantId', '==', DEFAULT_TENANT_ID)
+      .where('name', '==', name.trim())
+      .get();
+
+    if (!existingQuery.empty) {
+      return NextResponse.json(
+        { error: `施設「${name}」は既に登録されています` },
+        { status: 409 }
+      );
+    }
+
+    // 施設を作成
+    const facilityData = {
+      tenantId: DEFAULT_TENANT_ID,
+      name: name.trim(),
+      address: address?.trim() || null,
+      area: area?.trim() || null,
+      capacity: capacity ? Number(capacity) : null,
+      note: note?.trim() || null,
+      isActive: true,
+      createdAt: Timestamp.now(),
+      createdBy: decodedToken.uid,
+      createdByName: userData?.displayName || decodedToken.email || 'Unknown',
+    };
+
+    const docRef = await db.collection('facilities').add(facilityData);
+
+    return NextResponse.json({
+      success: true,
+      message: `施設「${name}」を追加しました`,
+      facility: {
+        id: docRef.id,
+        ...facilityData,
+        createdAt: new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to create facility:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -16,76 +16,30 @@ import {
   Lock,
   Home,
   Wrench,
-  HelpCircle,
   ChevronDown,
   ChevronUp,
   AlertCircle,
-  Filter,
   Plus,
   X,
   Users,
   DoorOpen,
+  MapPin,
+  ChevronRight,
 } from 'lucide-react';
 import Link from 'next/link';
 
 // ===== 型定義 =====
 
-interface FacilityMetrics {
+interface FacilityData {
   id: string;
   name: string;
-  area: string;
-  capacity: number;
-  available: number;
-  locked: number;
-  occupied: number;
-  maintenance: number;
-  unknown: number;
-  occupancyRate: number | null;
-  vacancyRate: number | null;
-  lastUpdated: string | null;
-  lastUpdatedBy: string | null;
+  address: string | null;
+  area: string | null;
+  capacity: number | null;
+  note: string | null;
+  isActive: boolean;
 }
 
-interface LockedRoom {
-  id: string;
-  buildingName: string;
-  roomNumber: string;
-  lockedCaseId: string | null;
-  lockedByName: string | null;
-  lockedAt: string | null;
-}
-
-interface Warning {
-  label: string;
-  code: string;
-  message: string;
-}
-
-interface VacancyMetrics {
-  success: boolean;
-  summary: {
-    totalRooms: number;
-    available: number;
-    locked: number;
-    occupied: number;
-    maintenance: number;
-    unknown: number;
-    occupancyRate: number | null;
-    vacancyRate: number | null;
-  };
-  facilities: FacilityMetrics[];
-  lockedRooms: LockedRoom[];
-  updatedAt: string;
-  warnings: Warning[];
-  debug?: {
-    roomsQueried: number;
-    facilitiesQueried: number;
-    unknownStatuses: string[];
-    rawStatusCounts: Record<string, number>;
-  };
-}
-
-// 部屋データ型
 interface RoomData {
   id: string;
   buildingName: string;
@@ -98,13 +52,18 @@ interface RoomData {
   lockedAt: string | null;
   occupantId: string | null;
   occupantName: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
 }
 
-// ===== フィルタタイプ =====
-type StatusFilter = 'all' | 'available' | 'locked' | 'occupied' | 'maintenance' | 'lowOccupancy';
-type ViewMode = 'summary' | 'rooms';
+interface FacilitySummary {
+  facilityId: string;
+  facilityName: string;
+  totalRooms: number;
+  available: number;
+  locked: number;
+  occupied: number;
+  maintenance: number;
+  occupancyRate: number | null;
+}
 
 // ===== ステータス設定 =====
 const ROOM_STATUS_CONFIG: Record<string, { label: string; color: string; bgColor: string; icon: React.ReactNode }> = {
@@ -137,38 +96,12 @@ const STATUS_TRANSITIONS: Record<string, { value: string; label: string }[]> = {
 
 // ===== ユーティリティ =====
 
-function displayRate(rate: number | null): string {
-  if (rate === null || rate === undefined) return '--';
-  return `${rate}%`;
-}
-
-function displayCount(count: number | null): string {
-  if (count === null || count === undefined) return '--';
-  return count.toString();
-}
-
-function getOccupancyColor(rate: number | null): { bg: string; text: string; border: string } {
-  if (rate === null) return { bg: 'bg-gray-50', text: 'text-gray-500', border: 'border-gray-200' };
-  if (rate >= 95) return { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200' };
-  if (rate >= 85) return { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200' };
-  if (rate >= 70) return { bg: 'bg-yellow-50', text: 'text-yellow-700', border: 'border-yellow-200' };
-  return { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' };
-}
-
-function OccupancyBar({ rate }: { rate: number | null }) {
-  if (rate === null) {
-    return (
-      <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
-        <div className="h-full bg-gray-300 w-0" />
-      </div>
-    );
-  }
-  const color = rate >= 95 ? 'bg-green-500' : rate >= 85 ? 'bg-blue-500' : rate >= 70 ? 'bg-yellow-500' : 'bg-red-500';
-  return (
-    <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
-      <div className={`h-full ${color} transition-all`} style={{ width: `${rate}%` }} />
-    </div>
-  );
+function getOccupancyColor(rate: number | null): string {
+  if (rate === null) return 'text-gray-500';
+  if (rate >= 95) return 'text-green-600';
+  if (rate >= 85) return 'text-blue-600';
+  if (rate >= 70) return 'text-yellow-600';
+  return 'text-red-600';
 }
 
 function formatTime(dateStr: string | null): string {
@@ -182,17 +115,134 @@ function formatTime(dateStr: string | null): string {
   });
 }
 
+// ===== 施設追加モーダル =====
+
+interface AddFacilityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: { name: string; address?: string; note?: string }) => Promise<void>;
+}
+
+function AddFacilityModal({ isOpen, onClose, onSubmit }: AddFacilityModalProps) {
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await onSubmit({ name, address: address || undefined, note: note || undefined });
+      setName('');
+      setAddress('');
+      setNote('');
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '追加に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Building2 className="w-5 h-5" />
+            施設を追加
+          </h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              施設名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="例: パシフィック"
+              className="w-full border rounded-lg px-3 py-2"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              住所
+            </label>
+            <input
+              type="text"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="例: 東京都..."
+              className="w-full border rounded-lg px-3 py-2"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              備考
+            </label>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="メモ..."
+              className="w-full border rounded-lg px-3 py-2 h-20 resize-none"
+            />
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              className="flex-1"
+              disabled={submitting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1"
+              disabled={submitting || !name.trim()}
+            >
+              {submitting ? '追加中...' : '追加'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 // ===== 部屋追加モーダル =====
 
 interface AddRoomModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (data: { buildingName: string; roomNumber: string; capacity: number }) => Promise<void>;
-  buildings: string[];
+  facilityName: string;
 }
 
-function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProps) {
-  const [buildingName, setBuildingName] = useState('');
+function AddRoomModal({ isOpen, onClose, onSubmit, facilityName }: AddRoomModalProps) {
   const [roomNumber, setRoomNumber] = useState('');
   const [capacity, setCapacity] = useState(1);
   const [submitting, setSubmitting] = useState(false);
@@ -204,8 +254,7 @@ function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProp
     setSubmitting(true);
 
     try {
-      await onSubmit({ buildingName, roomNumber, capacity });
-      setBuildingName('');
+      await onSubmit({ buildingName: facilityName, roomNumber, capacity });
       setRoomNumber('');
       setCapacity(1);
       onClose();
@@ -224,7 +273,7 @@ function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProp
         <div className="flex items-center justify-between p-4 border-b">
           <h2 className="text-lg font-semibold flex items-center gap-2">
             <Plus className="w-5 h-5" />
-            部屋を追加
+            {facilityName} に部屋を追加
           </h2>
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
             <X className="w-5 h-5" />
@@ -237,33 +286,6 @@ function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProp
               {error}
             </div>
           )}
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              建物 <span className="text-red-500">*</span>
-            </label>
-            <select
-              value={buildingName}
-              onChange={(e) => setBuildingName(e.target.value)}
-              className="w-full border rounded-lg px-3 py-2"
-              required
-            >
-              <option value="">選択してください</option>
-              {buildings.map((b) => (
-                <option key={b} value={b}>{b}</option>
-              ))}
-              <option value="__other__">その他（新規建物）</option>
-            </select>
-            {buildingName === '__other__' && (
-              <input
-                type="text"
-                placeholder="建物名を入力"
-                className="w-full border rounded-lg px-3 py-2 mt-2"
-                onChange={(e) => setBuildingName(e.target.value)}
-                required
-              />
-            )}
-          </div>
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -306,7 +328,7 @@ function AddRoomModal({ isOpen, onClose, onSubmit, buildings }: AddRoomModalProp
             <Button
               type="submit"
               className="flex-1"
-              disabled={submitting || !buildingName || !roomNumber}
+              disabled={submitting || !roomNumber.trim()}
             >
               {submitting ? '追加中...' : '追加'}
             </Button>
@@ -338,7 +360,6 @@ function StatusChangeDropdown({ room, onStatusChange, disabled }: StatusChangeDr
     icon: null,
   };
 
-  // 外部クリックで閉じる
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -393,30 +414,254 @@ function StatusChangeDropdown({ room, onStatusChange, disabled }: StatusChangeDr
   );
 }
 
+// ===== 施設詳細ドロワー =====
+
+interface FacilityDrawerProps {
+  facility: FacilityData | null;
+  rooms: RoomData[];
+  isOpen: boolean;
+  onClose: () => void;
+  onAddRoom: () => void;
+  onStatusChange: (roomId: string, newStatus: string) => Promise<void>;
+  canAddRoom: boolean;
+  canChangeStatus: boolean;
+}
+
+function FacilityDrawer({
+  facility,
+  rooms,
+  isOpen,
+  onClose,
+  onAddRoom,
+  onStatusChange,
+  canAddRoom,
+  canChangeStatus,
+}: FacilityDrawerProps) {
+  if (!isOpen || !facility) return null;
+
+  const facilityRooms = rooms.filter((r) => r.buildingName === facility.name);
+  const summary = {
+    total: facilityRooms.length,
+    available: facilityRooms.filter((r) => r.status === '空室').length,
+    locked: facilityRooms.filter((r) => r.status === '予約').length,
+    occupied: facilityRooms.filter((r) => r.status === '入居中' || r.status === '退去予定').length,
+    maintenance: facilityRooms.filter((r) => r.status === 'メンテナンス').length,
+  };
+
+  return (
+    <>
+      {/* オーバーレイ */}
+      <div
+        className="fixed inset-0 bg-black/30 z-40"
+        onClick={onClose}
+      />
+
+      {/* ドロワー */}
+      <div className="fixed inset-y-0 right-0 w-full max-w-lg bg-white shadow-xl z-50 flex flex-col">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between p-4 border-b bg-gray-50">
+          <div>
+            <h2 className="text-lg font-bold flex items-center gap-2">
+              <Building2 className="w-5 h-5" />
+              {facility.name}
+            </h2>
+            {facility.address && (
+              <p className="text-sm text-gray-500 flex items-center gap-1 mt-1">
+                <MapPin className="w-3 h-3" />
+                {facility.address}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* サマリー */}
+        <div className="grid grid-cols-4 gap-2 p-4 bg-gray-50 border-b">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600">{summary.available}</div>
+            <div className="text-xs text-gray-500">空室</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-purple-600">{summary.locked}</div>
+            <div className="text-xs text-gray-500">ロック</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">{summary.occupied}</div>
+            <div className="text-xs text-gray-500">入居中</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-yellow-600">{summary.maintenance}</div>
+            <div className="text-xs text-gray-500">修繕中</div>
+          </div>
+        </div>
+
+        {/* アクション */}
+        <div className="p-4 border-b">
+          {canAddRoom && (
+            <Button
+              onClick={onAddRoom}
+              className="w-full flex items-center justify-center gap-2"
+            >
+              <Plus className="w-4 h-4" />
+              部屋を追加
+            </Button>
+          )}
+        </div>
+
+        {/* 部屋一覧 */}
+        <div className="flex-1 overflow-y-auto">
+          {facilityRooms.length === 0 ? (
+            <div className="p-8 text-center text-gray-500">
+              <Home className="w-12 h-12 mx-auto mb-3 opacity-30" />
+              <p>部屋がありません</p>
+              {canAddRoom && (
+                <p className="text-sm mt-2">「部屋を追加」から登録してください</p>
+              )}
+            </div>
+          ) : (
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b sticky top-0">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">部屋番号</th>
+                  <th className="px-4 py-2 text-center text-xs font-medium text-gray-500">状態</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">入居者/ロック</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {facilityRooms.map((room) => (
+                  <tr key={room.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-medium">{room.roomNumber}</td>
+                    <td className="px-4 py-3 text-center">
+                      <StatusChangeDropdown
+                        room={room}
+                        onStatusChange={onStatusChange}
+                        disabled={!canChangeStatus}
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600">
+                      {room.status === '予約' && room.lockedCaseId && (
+                        <Link
+                          href={`/dashboard/prospects/${room.lockedCaseId}`}
+                          className="text-purple-600 hover:underline"
+                        >
+                          {room.lockedByName || '申込中'}
+                        </Link>
+                      )}
+                      {(room.status === '入居中' || room.status === '退去予定') && room.occupantName && (
+                        <span>{room.occupantName}</span>
+                      )}
+                      {room.status === '空室' && <span className="text-gray-400">-</span>}
+                      {room.status === 'メンテナンス' && <span className="text-gray-400">-</span>}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ===== 施設カード =====
+
+interface FacilityCardProps {
+  facility: FacilityData;
+  summary: FacilitySummary;
+  onClick: () => void;
+}
+
+function FacilityCard({ facility, summary, onClick }: FacilityCardProps) {
+  const occupancyRate = summary.totalRooms > 0
+    ? Math.round((summary.occupied / summary.totalRooms) * 100)
+    : null;
+
+  return (
+    <Card
+      className="p-4 hover:shadow-lg transition-shadow cursor-pointer border-l-4 border-l-blue-500"
+      onClick={onClick}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h3 className="font-bold text-lg flex items-center gap-2">
+            <Building2 className="w-5 h-5 text-blue-600" />
+            {facility.name}
+          </h3>
+          {facility.address && (
+            <p className="text-sm text-gray-500 mt-1 flex items-center gap-1">
+              <MapPin className="w-3 h-3" />
+              {facility.address}
+            </p>
+          )}
+        </div>
+        <ChevronRight className="w-5 h-5 text-gray-400" />
+      </div>
+
+      {/* サマリー数字 */}
+      <div className="grid grid-cols-4 gap-2 mb-3">
+        <div className="text-center p-2 bg-blue-50 rounded">
+          <div className="text-lg font-bold text-blue-600">{summary.available}</div>
+          <div className="text-xs text-gray-500">空室</div>
+        </div>
+        <div className="text-center p-2 bg-purple-50 rounded">
+          <div className="text-lg font-bold text-purple-600">{summary.locked}</div>
+          <div className="text-xs text-gray-500">ロック</div>
+        </div>
+        <div className="text-center p-2 bg-green-50 rounded">
+          <div className="text-lg font-bold text-green-600">{summary.occupied}</div>
+          <div className="text-xs text-gray-500">入居中</div>
+        </div>
+        <div className="text-center p-2 bg-yellow-50 rounded">
+          <div className="text-lg font-bold text-yellow-600">{summary.maintenance}</div>
+          <div className="text-xs text-gray-500">修繕</div>
+        </div>
+      </div>
+
+      {/* 稼働率バー */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className={`h-full ${
+              occupancyRate === null ? 'bg-gray-300' :
+              occupancyRate >= 95 ? 'bg-green-500' :
+              occupancyRate >= 85 ? 'bg-blue-500' :
+              occupancyRate >= 70 ? 'bg-yellow-500' : 'bg-red-500'
+            }`}
+            style={{ width: `${occupancyRate || 0}%` }}
+          />
+        </div>
+        <span className={`text-sm font-medium ${getOccupancyColor(occupancyRate)}`}>
+          {occupancyRate !== null ? `${occupancyRate}%` : '--'}
+        </span>
+      </div>
+      <p className="text-xs text-gray-400 mt-1">
+        稼働率 ({summary.occupied}/{summary.totalRooms}室)
+      </p>
+    </Card>
+  );
+}
+
 // ===== メインコンポーネント =====
 
 export default function VacancyPage() {
   const { user, firebaseUser } = useAuth();
-  const [metrics, setMetrics] = useState<VacancyMetrics | null>(null);
+  const [facilities, setFacilities] = useState<FacilityData[]>([]);
   const [rooms, setRooms] = useState<RoomData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
-  // 表示モード
-  const [viewMode, setViewMode] = useState<ViewMode>('summary');
-
-  // フィルタ
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-  const [buildingFilter, setBuildingFilter] = useState<string>('all');
-  const [showLockedRooms, setShowLockedRooms] = useState(true);
-
-  // モーダル
+  // ドロワー・モーダル
+  const [selectedFacility, setSelectedFacility] = useState<FacilityData | null>(null);
+  const [showAddFacilityModal, setShowAddFacilityModal] = useState(false);
   const [showAddRoomModal, setShowAddRoomModal] = useState(false);
-
-  // デバッグモード
-  const [debugMode, setDebugMode] = useState(false);
 
   // 自動更新タイマー
   const timerRef = useRef<NodeJS.Timeout | null>(null);
@@ -425,10 +670,35 @@ export default function VacancyPage() {
   const isAdmin = hasMinRole(user?.role, 'admin');
   const isLeader = hasMinRole(user?.role, 'leader');
 
-  // 建物リスト
-  const buildings = Array.from(new Set(rooms.map((r) => r.buildingName))).sort((a, b) =>
-    a.localeCompare(b, 'ja')
-  );
+  // 施設ごとのサマリーを計算
+  const facilitySummaries: Record<string, FacilitySummary> = {};
+  facilities.forEach((f) => {
+    const facilityRooms = rooms.filter((r) => r.buildingName === f.name);
+    const occupied = facilityRooms.filter((r) => r.status === '入居中' || r.status === '退去予定').length;
+    const total = facilityRooms.length;
+    facilitySummaries[f.id] = {
+      facilityId: f.id,
+      facilityName: f.name,
+      totalRooms: total,
+      available: facilityRooms.filter((r) => r.status === '空室').length,
+      locked: facilityRooms.filter((r) => r.status === '予約').length,
+      occupied,
+      maintenance: facilityRooms.filter((r) => r.status === 'メンテナンス').length,
+      occupancyRate: total > 0 ? Math.round((occupied / total) * 100) : null,
+    };
+  });
+
+  // 全体サマリー
+  const totalSummary = {
+    totalRooms: rooms.length,
+    available: rooms.filter((r) => r.status === '空室').length,
+    locked: rooms.filter((r) => r.status === '予約').length,
+    occupied: rooms.filter((r) => r.status === '入居中' || r.status === '退去予定').length,
+    maintenance: rooms.filter((r) => r.status === 'メンテナンス').length,
+    occupancyRate: rooms.length > 0
+      ? Math.round((rooms.filter((r) => r.status === '入居中' || r.status === '退去予定').length / rooms.length) * 100)
+      : null,
+  };
 
   // APIからデータ取得
   const fetchData = useCallback(async (showLoadingState = true) => {
@@ -442,9 +712,8 @@ export default function VacancyPage() {
     try {
       const token = await firebaseUser.getIdToken();
 
-      // メトリクスと部屋一覧を並列取得
-      const [metricsRes, roomsRes] = await Promise.all([
-        fetch(debugMode ? '/api/vacancy/metrics?debug=1' : '/api/vacancy/metrics', {
+      const [facilitiesRes, roomsRes] = await Promise.all([
+        fetch('/api/facilities', {
           headers: { Authorization: `Bearer ${token}` },
           cache: 'no-store',
         }),
@@ -454,21 +723,17 @@ export default function VacancyPage() {
         }),
       ]);
 
-      if (!metricsRes.ok) {
-        const errorData = await metricsRes.json().catch(() => ({}));
-        throw new Error(errorData.error || `HTTP ${metricsRes.status}`);
+      if (facilitiesRes.ok) {
+        const data = await facilitiesRes.json();
+        if (data.success) {
+          setFacilities(data.facilities || []);
+        }
       }
-
-      const metricsData: VacancyMetrics = await metricsRes.json();
-      if (!metricsData.success) {
-        throw new Error('メトリクス取得に失敗しました');
-      }
-      setMetrics(metricsData);
 
       if (roomsRes.ok) {
-        const roomsData = await roomsRes.json();
-        if (roomsData.success) {
-          setRooms(roomsData.rooms || []);
+        const data = await roomsRes.json();
+        if (data.success) {
+          setRooms(data.rooms || []);
         }
       }
 
@@ -480,14 +745,12 @@ export default function VacancyPage() {
       setLoading(false);
       setRefreshing(false);
     }
-  }, [firebaseUser, debugMode]);
+  }, [firebaseUser]);
 
-  // 初回ロード & デバッグモード変更時
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  // 自動更新
   useEffect(() => {
     timerRef.current = setInterval(() => {
       fetchData(false);
@@ -500,19 +763,26 @@ export default function VacancyPage() {
     };
   }, [fetchData]);
 
-  // URLパラメータからデバッグモード検出
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-      if (params.get('debug') === '1' && isAdmin) {
-        setDebugMode(true);
-      }
-    }
-  }, [isAdmin]);
+  // 施設追加
+  const handleAddFacility = async (data: { name: string; address?: string; note?: string }) => {
+    if (!firebaseUser) throw new Error('認証が必要です');
 
-  // 手動更新
-  const handleRefresh = () => {
-    fetchData(true);
+    const token = await firebaseUser.getIdToken();
+    const res = await fetch('/api/facilities', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    });
+
+    const result = await res.json();
+    if (!res.ok || !result.success) {
+      throw new Error(result.error || '追加に失敗しました');
+    }
+
+    await fetchData(false);
   };
 
   // 部屋追加
@@ -534,7 +804,6 @@ export default function VacancyPage() {
       throw new Error(result.error || '追加に失敗しました');
     }
 
-    // データを再取得
     await fetchData(false);
   };
 
@@ -557,53 +826,8 @@ export default function VacancyPage() {
       throw new Error(result.error || '状態変更に失敗しました');
     }
 
-    // データを再取得
     await fetchData(false);
   };
-
-  // フィルタされた施設リスト
-  const filteredFacilities = metrics?.facilities.filter((f) => {
-    switch (statusFilter) {
-      case 'available':
-        return f.available > 0;
-      case 'locked':
-        return f.locked > 0;
-      case 'occupied':
-        return f.occupied > 0;
-      case 'maintenance':
-        return f.maintenance > 0;
-      case 'lowOccupancy':
-        return f.occupancyRate !== null && f.occupancyRate < 70;
-      default:
-        return true;
-    }
-  }) || [];
-
-  // フィルタされた部屋リスト
-  const filteredRooms = rooms.filter((r) => {
-    // 建物フィルター
-    if (buildingFilter !== 'all' && r.buildingName !== buildingFilter) {
-      return false;
-    }
-    // ステータスフィルター
-    switch (statusFilter) {
-      case 'available':
-        return r.status === '空室';
-      case 'locked':
-        return r.status === '予約';
-      case 'occupied':
-        return r.status === '入居中' || r.status === '退去予定';
-      case 'maintenance':
-        return r.status === 'メンテナンス';
-      default:
-        return true;
-    }
-  });
-
-  // 低稼働施設
-  const lowOccupancyFacilities = metrics?.facilities.filter(
-    (f) => f.occupancyRate !== null && f.occupancyRate < 70
-  ) || [];
 
   if (loading) {
     return <Loading />;
@@ -616,33 +840,36 @@ export default function VacancyPage() {
 
         <main className="max-w-6xl mx-auto px-4 py-6">
           {/* ヘッダー */}
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
             <div>
               <h1 className="text-2xl font-bold flex items-center gap-2">
                 <Building2 className="w-6 h-6" />
-                空室・稼働状況
+                空室管理
               </h1>
+              <p className="text-sm text-gray-500 mt-1">
+                施設・部屋・状態を一元管理します
+              </p>
               {lastUpdated && (
-                <p className="text-sm text-gray-500 mt-1 flex items-center gap-1">
+                <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
                   <Clock className="w-3 h-3" />
                   最終更新: {formatTime(lastUpdated.toISOString())}
                 </p>
               )}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               {isAdmin && (
                 <Button
-                  variant="primary"
-                  onClick={() => setShowAddRoomModal(true)}
+                  variant="secondary"
+                  onClick={() => setShowAddFacilityModal(true)}
                   className="flex items-center gap-2"
                 >
                   <Plus className="w-4 h-4" />
-                  部屋を追加
+                  施設を追加
                 </Button>
               )}
               <Button
                 variant="secondary"
-                onClick={handleRefresh}
+                onClick={() => fetchData(true)}
                 disabled={refreshing}
                 className="flex items-center gap-2"
               >
@@ -661,488 +888,130 @@ export default function VacancyPage() {
                   <p className="font-medium text-red-800">データ取得エラー</p>
                   <p className="text-sm text-red-700 mt-1">{error}</p>
                 </div>
-                <Button variant="secondary" onClick={handleRefresh} className="text-sm">
+                <Button variant="secondary" onClick={() => fetchData(true)} className="text-sm">
                   再試行
                 </Button>
               </div>
             </Card>
           )}
 
-          {/* 警告バナー */}
-          {metrics?.warnings && metrics.warnings.length > 0 && (
-            <Card className="p-4 mb-6 bg-yellow-50 border border-yellow-200">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="w-5 h-5 text-yellow-600 shrink-0 mt-0.5" />
-                <div>
-                  <p className="font-medium text-yellow-800">警告</p>
-                  {metrics.warnings.map((w, i) => (
-                    <p key={i} className="text-sm text-yellow-700 mt-1">
-                      [{w.label}] {w.message}
-                    </p>
-                  ))}
-                </div>
+          {/* 全体サマリー */}
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
+            <Card className="p-4 bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
+              <div className="flex items-center gap-2 mb-1">
+                <TrendingUp className="w-4 h-4 text-blue-600" />
+                <span className="text-xs font-medium text-gray-600">稼働率</span>
+              </div>
+              <div className={`text-2xl font-bold ${getOccupancyColor(totalSummary.occupancyRate)}`}>
+                {totalSummary.occupancyRate !== null ? `${totalSummary.occupancyRate}%` : '--'}
               </div>
             </Card>
-          )}
-
-          {/* サマリーカード */}
-          {metrics && (
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
-              {/* 全体稼働率 */}
-              <Card className={`p-4 ${getOccupancyColor(metrics.summary.occupancyRate).bg} border ${getOccupancyColor(metrics.summary.occupancyRate).border}`}>
-                <div className="flex items-center gap-2 mb-2">
-                  <TrendingUp className="w-4 h-4 text-gray-600" />
-                  <span className="text-xs font-medium text-gray-600">稼働率</span>
-                </div>
-                <div className="flex items-baseline gap-1">
-                  <span className={`text-2xl font-bold ${getOccupancyColor(metrics.summary.occupancyRate).text}`}>
-                    {displayRate(metrics.summary.occupancyRate)}
-                  </span>
-                </div>
-                <div className="mt-2">
-                  <OccupancyBar rate={metrics.summary.occupancyRate} />
-                </div>
-              </Card>
-
-              {/* 空室数 */}
-              <Card className="p-4 bg-blue-50 border border-blue-200">
-                <div className="flex items-center gap-2 mb-2">
-                  <Home className="w-4 h-4 text-blue-600" />
-                  <span className="text-xs font-medium text-gray-600">空室</span>
-                </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-2xl font-bold text-blue-600">
-                    {displayCount(metrics.summary.available)}
-                  </span>
-                  <span className="text-gray-500 text-sm">室</span>
-                </div>
-                <p className="text-xs text-gray-500 mt-1">即入居可</p>
-              </Card>
-
-              {/* ロック数 */}
-              <Card className="p-4 bg-purple-50 border border-purple-200">
-                <div className="flex items-center gap-2 mb-2">
-                  <Lock className="w-4 h-4 text-purple-600" />
-                  <span className="text-xs font-medium text-gray-600">ロック</span>
-                </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-2xl font-bold text-purple-600">
-                    {displayCount(metrics.summary.locked)}
-                  </span>
-                  <span className="text-gray-500 text-sm">室</span>
-                </div>
-                <p className="text-xs text-gray-500 mt-1">申込中</p>
-              </Card>
-
-              {/* 入居中 */}
-              <Card className="p-4 bg-green-50 border border-green-200">
-                <div className="flex items-center gap-2 mb-2">
-                  <Building2 className="w-4 h-4 text-green-600" />
-                  <span className="text-xs font-medium text-gray-600">入居中</span>
-                </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-2xl font-bold text-green-600">
-                    {displayCount(metrics.summary.occupied)}
-                  </span>
-                  <span className="text-gray-500 text-sm">室</span>
-                </div>
-                <p className="text-xs text-gray-500 mt-1">/ {displayCount(metrics.summary.totalRooms)}室</p>
-              </Card>
-
-              {/* 修繕中 */}
-              <Card className="p-4 bg-yellow-50 border border-yellow-200">
-                <div className="flex items-center gap-2 mb-2">
-                  <Wrench className="w-4 h-4 text-yellow-600" />
-                  <span className="text-xs font-medium text-gray-600">修繕中</span>
-                </div>
-                <div className="flex items-baseline gap-1">
-                  <span className="text-2xl font-bold text-yellow-600">
-                    {displayCount(metrics.summary.maintenance)}
-                  </span>
-                  <span className="text-gray-500 text-sm">室</span>
-                </div>
-              </Card>
-            </div>
-          )}
-
-          {/* 表示モード切替 */}
-          <div className="flex items-center gap-4 mb-4">
-            <div className="flex rounded-lg border overflow-hidden">
-              <button
-                onClick={() => setViewMode('summary')}
-                className={`px-4 py-2 text-sm font-medium ${
-                  viewMode === 'summary'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 hover:bg-gray-50'
-                }`}
-              >
-                施設サマリー
-              </button>
-              <button
-                onClick={() => setViewMode('rooms')}
-                className={`px-4 py-2 text-sm font-medium ${
-                  viewMode === 'rooms'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 hover:bg-gray-50'
-                }`}
-              >
-                部屋一覧
-              </button>
-            </div>
-
-            {/* 建物フィルター（部屋一覧モード時のみ） */}
-            {viewMode === 'rooms' && buildings.length > 0 && (
-              <select
-                value={buildingFilter}
-                onChange={(e) => setBuildingFilter(e.target.value)}
-                className="border rounded-lg px-3 py-2 text-sm"
-              >
-                <option value="all">全建物</option>
-                {buildings.map((b) => (
-                  <option key={b} value={b}>{b}</option>
-                ))}
-              </select>
-            )}
-          </div>
-
-          {/* フィルタチップ */}
-          <div className="flex items-center gap-2 mb-4 flex-wrap">
-            <Filter className="w-4 h-4 text-gray-400" />
-            {[
-              { key: 'all', label: '全て', count: viewMode === 'summary' ? metrics?.facilities.length : rooms.length },
-              { key: 'available', label: '空室', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.available > 0).length : rooms.filter(r => r.status === '空室').length },
-              { key: 'locked', label: 'ロック', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.locked > 0).length : rooms.filter(r => r.status === '予約').length },
-              { key: 'occupied', label: '入居中', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.occupied > 0).length : rooms.filter(r => r.status === '入居中' || r.status === '退去予定').length },
-              { key: 'maintenance', label: '修繕中', count: viewMode === 'summary' ? metrics?.facilities.filter(f => f.maintenance > 0).length : rooms.filter(r => r.status === 'メンテナンス').length },
-            ].map((chip) => (
-              <button
-                key={chip.key}
-                onClick={() => setStatusFilter(chip.key as StatusFilter)}
-                className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
-                  statusFilter === chip.key
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                }`}
-              >
-                {chip.label}
-                {chip.count !== undefined && (
-                  <span className="ml-1 opacity-75">({chip.count})</span>
-                )}
-              </button>
-            ))}
-          </div>
-
-          {/* 低稼働アラート */}
-          {viewMode === 'summary' && lowOccupancyFacilities.length > 0 && statusFilter === 'all' && (
-            <Card className="p-4 mb-6 bg-red-50 border border-red-200">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
-                <div>
-                  <p className="font-medium text-red-800">入居促進が必要な施設</p>
-                  <p className="text-sm text-red-700 mt-1">
-                    {lowOccupancyFacilities.map(f => f.name).join('、')} の稼働率が70%を下回っています
-                  </p>
-                </div>
+            <Card className="p-4 bg-blue-50 border-blue-200">
+              <div className="flex items-center gap-2 mb-1">
+                <Home className="w-4 h-4 text-blue-600" />
+                <span className="text-xs font-medium text-gray-600">空室</span>
               </div>
+              <div className="text-2xl font-bold text-blue-600">{totalSummary.available}</div>
             </Card>
-          )}
+            <Card className="p-4 bg-purple-50 border-purple-200">
+              <div className="flex items-center gap-2 mb-1">
+                <Lock className="w-4 h-4 text-purple-600" />
+                <span className="text-xs font-medium text-gray-600">ロック</span>
+              </div>
+              <div className="text-2xl font-bold text-purple-600">{totalSummary.locked}</div>
+            </Card>
+            <Card className="p-4 bg-green-50 border-green-200">
+              <div className="flex items-center gap-2 mb-1">
+                <Users className="w-4 h-4 text-green-600" />
+                <span className="text-xs font-medium text-gray-600">入居中</span>
+              </div>
+              <div className="text-2xl font-bold text-green-600">{totalSummary.occupied}</div>
+            </Card>
+            <Card className="p-4 bg-yellow-50 border-yellow-200">
+              <div className="flex items-center gap-2 mb-1">
+                <Wrench className="w-4 h-4 text-yellow-600" />
+                <span className="text-xs font-medium text-gray-600">修繕中</span>
+              </div>
+              <div className="text-2xl font-bold text-yellow-600">{totalSummary.maintenance}</div>
+            </Card>
+          </div>
 
-          {/* ロック済み部屋（サマリーモード） */}
-          {viewMode === 'summary' && metrics && metrics.lockedRooms.length > 0 && (
-            <Card className="mb-6 border border-purple-200">
-              <button
-                onClick={() => setShowLockedRooms(!showLockedRooms)}
-                className="w-full p-4 flex items-center justify-between text-left"
-              >
-                <div className="flex items-center gap-2">
-                  <Lock className="w-5 h-5 text-purple-600" />
-                  <span className="font-medium text-purple-800">
-                    ロック中の部屋（{metrics.lockedRooms.length}室）
-                  </span>
-                </div>
-                {showLockedRooms ? (
-                  <ChevronUp className="w-5 h-5 text-gray-400" />
-                ) : (
-                  <ChevronDown className="w-5 h-5 text-gray-400" />
-                )}
-              </button>
-              {showLockedRooms && (
-                <div className="px-4 pb-4">
-                  <p className="text-sm text-gray-600 mb-3">
-                    入居希望者の申込によりロックされている部屋です
-                  </p>
-                  <div className="space-y-2">
-                    {metrics.lockedRooms.map((room) => (
-                      <div
-                        key={room.id}
-                        className="flex items-center justify-between p-3 bg-purple-50 rounded-lg"
-                      >
-                        <div>
-                          <span className="font-medium text-purple-800">
-                            {room.buildingName} {room.roomNumber}
-                          </span>
-                          {room.lockedByName && (
-                            <span className="text-xs text-purple-600 ml-2">
-                              by {room.lockedByName}
-                            </span>
-                          )}
-                          {room.lockedAt && (
-                            <span className="text-xs text-gray-500 ml-2">
-                              ({formatTime(room.lockedAt)}〜)
-                            </span>
-                          )}
-                        </div>
-                        {room.lockedCaseId && (
-                          <Link
-                            href={`/dashboard/prospects/${room.lockedCaseId}`}
-                            className="text-sm text-purple-600 hover:underline"
-                          >
-                            詳細
-                          </Link>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </div>
+          {/* 施設カード一覧 */}
+          <h2 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <Building2 className="w-5 h-5" />
+            施設一覧
+          </h2>
+
+          {facilities.length === 0 ? (
+            <Card className="p-8 text-center">
+              <Building2 className="w-12 h-12 mx-auto mb-3 text-gray-300" />
+              <p className="text-gray-500">施設が登録されていません</p>
+              {isAdmin && (
+                <Button
+                  onClick={() => setShowAddFacilityModal(true)}
+                  className="mt-4"
+                >
+                  <Plus className="w-4 h-4 mr-2" />
+                  施設を追加
+                </Button>
               )}
             </Card>
+          ) : (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {facilities.map((facility) => (
+                <FacilityCard
+                  key={facility.id}
+                  facility={facility}
+                  summary={facilitySummaries[facility.id] || {
+                    facilityId: facility.id,
+                    facilityName: facility.name,
+                    totalRooms: 0,
+                    available: 0,
+                    locked: 0,
+                    occupied: 0,
+                    maintenance: 0,
+                    occupancyRate: null,
+                  }}
+                  onClick={() => setSelectedFacility(facility)}
+                />
+              ))}
+            </div>
           )}
 
-          {/* 施設一覧テーブル（サマリーモード） */}
-          {viewMode === 'summary' && (
-            <Card className="overflow-hidden">
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead className="bg-gray-50 border-b">
-                    <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        施設
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        稼働率
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        <Home className="w-3 h-3 inline mr-1" />空室
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        <Lock className="w-3 h-3 inline mr-1" />ロック
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        <Building2 className="w-3 h-3 inline mr-1" />入居
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        <Wrench className="w-3 h-3 inline mr-1" />修繕
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200">
-                    {filteredFacilities.length === 0 ? (
-                      <tr>
-                        <td colSpan={6} className="px-4 py-8 text-center text-gray-500">
-                          {statusFilter === 'all' ? '施設データがありません' : '該当する施設がありません'}
-                        </td>
-                      </tr>
-                    ) : (
-                      filteredFacilities.map((facility) => {
-                        const colors = getOccupancyColor(facility.occupancyRate);
-                        return (
-                          <tr key={facility.id} className="hover:bg-gray-50">
-                            <td className="px-4 py-4">
-                              <div className="font-medium text-gray-900">{facility.name}</div>
-                              {facility.area && (
-                                <div className="text-xs text-gray-500">{facility.area}</div>
-                              )}
-                              {facility.lastUpdated && (
-                                <div className="text-xs text-gray-400 mt-1">
-                                  更新: {formatTime(facility.lastUpdated)}
-                                  {facility.lastUpdatedBy && ` (${facility.lastUpdatedBy})`}
-                                </div>
-                              )}
-                            </td>
-                            <td className="px-4 py-4 text-center">
-                              <div className="flex flex-col items-center gap-1">
-                                <span className={`text-lg font-bold ${colors.text}`}>
-                                  {displayRate(facility.occupancyRate)}
-                                </span>
-                                <div className="w-16">
-                                  <OccupancyBar rate={facility.occupancyRate} />
-                                </div>
-                              </div>
-                            </td>
-                            <td className="px-4 py-4 text-center">
-                              {facility.available > 0 ? (
-                                <Badge variant="info" className="min-w-[2rem]">
-                                  {facility.available}
-                                </Badge>
-                              ) : (
-                                <span className="text-gray-400">-</span>
-                              )}
-                            </td>
-                            <td className="px-4 py-4 text-center">
-                              {facility.locked > 0 ? (
-                                <Badge variant="default" className="min-w-[2rem]">
-                                  {facility.locked}
-                                </Badge>
-                              ) : (
-                                <span className="text-gray-400">-</span>
-                              )}
-                            </td>
-                            <td className="px-4 py-4 text-center">
-                              <span className="font-medium text-gray-700">
-                                {facility.occupied}
-                              </span>
-                              <span className="text-gray-400 text-xs ml-1">
-                                /{facility.capacity || (facility.available + facility.locked + facility.occupied + facility.maintenance)}
-                              </span>
-                            </td>
-                            <td className="px-4 py-4 text-center">
-                              {facility.maintenance > 0 ? (
-                                <Badge variant="warning" className="min-w-[2rem]">
-                                  {facility.maintenance}
-                                </Badge>
-                              ) : (
-                                <span className="text-gray-400">-</span>
-                              )}
-                            </td>
-                          </tr>
-                        );
-                      })
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
-          )}
-
-          {/* 部屋一覧テーブル（部屋モード） */}
-          {viewMode === 'rooms' && (
-            <Card className="overflow-hidden">
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead className="bg-gray-50 border-b">
-                    <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        建物
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        部屋番号
-                      </th>
-                      <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        状態
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        ロック/入居者
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        備考
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200">
-                    {filteredRooms.length === 0 ? (
-                      <tr>
-                        <td colSpan={5} className="px-4 py-8 text-center text-gray-500">
-                          {rooms.length === 0 ? '部屋データがありません' : '該当する部屋がありません'}
-                        </td>
-                      </tr>
-                    ) : (
-                      filteredRooms.map((room) => (
-                        <tr key={room.id} className="hover:bg-gray-50">
-                          <td className="px-4 py-3 font-medium text-gray-900">
-                            {room.buildingName}
-                          </td>
-                          <td className="px-4 py-3 text-gray-700">
-                            {room.roomNumber}
-                          </td>
-                          <td className="px-4 py-3 text-center">
-                            <StatusChangeDropdown
-                              room={room}
-                              onStatusChange={handleStatusChange}
-                              disabled={!isLeader}
-                            />
-                          </td>
-                          <td className="px-4 py-3 text-sm text-gray-600">
-                            {room.status === '予約' && room.lockedCaseId && (
-                              <Link
-                                href={`/dashboard/prospects/${room.lockedCaseId}`}
-                                className="text-purple-600 hover:underline"
-                              >
-                                {room.lockedByName || '申込中'}
-                              </Link>
-                            )}
-                            {(room.status === '入居中' || room.status === '退去予定') && room.occupantName && (
-                              <span>{room.occupantName}</span>
-                            )}
-                            {room.status === '空室' && '-'}
-                            {room.status === 'メンテナンス' && '-'}
-                          </td>
-                          <td className="px-4 py-3 text-sm text-gray-500">
-                            {room.note || '-'}
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
-          )}
-
-          {/* デバッグパネル */}
-          {debugMode && metrics?.debug && (
-            <Card className="mt-6 p-4 bg-gray-900 text-gray-100">
-              <div className="flex items-center gap-2 mb-3">
-                <HelpCircle className="w-4 h-4" />
-                <span className="font-medium">Debug Info</span>
-              </div>
-              <div className="grid grid-cols-2 gap-4 text-sm font-mono">
-                <div>
-                  <span className="text-gray-400">Rooms Queried:</span>
-                  <span className="ml-2">{metrics.debug.roomsQueried}</span>
-                </div>
-                <div>
-                  <span className="text-gray-400">Facilities Queried:</span>
-                  <span className="ml-2">{metrics.debug.facilitiesQueried}</span>
-                </div>
-                <div className="col-span-2">
-                  <span className="text-gray-400">Raw Status Counts:</span>
-                  <pre className="mt-1 text-xs bg-gray-800 p-2 rounded overflow-auto">
-                    {JSON.stringify(metrics.debug.rawStatusCounts, null, 2)}
-                  </pre>
-                </div>
-                {metrics.debug.unknownStatuses.length > 0 && (
-                  <div className="col-span-2">
-                    <span className="text-yellow-400">Unknown Statuses:</span>
-                    <span className="ml-2">{metrics.debug.unknownStatuses.join(', ')}</span>
-                  </div>
-                )}
-              </div>
-            </Card>
-          )}
-
-          {/* フッター情報 */}
-          <div className="mt-6 text-center text-xs text-gray-400">
+          {/* フッター */}
+          <div className="mt-8 text-center text-xs text-gray-400">
             <p>自動更新: 60秒ごと</p>
-            {isAdmin && (
-              <p className="mt-1">
-                <button
-                  onClick={() => setDebugMode(!debugMode)}
-                  className="text-gray-500 hover:text-gray-700 underline"
-                >
-                  {debugMode ? 'デバッグモードOFF' : 'デバッグモードON'}
-                </button>
-              </p>
-            )}
           </div>
         </main>
 
-        {/* 部屋追加モーダル */}
-        <AddRoomModal
-          isOpen={showAddRoomModal}
-          onClose={() => setShowAddRoomModal(false)}
-          onSubmit={handleAddRoom}
-          buildings={buildings}
+        {/* 施設詳細ドロワー */}
+        <FacilityDrawer
+          facility={selectedFacility}
+          rooms={rooms}
+          isOpen={!!selectedFacility}
+          onClose={() => setSelectedFacility(null)}
+          onAddRoom={() => setShowAddRoomModal(true)}
+          onStatusChange={handleStatusChange}
+          canAddRoom={isAdmin}
+          canChangeStatus={isLeader}
         />
+
+        {/* 施設追加モーダル */}
+        <AddFacilityModal
+          isOpen={showAddFacilityModal}
+          onClose={() => setShowAddFacilityModal(false)}
+          onSubmit={handleAddFacility}
+        />
+
+        {/* 部屋追加モーダル */}
+        {selectedFacility && (
+          <AddRoomModal
+            isOpen={showAddRoomModal}
+            onClose={() => setShowAddRoomModal(false)}
+            onSubmit={handleAddRoom}
+            facilityName={selectedFacility.name}
+          />
+        )}
       </div>
     </AuthGuard>
   );

--- a/src/types/vacancy.ts
+++ b/src/types/vacancy.ts
@@ -4,8 +4,10 @@
 export interface Facility {
   id: string;
   name: string;
-  area?: string;
-  capacity?: number; // 定員
+  address?: string;    // 住所
+  area?: string;       // エリア
+  capacity?: number;   // 定員
+  note?: string;       // 備考
   isActive: boolean;
   tenantId: string;
   createdAt: Date;


### PR DESCRIPTION
- GET/POST /api/facilities: 施設マスタAPI
- 施設カード一覧（サマリー数字・稼働率バー）
- 施設詳細ドロワー（部屋一覧・状態変更）
- 施設追加モーダル（名前・住所・備考）
- 部屋追加は施設配下で実行（施設ドロワー内）
- モバイル対応レイアウト

UI構成:
- 上部: 全体サマリー（稼働率・空室・ロック・入居中・修繕中）
- メイン: 施設カード一覧（クリックでドロワー表示）
- ドロワー: 施設詳細+部屋一覧+状態変更

権限:
- 施設追加: admin
- 部屋追加: admin
- 状態変更: leader以上
- 閲覧: 全員

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
