### PR TITLE
fix: 書類自動生成の最終安定化

### DIFF
--- a/src/app/api/documents/generate-required/route.ts
+++ b/src/app/api/documents/generate-required/route.ts
@@ -1,8 +1,11 @@
 // ======== 必須書類自動生成API ========
 // POST: 入居者・従業員等の必須書類を一括生成
+// - 重複チェック: 同一 ownerId + docType の書類は再生成しない
+// - エラー継続: 1件失敗しても他の書類は生成継続
+// - Firestore安全: undefinedは絶対に渡さない
 
 import { NextRequest, NextResponse } from 'next/server';
-import { generateRequiredDocuments, getDocuments } from '@/lib/document';
+import { generateRequiredDocumentsWithDetails } from '@/lib/document';
 import { getRequiredTemplates } from '@/data/document-templates';
 import { DocumentOwnerType } from '@/types/document';
 import { DEFAULT_TENANT_ID } from '@/lib/firebase';
@@ -17,7 +20,6 @@ export async function POST(request: NextRequest) {
       ownerName,
       actorId,
       actorName,
-      skipExisting = true, // 既存書類がある場合はスキップ
     } = body;
 
     // 必須フィールド検証
@@ -39,7 +41,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // テンプレート数を事前確認（デバッグ用）
+    // テンプレート数を事前確認
     const templates = getRequiredTemplates(ownerType);
     console.log(`[generate-required] ownerType=${ownerType}, ownerId=${ownerId}, templates=${templates.length}`);
 
@@ -49,52 +51,58 @@ export async function POST(request: NextRequest) {
         success: true,
         message: 'No required document templates defined for this owner type',
         created: 0,
-        existing: 0,
+        skipped: 0,
+        errors: 0,
         documents: [],
       });
     }
 
-    // 既存書類を確認（スキップオプション）
-    if (skipExisting) {
-      const existingDocs = await getDocuments(tenantId, { ownerType, ownerId });
-      if (existingDocs.length > 0) {
-        console.log(`[generate-required] Documents already exist: ${existingDocs.length}`);
-        return NextResponse.json({
-          success: true,
-          message: 'Documents already exist for this owner',
-          created: 0,
-          existing: existingDocs.length,
-          documents: [],
-        });
-      }
-    }
-
-    // 必須書類を生成
-    const documents = await generateRequiredDocuments(
+    // 必須書類を生成（重複チェック込み）
+    const result = await generateRequiredDocumentsWithDetails(
       ownerType,
       ownerId,
       ownerName || ownerId || '',
       tenantId,
-      actorId,
-      actorName || actorId || ''
+      actorId || 'system',
+      actorName || actorId || 'System'
     );
 
-    console.log(`[generate-required] Successfully generated ${documents.length} documents`);
+    console.log(`[generate-required] Result: created=${result.created.length}, skipped=${result.skipped.length}, errors=${result.errors.length}`);
+
+    // 結果メッセージを構築
+    let message = '';
+    if (result.created.length > 0) {
+      message = `${result.created.length}件の書類を生成しました`;
+    }
+    if (result.skipped.length > 0) {
+      message += message ? '。' : '';
+      message += `${result.skipped.length}件は既に存在するためスキップ`;
+    }
+    if (result.errors.length > 0) {
+      message += message ? '。' : '';
+      message += `${result.errors.length}件でエラーが発生`;
+    }
+    if (!message) {
+      message = '書類生成の処理が完了しました';
+    }
 
     return NextResponse.json({
-      success: true,
-      message: `Generated ${documents.length} required documents`,
-      created: documents.length,
-      documents: documents.map(d => ({
+      success: result.errors.length === 0,
+      message,
+      created: result.created.length,
+      skipped: result.skipped.length,
+      errors: result.errors.length,
+      documents: result.created.map(d => ({
         id: d.id,
         docType: d.docType,
         docTypeName: d.docTypeName,
         status: d.status,
       })),
+      skippedDetails: result.skipped,
+      errorDetails: result.errors,
     });
   } catch (error) {
     console.error('[generate-required] POST Error:', error);
-    // エラーの詳細をログに出力
     if (error instanceof Error) {
       console.error('[generate-required] Error stack:', error.stack);
     }

--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -342,6 +342,21 @@ export async function uploadDocumentFile(
 
 // ======== 必須書類の自動生成 ========
 
+/**
+ * 生成結果の詳細
+ */
+export interface GenerateDocumentsResult {
+  created: Document[];
+  skipped: { docType: string; reason: string }[];
+  errors: { docType: string; error: string }[];
+}
+
+/**
+ * 必須書類を自動生成
+ * - テンプレートに基づいて書類レコードを作成
+ * - 既存の書類は重複生成しない（doc_key + ownerIdで判定）
+ * - 生成失敗しても他の書類は継続生成
+ */
 export async function generateRequiredDocuments(
   ownerType: DocumentOwnerType,
   ownerId: string,
@@ -350,16 +365,43 @@ export async function generateRequiredDocuments(
   actorId: string,
   actorName: string
 ): Promise<Document[]> {
+  const result = await generateRequiredDocumentsWithDetails(
+    ownerType,
+    ownerId,
+    ownerName,
+    tenantId,
+    actorId,
+    actorName
+  );
+  return result.created;
+}
+
+/**
+ * 必須書類を自動生成（詳細結果付き）
+ */
+export async function generateRequiredDocumentsWithDetails(
+  ownerType: DocumentOwnerType,
+  ownerId: string,
+  ownerName: string,
+  tenantId: string = DEFAULT_TENANT_ID,
+  actorId: string,
+  actorName: string
+): Promise<GenerateDocumentsResult> {
+  const result: GenerateDocumentsResult = {
+    created: [],
+    skipped: [],
+    errors: [],
+  };
+
   // テンプレート取得
   const required = getRequiredTemplates(ownerType);
 
-  // ログ出力（デバッグ用）
   console.log(`[generateRequiredDocuments] ownerType=${ownerType}, ownerId=${ownerId}, templates=${required.length}`);
 
-  // テンプレートが0件の場合は早期リターン（エラーではない）
+  // テンプレートが0件の場合は早期リターン
   if (required.length === 0) {
     console.warn(`[generateRequiredDocuments] No required templates found for ownerType=${ownerType}`);
-    return [];
+    return result;
   }
 
   // 有効なテンプレートのみフィルタ（undefinedや不正データ防止）
@@ -368,23 +410,40 @@ export async function generateRequiredDocuments(
     console.warn(`[generateRequiredDocuments] Filtered ${required.length - validTemplates.length} invalid templates`);
   }
 
-  // テンプレート一覧をログ出力
   console.log(`[generateRequiredDocuments] Valid templates:`, validTemplates.map(t => ({ key: t.key, name: t.name })));
 
-  const created: Document[] = [];
+  // 既存書類を取得（重複チェック用）
+  const existingDocs = await getDocuments(tenantId, { ownerType, ownerId });
+  const existingDocTypes = new Set(existingDocs.map(d => d.docType));
+
+  console.log(`[generateRequiredDocuments] Existing doc types:`, Array.from(existingDocTypes));
 
   for (const template of validTemplates) {
-    // 生成するドキュメントデータを事前に構築
+    // 重複チェック（同一 ownerId + docType の書類が既に存在する場合はスキップ）
+    if (existingDocTypes.has(template.key)) {
+      console.log(`[generateRequiredDocuments] Skipping duplicate: ${template.key}`);
+      result.skipped.push({ docType: template.key, reason: '既に存在' });
+      continue;
+    }
+
+    // 生成するドキュメントデータを構築（undefined防止）
     const docInput = {
       tenantId: tenantId || 'defaultTenant',
       ownerType,
       ownerId: ownerId || '',
       ownerName: ownerName || '',
-      docType: template.key,
-      docTypeName: template.name,
+      docType: template.key || '',
+      docTypeName: template.name || '',
       status: 'MISSING' as const,
-      signedRequired: template.signedRequired ?? false,
+      signedRequired: Boolean(template.signedRequired),
     };
+
+    // 入力データの検証
+    if (!docInput.docType || !docInput.ownerId) {
+      console.error(`[generateRequiredDocuments] Invalid input data:`, docInput);
+      result.errors.push({ docType: template.key || 'unknown', error: 'Invalid input data' });
+      continue;
+    }
 
     console.log(`[generateRequiredDocuments] Creating document:`, docInput);
 
@@ -394,20 +453,18 @@ export async function generateRequiredDocuments(
         actorId || 'system',
         actorName || 'System'
       );
-      created.push(doc);
+      result.created.push(doc);
       console.log(`[generateRequiredDocuments] Created document: ${doc.id} (${template.key})`);
     } catch (error) {
-      // 個別のエラーをログに出力し、他の書類生成を継続
-      console.error(`[generateRequiredDocuments] Failed to create document: ${template.key}`, error);
-      if (error instanceof Error) {
-        console.error(`[generateRequiredDocuments] Error details:`, error.message, error.stack);
-      }
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`[generateRequiredDocuments] Failed to create document: ${template.key}`, errorMessage);
+      result.errors.push({ docType: template.key, error: errorMessage });
     }
   }
 
-  console.log(`[generateRequiredDocuments] Successfully created ${created.length}/${validTemplates.length} documents`);
+  console.log(`[generateRequiredDocuments] Result: created=${result.created.length}, skipped=${result.skipped.length}, errors=${result.errors.length}`);
 
-  return created;
+  return result;
 }
 
 // ======== サマリー取得 ========


### PR DESCRIPTION
- 書類ごとの重複チェック実装（同一 ownerId + docType はスキップ）
- generateRequiredDocumentsWithDetails関数を追加（詳細結果付き）
- 結果レポートに created/skipped/errors を分離
- 入力データの検証を強化（undefined/空文字防止）
- 1件失敗しても他の書類は継続生成
- APIレスポンスに詳細情報（skippedDetails, errorDetails）を追加

これにより：
- 再実行しても重複生成されない
- Firestoreのundefinedエラーが発生しない
- エラー発生時も部分的に書類が生成される

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
