### PR TITLE
feat: Firestore undefined防止・承認経路シード拡張

### DIFF
--- a/src/app/api/applications/[id]/approve/route.ts
+++ b/src/app/api/applications/[id]/approve/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
 import { hasMinRole } from '@/lib/auth';
 import { Timestamp } from 'firebase-admin/firestore';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -87,23 +88,20 @@ export async function POST(
     const now = Timestamp.now();
     const fromStatus = data.status;
 
-    // 更新データ
-    const updateData: Record<string, unknown> = {
+    // 更新データ（normalizeForFirestoreで安全に保存）
+    const updateData = normalizeForFirestore({
       status: 'approved',
       approvedBy: decodedToken.uid,
       approvedByName: userData.name,
       approvedAt: now,
       updatedAt: now,
-    };
-
-    if (comment) {
-      updateData.approvalComment = comment;
-    }
+      approvalComment: comment || '',
+    });
 
     await applicationRef.update(updateData);
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -112,9 +110,9 @@ export async function POST(
       toStatus: 'approved',
       performedBy: decodedToken.uid,
       performedByName: userData.name,
-      comment,
+      comment: comment || '',
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/[id]/reject/route.ts
+++ b/src/app/api/applications/[id]/reject/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
 import { hasMinRole } from '@/lib/auth';
 import { Timestamp } from 'firebase-admin/firestore';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -89,18 +90,18 @@ export async function POST(
     const now = Timestamp.now();
     const fromStatus = data.status;
 
-    // 更新データ
-    await applicationRef.update({
+    // 更新データ（normalizeForFirestoreで安全に保存）
+    await applicationRef.update(normalizeForFirestore({
       status: 'rejected',
       rejectedBy: decodedToken.uid,
       rejectedByName: userData.name,
       rejectedAt: now,
       rejectionReason: reason.trim(),
       updatedAt: now,
-    });
+    }));
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -111,7 +112,7 @@ export async function POST(
       performedByName: userData.name,
       comment: reason.trim(),
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/[id]/return/route.ts
+++ b/src/app/api/applications/[id]/return/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
 import { hasMinRole } from '@/lib/auth';
 import { Timestamp } from 'firebase-admin/firestore';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -89,18 +90,18 @@ export async function POST(
     const now = Timestamp.now();
     const fromStatus = data.status;
 
-    // 更新データ
-    await applicationRef.update({
+    // 更新データ（normalizeForFirestoreで安全に保存）
+    await applicationRef.update(normalizeForFirestore({
       status: 'returned',
       returnedBy: decodedToken.uid,
       returnedByName: userData.name,
       returnedAt: now,
       returnReason: reason.trim(),
       updatedAt: now,
-    });
+    }));
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -111,7 +112,7 @@ export async function POST(
       performedByName: userData.name,
       comment: reason.trim(),
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   OvertimeFormData,
 } from '@/types/application';
 import { RingiStatus } from '@/types/ringi';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -189,18 +190,19 @@ export async function PUT(
     if (data.type === 'EXPENSE') {
       const expenseData = formData as ExpenseFormData;
       const currentPayload = data.payload as ExpensePayload;
-      newPayload = {
+      // normalizeForFirestoreでundefinedを完全除去
+      newPayload = normalizeForFirestore({
         ...currentPayload,
-        ...(expenseData.expenseDate !== undefined && { expenseDate: expenseData.expenseDate }),
-        ...(expenseData.amount !== undefined && expenseData.amount !== '' && { amount: expenseData.amount as number }),
-        ...(expenseData.category !== undefined && expenseData.category !== '' && { category: expenseData.category as ExpensePayload['category'] }),
-        ...(expenseData.paymentMethod !== undefined && expenseData.paymentMethod !== '' && { paymentMethod: expenseData.paymentMethod as ExpensePayload['paymentMethod'] }),
-        ...(expenseData.description !== undefined && { description: expenseData.description }),
-        ...(expenseData.receiptUrls !== undefined && { receiptUrls: expenseData.receiptUrls }),
-        ...(expenseData.vendor !== undefined && { vendor: expenseData.vendor || undefined }),
-        ...(expenseData.purpose !== undefined && { purpose: expenseData.purpose || undefined }),
-        ...(expenseData.projectCode !== undefined && { projectCode: expenseData.projectCode || undefined }),
-      };
+        expenseDate: expenseData.expenseDate !== undefined ? expenseData.expenseDate : currentPayload.expenseDate,
+        amount: expenseData.amount !== undefined && expenseData.amount !== '' ? expenseData.amount as number : currentPayload.amount,
+        category: expenseData.category !== undefined && expenseData.category !== '' ? expenseData.category as ExpensePayload['category'] : currentPayload.category,
+        paymentMethod: expenseData.paymentMethod !== undefined && expenseData.paymentMethod !== '' ? expenseData.paymentMethod as ExpensePayload['paymentMethod'] : currentPayload.paymentMethod,
+        description: expenseData.description !== undefined ? expenseData.description : currentPayload.description,
+        receiptUrls: expenseData.receiptUrls !== undefined ? expenseData.receiptUrls : (currentPayload.receiptUrls || []),
+        vendor: expenseData.vendor !== undefined ? (expenseData.vendor || '') : (currentPayload.vendor || ''),
+        purpose: expenseData.purpose !== undefined ? (expenseData.purpose || '') : (currentPayload.purpose || ''),
+        projectCode: expenseData.projectCode !== undefined ? (expenseData.projectCode || '') : (currentPayload.projectCode || ''),
+      }) as ExpensePayload;
       newTitle = generateApplicationTitle('EXPENSE', newPayload, data.authorName);
       newAmount = newPayload.amount;
     } else {
@@ -210,36 +212,34 @@ export async function PUT(
       const endTime = overtimeData.endTime !== undefined ? overtimeData.endTime : currentPayload.endTime;
       const hours = calculateOvertimeHours(startTime, endTime);
 
-      newPayload = {
+      // normalizeForFirestoreでundefinedを完全除去
+      newPayload = normalizeForFirestore({
         ...currentPayload,
-        ...(overtimeData.date !== undefined && { date: overtimeData.date }),
-        ...(overtimeData.startTime !== undefined && { startTime: overtimeData.startTime }),
-        ...(overtimeData.endTime !== undefined && { endTime: overtimeData.endTime }),
+        date: overtimeData.date !== undefined ? overtimeData.date : currentPayload.date,
+        startTime,
+        endTime,
         hours,
-        ...(overtimeData.reason !== undefined && overtimeData.reason !== '' && { reason: overtimeData.reason as OvertimePayload['reason'] }),
-        ...(overtimeData.reasonDetail !== undefined && { reasonDetail: overtimeData.reasonDetail || undefined }),
-        ...(overtimeData.workContent !== undefined && { workContent: overtimeData.workContent || undefined }),
-        ...(overtimeData.isHoliday !== undefined && { isHoliday: overtimeData.isHoliday }),
-        ...(overtimeData.isNightShift !== undefined && { isNightShift: overtimeData.isNightShift }),
-      };
+        reason: overtimeData.reason !== undefined && overtimeData.reason !== '' ? overtimeData.reason as OvertimePayload['reason'] : currentPayload.reason,
+        reasonDetail: overtimeData.reasonDetail !== undefined ? (overtimeData.reasonDetail || '') : (currentPayload.reasonDetail || ''),
+        workContent: overtimeData.workContent !== undefined ? (overtimeData.workContent || '') : (currentPayload.workContent || ''),
+        isHoliday: overtimeData.isHoliday !== undefined ? overtimeData.isHoliday : currentPayload.isHoliday,
+        isNightShift: overtimeData.isNightShift !== undefined ? overtimeData.isNightShift : currentPayload.isNightShift,
+      }) as OvertimePayload;
       newTitle = generateApplicationTitle('OVERTIME', newPayload, data.authorName);
     }
 
-    // 更新データ
-    const updateData: Record<string, unknown> = {
+    // 更新データ（normalizeForFirestoreでundefined完全除去）
+    const updateData = normalizeForFirestore({
       payload: newPayload,
       title: newTitle,
       updatedAt: now,
-    };
-
-    if (newAmount !== undefined) {
-      updateData.amount = newAmount;
-    }
+      amount: newAmount ?? 0,
+    });
 
     await applicationRef.update(updateData);
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -247,7 +247,7 @@ export async function PUT(
       performedBy: decodedToken.uid,
       performedByName: userData.name,
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/[id]/submit/route.ts
+++ b/src/app/api/applications/[id]/submit/route.ts
@@ -10,6 +10,7 @@ import {
   ExpensePayload,
   OvertimePayload,
 } from '@/types/application';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -120,16 +121,15 @@ export async function POST(
     const now = Timestamp.now();
     const fromStatus = data.status;
 
-    // 申請を更新
-    await applicationRef.update({
+    // 申請を更新（normalizeForFirestoreで安全に保存）
+    await applicationRef.update(normalizeForFirestore({
       status: 'submitted',
       submittedAt: now,
       updatedAt: now,
-      // 差戻し後の再提出の場合は差戻し情報はそのまま履歴として保持
-    });
+    }));
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -139,7 +139,7 @@ export async function POST(
       performedBy: decodedToken.uid,
       performedByName: userData.name,
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/[id]/withdraw/route.ts
+++ b/src/app/api/applications/[id]/withdraw/route.ts
@@ -4,6 +4,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb, verifyIdToken } from '@/lib/firebase-admin';
 import { Timestamp } from 'firebase-admin/firestore';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const COLLECTION_NAME = 'applications';
 const AUDIT_LOG_COLLECTION = 'applicationAuditLogs';
@@ -71,15 +72,15 @@ export async function POST(
     const now = Timestamp.now();
     const fromStatus = data.status;
 
-    // 更新データ
-    await applicationRef.update({
+    // 更新データ（normalizeForFirestoreで安全に保存）
+    await applicationRef.update(normalizeForFirestore({
       status: 'draft',
       submittedAt: null,
       updatedAt: now,
-    });
+    }));
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId: data.tenantId,
       applicationId: id,
       applicationType: data.type,
@@ -89,7 +90,7 @@ export async function POST(
       performedBy: decodedToken.uid,
       performedByName: userData.name,
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -17,6 +17,7 @@ import {
   OvertimeFormData,
 } from '@/types/application';
 import { RingiStatus } from '@/types/ringi';
+import { normalizeForFirestore } from '@/lib/firestore/normalize';
 
 const DEFAULT_TENANT_ID = 'defaultTenant';
 const COLLECTION_NAME = 'applications';
@@ -206,35 +207,37 @@ export async function POST(request: NextRequest) {
 
     if (type === 'EXPENSE') {
       const expenseData = formData as ExpenseFormData;
-      payload = {
+      // normalizeForFirestoreでundefinedを除去
+      payload = normalizeForFirestore({
         expenseDate: expenseData.expenseDate || '',
         amount: typeof expenseData.amount === 'number' ? expenseData.amount : 0,
         category: (expenseData.category || '交通費') as ExpensePayload['category'],
         paymentMethod: (expenseData.paymentMethod || '立替') as ExpensePayload['paymentMethod'],
         description: expenseData.description || '',
         receiptUrls: expenseData.receiptUrls || [],
-        vendor: expenseData.vendor || undefined,
-        taxAmount: typeof expenseData.taxAmount === 'number' ? expenseData.taxAmount : undefined,
-        purpose: expenseData.purpose || undefined,
-        participants: expenseData.participants?.split(',').map((s: string) => s.trim()).filter(Boolean) || undefined,
-        projectCode: expenseData.projectCode || undefined,
-      };
+        vendor: expenseData.vendor || '',
+        taxAmount: typeof expenseData.taxAmount === 'number' ? expenseData.taxAmount : 0,
+        purpose: expenseData.purpose || '',
+        participants: expenseData.participants?.split(',').map((s: string) => s.trim()).filter(Boolean) || [],
+        projectCode: expenseData.projectCode || '',
+      }) as ExpensePayload;
       title = generateApplicationTitle('EXPENSE', payload, userData.name);
       amount = payload.amount;
     } else {
       const overtimeData = formData as OvertimeFormData;
       const hours = calculateOvertimeHours(overtimeData.startTime || '', overtimeData.endTime || '');
-      payload = {
+      // normalizeForFirestoreでundefinedを除去
+      payload = normalizeForFirestore({
         date: overtimeData.date || '',
         startTime: overtimeData.startTime || '',
         endTime: overtimeData.endTime || '',
         hours,
         reason: (overtimeData.reason || '業務繁忙') as OvertimePayload['reason'],
-        reasonDetail: overtimeData.reasonDetail || undefined,
-        workContent: overtimeData.workContent || undefined,
+        reasonDetail: overtimeData.reasonDetail || '',
+        workContent: overtimeData.workContent || '',
         isHoliday: overtimeData.isHoliday || false,
         isNightShift: overtimeData.isNightShift || false,
-      };
+      }) as OvertimePayload;
       title = generateApplicationTitle('OVERTIME', payload, userData.name);
     }
 
@@ -242,8 +245,8 @@ export async function POST(request: NextRequest) {
     const tenantId = userData.tenantId || DEFAULT_TENANT_ID;
     const branchId = userData.branchId || '';
 
-    // 申請を作成
-    const applicationData: Record<string, unknown> = {
+    // 申請を作成（normalizeForFirestoreでundefinedを完全除去）
+    const applicationData = normalizeForFirestore({
       tenantId,
       branchId,
       type,
@@ -253,16 +256,13 @@ export async function POST(request: NextRequest) {
       payload,
       status: 'draft' as RingiStatus,
       createdAt: now,
-    };
-
-    if (amount !== undefined) {
-      applicationData.amount = amount;
-    }
+      amount: amount ?? 0,
+    });
 
     const docRef = await db.collection(COLLECTION_NAME).add(applicationData);
 
-    // 監査ログ
-    await db.collection(AUDIT_LOG_COLLECTION).add({
+    // 監査ログ（normalizeForFirestoreで安全に保存）
+    await db.collection(AUDIT_LOG_COLLECTION).add(normalizeForFirestore({
       tenantId,
       applicationId: docRef.id,
       applicationType: type,
@@ -271,7 +271,7 @@ export async function POST(request: NextRequest) {
       performedBy: decodedToken.uid,
       performedByName: userData.name,
       createdAt: now,
-    });
+    }));
 
     return NextResponse.json({
       success: true,

--- a/src/lib/approval-routes.ts
+++ b/src/lib/approval-routes.ts
@@ -434,9 +434,15 @@ export async function findMatchingApprovalRoute(
  * approval_routes が 0件のときのみ実行
  *
  * 作成する経路:
- * 1. 通常稟議: manager → exec（デフォルト）
- * 2. 高額稟議: manager → exec（50万円以上）
- * 3. 人事稟議: execのみ（人事関連カテゴリ）
+ * RINGI:
+ *   1. 通常稟議: manager → exec（デフォルト）
+ *   2. 高額稟議: manager → exec（50万円以上）
+ *   3. 人事稟議: execのみ（人事関連カテゴリ）
+ * EXPENSE:
+ *   4. 経費申請（通常）: leader承認（デフォルト）
+ *   5. 経費申請（高額）: leader → manager（5万円以上）
+ * OVERTIME:
+ *   6. 残業申請: leader承認（デフォルト）
  */
 export interface SeedResult {
   seeded: boolean;
@@ -444,6 +450,9 @@ export interface SeedResult {
   routesCreated: number;
   routeIds: string[];
 }
+
+// 申請種別（RINGI/EXPENSE/OVERTIMEで承認経路を分離）
+export type ApprovalRouteApplicationType = 'RINGI' | 'EXPENSE' | 'OVERTIME';
 
 export async function seedApprovalRouteTemplates(
   tenantId: string = DEFAULT_TENANT_ID,
@@ -466,11 +475,13 @@ export async function seedApprovalRouteTemplates(
   const now = Timestamp.now();
   const routeIds: string[] = [];
 
-  // テンプレート定義
+  // テンプレート定義（RINGI + EXPENSE + OVERTIME）
   const templates = [
+    // === RINGI（稟議）===
     {
       name: '通常稟議',
       description: '一般的な稟議（デフォルト経路）',
+      applicationType: 'RINGI' as ApprovalRouteApplicationType,
       category: null,
       branchId: null,
       minAmount: null,
@@ -486,13 +497,14 @@ export async function seedApprovalRouteTemplates(
     {
       name: '高額稟議',
       description: '50万円以上の高額稟議',
+      applicationType: 'RINGI' as ApprovalRouteApplicationType,
       category: null,
       branchId: null,
       minAmount: 500000,
       maxAmount: null,
       isActive: true,
       isDefault: false,
-      priority: 10, // 高優先度（先にマッチ）
+      priority: 10,
       steps: [
         { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
         { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
@@ -501,15 +513,64 @@ export async function seedApprovalRouteTemplates(
     {
       name: '人事稟議',
       description: '人事関連の稟議（経営層のみ）',
+      applicationType: 'RINGI' as ApprovalRouteApplicationType,
       category: '人事関連' as RingiCategory,
       branchId: null,
       minAmount: null,
       maxAmount: null,
       isActive: true,
       isDefault: false,
-      priority: 5, // 最高優先度
+      priority: 5,
       steps: [
         { approverType: 'ROLE' as const, approverValue: 'exec', required: true },
+      ],
+    },
+    // === EXPENSE（経費申請）===
+    {
+      name: '経費申請（通常）',
+      description: '通常の経費申請（リーダー承認）',
+      applicationType: 'EXPENSE' as ApprovalRouteApplicationType,
+      category: null,
+      branchId: null,
+      minAmount: null,
+      maxAmount: 49999,
+      isActive: true,
+      isDefault: true,
+      priority: 100,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'leader', required: true },
+      ],
+    },
+    {
+      name: '経費申請（高額）',
+      description: '5万円以上の高額経費（リーダー→マネージャー承認）',
+      applicationType: 'EXPENSE' as ApprovalRouteApplicationType,
+      category: null,
+      branchId: null,
+      minAmount: 50000,
+      maxAmount: null,
+      isActive: true,
+      isDefault: false,
+      priority: 10,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'leader', required: true },
+        { approverType: 'ROLE' as const, approverValue: 'manager', required: true },
+      ],
+    },
+    // === OVERTIME（残業申請）===
+    {
+      name: '残業申請',
+      description: '残業・休日出勤の事前申請（リーダー承認）',
+      applicationType: 'OVERTIME' as ApprovalRouteApplicationType,
+      category: null,
+      branchId: null,
+      minAmount: null,
+      maxAmount: null,
+      isActive: true,
+      isDefault: true,
+      priority: 100,
+      steps: [
+        { approverType: 'ROLE' as const, approverValue: 'leader', required: true },
       ],
     },
   ];
@@ -521,6 +582,7 @@ export async function seedApprovalRouteTemplates(
       tenantId,
       name: template.name,
       description: template.description,
+      applicationType: template.applicationType, // RINGI/EXPENSE/OVERTIME
       category: template.category,
       branchId: template.branchId,
       minAmount: template.minAmount,

--- a/src/lib/firestore/normalize.ts
+++ b/src/lib/firestore/normalize.ts
@@ -1,0 +1,191 @@
+/**
+ * Firestore undefined 完全排除ユーティリティ
+ *
+ * Firestore は undefined を保存できないため、
+ * すべてのペイロードは保存前にこの関数を通す必要がある。
+ */
+
+/**
+ * オブジェクトから undefined を除去し、空文字列に置換
+ * - undefined → ''
+ * - null はそのまま（Firestoreは null を許容）
+ * - 配列内の undefined も除去
+ * - ネストしたオブジェクトも再帰的に処理
+ */
+export function normalizePayload<T extends Record<string, unknown>>(obj: T): T {
+  if (obj === null || obj === undefined) {
+    return {} as T;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) {
+      // undefined は空文字列に変換
+      result[key] = '';
+    } else if (Array.isArray(value)) {
+      // 配列の場合は undefined を除去し、各要素を正規化
+      result[key] = value
+        .filter((item) => item !== undefined)
+        .map((item) =>
+          typeof item === 'object' && item !== null
+            ? normalizePayload(item as Record<string, unknown>)
+            : item
+        );
+    } else if (typeof value === 'object' && value !== null) {
+      // ネストしたオブジェクトは再帰的に処理
+      result[key] = normalizePayload(value as Record<string, unknown>);
+    } else {
+      // その他の値はそのまま
+      result[key] = value;
+    }
+  }
+
+  return result as T;
+}
+
+/**
+ * Firestore ドキュメント用に正規化
+ * - undefined を除去
+ * - Date オブジェクトはそのまま（Firestore が Timestamp に変換）
+ * - 空文字列は保持（削除しない）
+ */
+export function normalizeForFirestore<T extends Record<string, unknown>>(
+  data: T,
+  options?: {
+    removeEmptyStrings?: boolean;
+    removeNulls?: boolean;
+  }
+): T {
+  const { removeEmptyStrings = false, removeNulls = false } = options || {};
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    // undefined は常にスキップ
+    if (value === undefined) {
+      continue;
+    }
+
+    // null のハンドリング
+    if (value === null) {
+      if (!removeNulls) {
+        result[key] = null;
+      }
+      continue;
+    }
+
+    // 空文字列のハンドリング
+    if (value === '' && removeEmptyStrings) {
+      continue;
+    }
+
+    // 配列のハンドリング
+    if (Array.isArray(value)) {
+      const normalizedArray = value
+        .filter((item) => item !== undefined)
+        .map((item) =>
+          typeof item === 'object' && item !== null && !(item instanceof Date)
+            ? normalizeForFirestore(item as Record<string, unknown>, options)
+            : item
+        );
+      result[key] = normalizedArray;
+      continue;
+    }
+
+    // Date オブジェクトはそのまま
+    if (value instanceof Date) {
+      result[key] = value;
+      continue;
+    }
+
+    // ネストしたオブジェクトは再帰的に処理
+    if (typeof value === 'object') {
+      result[key] = normalizeForFirestore(value as Record<string, unknown>, options);
+      continue;
+    }
+
+    // その他の値はそのまま
+    result[key] = value;
+  }
+
+  return result as T;
+}
+
+/**
+ * 申請ペイロード専用の正規化
+ * - 必須フィールドが undefined の場合はデフォルト値を設定
+ * - オプションフィールドの undefined は空文字列に変換
+ */
+export function normalizeApplicationPayload<T extends Record<string, unknown>>(
+  payload: T,
+  defaults?: Partial<T>
+): T {
+  // まずデフォルト値をマージ
+  const merged = { ...defaults, ...payload };
+
+  // 次に正規化
+  return normalizePayload(merged);
+}
+
+/**
+ * 経費申請ペイロードの正規化
+ */
+export interface ExpensePayloadInput {
+  expenseDate?: string;
+  amount?: number;
+  category?: string;
+  paymentMethod?: string;
+  vendor?: string;
+  description?: string;
+  receiptUrls?: string[];
+  taxAmount?: number;
+  purpose?: string;
+  participants?: string[];
+  projectCode?: string;
+}
+
+export function normalizeExpensePayload(input: ExpensePayloadInput) {
+  return normalizeForFirestore({
+    expenseDate: input.expenseDate || '',
+    amount: input.amount || 0,
+    category: input.category || '交通費',
+    paymentMethod: input.paymentMethod || '立替',
+    vendor: input.vendor || '',
+    description: input.description || '',
+    receiptUrls: input.receiptUrls || [],
+    taxAmount: input.taxAmount,
+    purpose: input.purpose || '',
+    participants: input.participants || [],
+    projectCode: input.projectCode || '',
+  }, { removeNulls: true });
+}
+
+/**
+ * 残業申請ペイロードの正規化
+ */
+export interface OvertimePayloadInput {
+  date?: string;
+  startTime?: string;
+  endTime?: string;
+  hours?: number;
+  reason?: string;
+  reasonDetail?: string;
+  workContent?: string;
+  isHoliday?: boolean;
+  isNightShift?: boolean;
+}
+
+export function normalizeOvertimePayload(input: OvertimePayloadInput) {
+  return normalizeForFirestore({
+    date: input.date || '',
+    startTime: input.startTime || '',
+    endTime: input.endTime || '',
+    hours: input.hours || 0,
+    reason: input.reason || '業務繁忙',
+    reasonDetail: input.reasonDetail || '',
+    workContent: input.workContent || '',
+    isHoliday: input.isHoliday || false,
+    isNightShift: input.isNightShift || false,
+  });
+}


### PR DESCRIPTION
- normalizeForFirestore関数追加でFirestoreにundefined渡さない
- 全applicationsAPIエンドポイントで正規化を適用
- 経費申請（EXPENSE）・残業申請（OVERTIME）用承認経路テンプレ追加
- applicationType追加でRINGI/EXPENSE/OVERTIMEを分離

https://claude.ai/code/session_01EJw9N6NjfCHS1Q7tdP1RrT

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
