### PR TITLE
feat: AA-HUBダッシュボードの再設計

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,64 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
-import { DEFAULT_TENANT_ID } from '@/lib/firebase';
-import { getCheckinHistory, getChaosDashboardMetrics, getInterventions } from '@/lib/chaos';
-import { getSalesDeals, getSalesAccounts } from '@/lib/sales';
-import { getProspects, applyProspectTimeScope } from '@/lib/prospect';
-import { getFacilitiesWithVacancy } from '@/lib/vacancy';
-import { getRingisByUser, getPendingRingis } from '@/lib/ringi';
+import { getChaosViewLevel } from '@/lib/auth';
+import { fetchKPIData, type KPIFetchResult } from '@/lib/dashboard/kpi-fetcher';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
-import { Card, CardHeader, CardTitle, CardContent, Badge, Button } from '@/components/ui';
 import { Loading } from '@/components/Loading';
 import { PreviewBadge } from '@/components/PreviewBadge';
+import { AIVPSummaryCard } from '@/components/dashboard/AIVPSummaryCard';
+import { KPIGrid } from '@/components/dashboard/KPICard';
+import { Card, CardContent, Button } from '@/components/ui';
 import {
-  StaffCheckin,
-  Intervention,
-  METER_LABELS,
-  METER_COLORS,
-  getMeterColor,
-  MeterColor,
-  SUPPORT_PURPOSE_TEXT,
-  ONEONONE_PURPOSE_TEXT,
-} from '@/types/chaos';
+  type DashboardRole,
+  KPI_DEFINITIONS,
+  getRoleLabel,
+} from '@/types/dashboard-kpi';
 import {
-  calculateBatchMoveInProbability,
-  aggregateByRank,
-  calculateExpectedMoveIns,
-} from '@/lib/scoring';
-import { getChaosViewLevel } from '@/lib/auth';
-import {
-  safeRate,
-  formatPercent,
-  calcOccupancyRate,
-  calcInterventionRate,
-  toDashboardError,
-  DashboardError,
-} from '@/lib/dashboard/calc';
-import {
-  Heart,
   Shield,
-  MessageCircle,
-  Bell,
-  Sparkles,
-  Users,
   AlertTriangle,
-  Target,
-  TrendingUp,
-  Calendar,
-  CheckCircle,
-  Clock,
-  Building2,
-  Briefcase,
-  BarChart2,
-  ArrowRight,
-  ClipboardList,
-  Plus,
-  RotateCcw,
-  FileText,
+  RefreshCw,
 } from 'lucide-react';
 
 export default function DashboardPage() {
@@ -72,210 +34,49 @@ export default function DashboardPage() {
 function DashboardContent() {
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<DashboardError | null>(null);
-
-  // 共通データ
-  const [checkinHistory, setCheckinHistory] = useState<StaffCheckin[]>([]);
-  const [interventions, setInterventions] = useState<Intervention[]>([]);
-
-  // Manager/Exec用データ
-  const [teamData, setTeamData] = useState<{
-    userId: string;
-    userName: string;
-    score: number;
-    level: MeterColor;
-  }[]>([]);
-  const [orgMetrics, setOrgMetrics] = useState<{
-    avgFatigue: number;
-    avgMentalLoad: number;
-    alertCount: { yellow: number; red: number };
-    burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
-  } | null>(null);
-
-  // 稟議データ（全員共通）
-  const [approvalStats, setApprovalStats] = useState<{
-    draft: number;
-    submitted: number;
-    returned: number;
-    pendingApproval: number; // 承認待ち（リーダー以上用）
-  }>({ draft: 0, submitted: 0, returned: 0, pendingApproval: 0 });
-
-  // Exec用データ
-  const [salesMetrics, setSalesMetrics] = useState<{
-    accounts: number;
-    activeDeals: number;
-    completedDeals: number;
-    totalDeals: number;
-    cvRate: number | null;
-    expectedMoveIns: number;
-    rankA: number;
-    rankB: number;
-    rankC: number;
-    rankD: number;
-  }>({
-    accounts: 0,
-    activeDeals: 0,
-    completedDeals: 0,
-    totalDeals: 0,
-    cvRate: null,
-    expectedMoveIns: 0,
-    rankA: 0,
-    rankB: 0,
-    rankC: 0,
-    rankD: 0,
-  });
-  const [occupancyRate, setOccupancyRate] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<KPIFetchResult | null>(null);
 
   // 役割判定
   const viewLevel = user ? getChaosViewLevel(user.role, user.email) : 'self';
-  const isStaff = viewLevel === 'self';
-  const isManager = viewLevel === 'team';
-  const isExec = viewLevel === 'all';
+  const role: DashboardRole = viewLevel === 'all' ? 'exec' : viewLevel === 'team' ? 'manager' : 'staff';
+
+  // データ取得
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (!user) return;
+
+    if (isRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+
+    try {
+      const result = await fetchKPIData(user, role);
+      setData(result);
+
+      if (result.errors.length > 0) {
+        console.warn('[Dashboard] Some data failed to load:', result.errors);
+      }
+    } catch (err) {
+      console.error('[Dashboard] Failed to fetch data:', err);
+      setError('データの取得に失敗しました');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [user, role]);
 
   useEffect(() => {
-    const fetchData = async () => {
-      if (!user) return;
-
-      const errors: DashboardError[] = [];
-
-      // 全員：自分のチェックイン履歴
-      try {
-        const history = await getCheckinHistory(user.id, 7);
-        setCheckinHistory(history);
-      } catch (err) {
-        console.error('[dashboard:checkinHistory] Failed:', err);
-        errors.push(toDashboardError(err));
-      }
-
-      // 全員：稟議データ
-      try {
-        const myRingis = await getRingisByUser(user.id, user.tenantId);
-        const draft = myRingis.filter(r => r.status === 'draft').length;
-        const submitted = myRingis.filter(r => r.status === 'submitted').length;
-        const returned = myRingis.filter(r => r.status === 'returned').length;
-
-        // リーダー以上：承認待ち件数
-        let pendingApproval = 0;
-        if (!isStaff) {
-          try {
-            const pending = await getPendingRingis(user.tenantId, user.branchId);
-            pendingApproval = pending.length;
-          } catch (e) {
-            console.error('[dashboard:pendingRingis] Failed:', e);
-          }
-        }
-
-        setApprovalStats({ draft, submitted, returned, pendingApproval });
-      } catch (err) {
-        console.error('[dashboard:approvalStats] Failed:', err);
-      }
-
-      // Manager以上：チーム・組織データ
-      if (!isStaff) {
-        // CHAOS組織データ
-        try {
-          const chaosData = await getChaosDashboardMetrics(DEFAULT_TENANT_ID);
-          setOrgMetrics(chaosData.organization);
-
-          const team = chaosData.organization.burnoutRiskHeatmap.map(m => ({
-            userId: m.userId,
-            userName: m.userName,
-            score: m.score,
-            level: getMeterColor(m.score),
-          }));
-          setTeamData(team);
-        } catch (err) {
-          console.error('[dashboard:chaosMetrics] Failed:', err);
-          errors.push(toDashboardError(err));
-        }
-
-        // 介入データ
-        try {
-          const interventionsData = await getInterventions('open', 20);
-          setInterventions(interventionsData);
-        } catch (err) {
-          console.error('[dashboard:interventions] Failed:', err);
-          errors.push(toDashboardError(err));
-        }
-      }
-
-      // Exec：営業・経営データ
-      if (isExec) {
-        // 営業データ（案件・営業先）
-        try {
-          const [dealsData, accountsData] = await Promise.all([
-            getSalesDeals(DEFAULT_TENANT_ID),
-            getSalesAccounts(DEFAULT_TENANT_ID),
-          ]);
-
-          const activeDeals = dealsData.filter(d => !['請求書到着', '失注'].includes(d.status));
-          const completedDeals = dealsData.filter(d => d.status === '請求書到着');
-          const cvRate = safeRate(completedDeals.length, dealsData.length);
-
-          setSalesMetrics(prev => ({
-            ...prev,
-            accounts: accountsData.length,
-            activeDeals: activeDeals.length,
-            completedDeals: completedDeals.length,
-            totalDeals: dealsData.length,
-            cvRate,
-          }));
-        } catch (err) {
-          console.error('[dashboard:salesData] Failed:', err);
-          errors.push(toDashboardError(err));
-        }
-
-        // 入居希望データ（スコアリング）- 2026-01-12 13:49 JST以降のみ
-        try {
-          const prospectsData = await getProspects(DEFAULT_TENANT_ID);
-          // 時間ベースのスコープ適用
-          const kpiTargetProspects = applyProspectTimeScope(prospectsData);
-          const activeProspects = kpiTargetProspects.filter(
-            p => p.status !== '見送り' && p.status !== 'クローズ' && p.status !== '入居決定'
-          );
-          const scoringResults = calculateBatchMoveInProbability(activeProspects);
-          const rankDistribution = aggregateByRank(scoringResults);
-          const expectedMoveIns = calculateExpectedMoveIns(scoringResults);
-
-          setSalesMetrics(prev => ({
-            ...prev,
-            expectedMoveIns,
-            rankA: rankDistribution.A,
-            rankB: rankDistribution.B,
-            rankC: rankDistribution.C,
-            rankD: rankDistribution.D,
-          }));
-        } catch (err) {
-          console.error('[dashboard:prospects] Failed:', err);
-          errors.push(toDashboardError(err));
-        }
-
-        // 稼働率データ
-        try {
-          const facilitiesData = await getFacilitiesWithVacancy(DEFAULT_TENANT_ID);
-          const totalCapacity = facilitiesData.reduce((sum, f) => sum + (f.facility.capacity || 0), 0);
-          const totalVacant = facilitiesData.reduce((sum, f) => sum + (f.vacancy?.vacantCount ?? 0), 0);
-          const rate = calcOccupancyRate(totalCapacity, totalVacant);
-          setOccupancyRate(rate);
-        } catch (err) {
-          console.error('[dashboard:occupancy] Failed:', err);
-          errors.push(toDashboardError(err));
-        }
-      }
-
-      // インデックスエラーがあれば最初のものを表示
-      const indexError = errors.find(e => e.code === 'INDEX_REQUIRED');
-      if (indexError) {
-        setError(indexError);
-      } else if (errors.length > 0) {
-        setError(errors[0]);
-      }
-
-      setLoading(false);
-    };
-
     fetchData();
-  }, [user, isStaff, isExec]);
+  }, [fetchData]);
+
+  // リフレッシュハンドラ
+  const handleRefresh = () => {
+    fetchData(true);
+  };
 
   if (loading) {
     return (
@@ -286,44 +87,20 @@ function DashboardContent() {
     );
   }
 
-  // エラー表示
-  const retryFetch = () => {
-    setLoading(true);
-    setError(null);
-    // Re-trigger useEffect
-    window.location.reload();
-  };
-
-  // 今日の余裕メーター計算
-  const todayCheckin = checkinHistory[0];
-  let todayMeterColor: MeterColor = 'green';
-  if (todayCheckin) {
-    const avgScore = Math.round(
-      ((todayCheckin.physicalFatigue + todayCheckin.mentalFatigue + todayCheckin.anxiety +
-        todayCheckin.decisionLoad + (4 - todayCheckin.sleep) + (4 - todayCheckin.consulted)) / 6) * 25
-    );
-    todayMeterColor = getMeterColor(avgScore);
-  }
-
   return (
     <>
       <Header />
       <PreviewBadge />
       <main className="pb-20 md:pb-8">
-        <div className="max-w-6xl mx-auto px-4 py-6">
-          {/* 支援目的の注意文（全画面共通） */}
-          <Card className="mb-6 bg-blue-50 border-blue-200">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          {/* 支援目的の注意文 */}
+          <Card className="mb-6 bg-zinc-50 border-zinc-200">
             <CardContent className="p-4">
               <div className="flex items-start gap-3">
-                <Shield className="w-5 h-5 text-blue-600 mt-0.5" />
-                <div>
-                  <p className="text-sm font-medium text-blue-800">
-                    これは支援のための仕組みです。評価や査定のためではありません。
-                  </p>
-                  <p className="text-xs text-blue-600 mt-1">
-                    {ONEONONE_PURPOSE_TEXT}
-                  </p>
-                </div>
+                <Shield className="w-5 h-5 text-zinc-500 mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-zinc-600">
+                  これは支援のための仕組みです。評価や査定のためではありません。
+                </p>
               </div>
             </CardContent>
           </Card>
@@ -337,664 +114,85 @@ function DashboardContent() {
                     <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
                     <div>
                       <p className="text-sm font-medium text-red-800">
-                        データの取得に失敗しました
+                        {error}
                       </p>
                       <p className="text-xs text-red-600 mt-1">
-                        {error.message}
+                        一部のデータが取得できませんでした
                       </p>
-                      {error.createIndexUrl && isExec && (
-                        <p className="text-xs text-red-500 mt-2">
-                          管理者向け: インデックス作成が必要です
-                        </p>
-                      )}
                     </div>
                   </div>
-                  <Button variant="secondary" onClick={retryFetch} className="text-sm">
-                    再試行
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleRefresh}
+                    disabled={refreshing}
+                  >
+                    {refreshing ? '更新中...' : '再試行'}
                   </Button>
                 </div>
               </CardContent>
             </Card>
           )}
 
-          {/* 役割別コンテンツ */}
-          {isStaff && <StaffDashboard
-            todayCheckin={todayCheckin}
-            todayMeterColor={todayMeterColor}
-            checkinHistory={checkinHistory}
-            approvalStats={approvalStats}
-          />}
+          {/* ヘッダー（役割表示 + リフレッシュ） */}
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-lg font-semibold text-zinc-900">ダッシュボード</h1>
+              <p className="text-sm text-zinc-500">{getRoleLabel(role)}ビュー</p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="gap-1.5"
+            >
+              <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+              更新
+            </Button>
+          </div>
 
-          {isManager && <ManagerDashboard
-            teamData={teamData}
-            interventions={interventions}
-            orgMetrics={orgMetrics}
-            approvalStats={approvalStats}
-          />}
+          {/* AI副社長サマリー（最上段） */}
+          <AIVPSummaryCard
+            summary={data?.aiSummary ?? null}
+            role={role}
+            loading={loading}
+          />
 
-          {isExec && <ExecDashboard
-            teamData={teamData}
-            interventions={interventions}
-            orgMetrics={orgMetrics}
-            salesMetrics={salesMetrics}
-            occupancyRate={occupancyRate}
-            approvalStats={approvalStats}
-          />}
+          {/* KPIグリッド（最大6つ） */}
+          <KPIGrid
+            kpis={data?.kpis ?? []}
+            definitions={KPI_DEFINITIONS}
+            loading={loading}
+            maxItems={6}
+          />
+
+          {/* フッター */}
+          <div className="mt-8 pt-6 border-t border-zinc-200">
+            <div className="flex items-center justify-center gap-4 text-sm text-zinc-400">
+              <Link href="/dashboard/os/checkin" className="hover:text-zinc-600">
+                チェックイン
+              </Link>
+              <span>・</span>
+              <Link href="/dashboard/approvals" className="hover:text-zinc-600">
+                稟議
+              </Link>
+              <span>・</span>
+              <Link href="/dashboard/os/team" className="hover:text-zinc-600">
+                チーム
+              </Link>
+              {role === 'exec' && (
+                <>
+                  <span>・</span>
+                  <Link href="/admin/ai-vp" className="hover:text-zinc-600">
+                    AI副社長
+                  </Link>
+                </>
+              )}
+            </div>
+          </div>
         </div>
       </main>
     </>
-  );
-}
-
-// ========== 稟議カード（共通） ==========
-function ApprovalCard({
-  approvalStats,
-  isLeader = false,
-}: {
-  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
-  isLeader?: boolean;
-}) {
-  const hasReturned = approvalStats.returned > 0;
-  const hasPending = approvalStats.pendingApproval > 0;
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base flex items-center justify-between">
-          <span className="flex items-center">
-            <ClipboardList className="w-5 h-5 mr-2 text-blue-600" />
-            稟議
-          </span>
-          <Link href="/dashboard/approvals/new">
-            <Button size="sm" variant="secondary">
-              <Plus className="w-4 h-4" />
-              新規
-            </Button>
-          </Link>
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {/* 差戻しアラート */}
-        {hasReturned && (
-          <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg flex items-center gap-2">
-            <RotateCcw className="w-5 h-5 text-orange-600" />
-            <div>
-              <p className="text-sm font-medium text-orange-700">
-                {approvalStats.returned}件の差戻しがあります
-              </p>
-            </div>
-          </div>
-        )}
-
-        {/* 承認待ちアラート（リーダー以上） */}
-        {isLeader && hasPending && (
-          <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-2">
-            <Clock className="w-5 h-5 text-amber-600" />
-            <div>
-              <p className="text-sm font-medium text-amber-700">
-                {approvalStats.pendingApproval}件の承認待ちがあります
-              </p>
-            </div>
-          </div>
-        )}
-
-        {/* 件数サマリー */}
-        <div className="grid grid-cols-3 gap-2 mb-4">
-          <div className="p-3 rounded-lg text-center bg-zinc-50">
-            <p className="text-2xl font-bold text-zinc-900">{approvalStats.draft}</p>
-            <p className="text-xs text-zinc-500">下書き</p>
-          </div>
-          <div className="p-3 rounded-lg text-center bg-amber-50">
-            <p className="text-2xl font-bold text-amber-600">{approvalStats.submitted}</p>
-            <p className="text-xs text-zinc-500">申請中</p>
-          </div>
-          {hasReturned ? (
-            <div className="p-3 rounded-lg text-center bg-orange-50">
-              <p className="text-2xl font-bold text-orange-600">{approvalStats.returned}</p>
-              <p className="text-xs text-orange-600">差戻し</p>
-            </div>
-          ) : (
-            <div className="p-3 rounded-lg text-center bg-zinc-50">
-              <p className="text-2xl font-bold text-zinc-400">-</p>
-              <p className="text-xs text-zinc-400">差戻し</p>
-            </div>
-          )}
-        </div>
-
-        {/* アクションボタン */}
-        <div className="flex gap-2">
-          <Link href="/dashboard/approvals" className="flex-1">
-            <Button variant="secondary" className="w-full">
-              <FileText className="w-4 h-4 mr-1" />
-              一覧を見る
-            </Button>
-          </Link>
-          {isLeader && (
-            <Link href="/admin/ringi" className="flex-1">
-              <Button variant="secondary" className="w-full">
-                <CheckCircle className="w-4 h-4 mr-1" />
-                承認する
-              </Button>
-            </Link>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-// ========== スタッフ用ダッシュボード ==========
-function StaffDashboard({
-  todayCheckin,
-  todayMeterColor,
-  checkinHistory,
-  approvalStats,
-}: {
-  todayCheckin: StaffCheckin | undefined;
-  todayMeterColor: MeterColor;
-  checkinHistory: StaffCheckin[];
-  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
-}) {
-  return (
-    <div className="space-y-6">
-      {/* 1. 今日の余裕メーター */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Heart className="w-5 h-5 mr-2 text-red-500" />
-            今日の余裕メーター
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {todayCheckin ? (
-            <div className="text-center">
-              <div className={`inline-flex items-center justify-center w-24 h-24 rounded-full ${METER_COLORS[todayMeterColor].bg} ${METER_COLORS[todayMeterColor].border} border-4 mb-4`}>
-                <span className={`text-lg font-bold ${METER_COLORS[todayMeterColor].text}`}>
-                  {METER_LABELS[todayMeterColor]}
-                </span>
-              </div>
-
-              {/* 7日推移（色の丸7個） */}
-              <div className="flex justify-center gap-2 mt-4">
-                {checkinHistory.slice(0, 7).map((checkin, idx) => {
-                  const avgScore = Math.round(
-                    ((checkin.physicalFatigue + checkin.mentalFatigue + checkin.anxiety +
-                      checkin.decisionLoad + (4 - checkin.sleep) + (4 - checkin.consulted)) / 6) * 25
-                  );
-                  const color = getMeterColor(avgScore);
-                  return (
-                    <div
-                      key={checkin.id || idx}
-                      className={`w-8 h-8 rounded-full ${METER_COLORS[color].bg} ${METER_COLORS[color].border} border-2`}
-                      title={`${checkin.date}: ${METER_LABELS[color]}`}
-                    />
-                  );
-                })}
-              </div>
-              <p className="text-xs text-gray-500 mt-2">過去7日間の推移</p>
-            </div>
-          ) : (
-            <div className="text-center py-8">
-              <p className="text-gray-500 mb-4">今日のチェックインがまだです</p>
-              <Link href="/dashboard/os/checkin">
-                <Button>
-                  <Heart className="w-4 h-4 mr-1" />
-                  チェックインする
-                </Button>
-              </Link>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* 2. 今日の自分タスク（期限が近いもの） */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <CheckCircle className="w-5 h-5 mr-2 text-green-600" />
-            今日のタスク
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center py-4 text-gray-500">
-            <Clock className="w-8 h-8 mx-auto mb-2 text-gray-300" />
-            <p className="text-sm">期限が近いタスクはありません</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* 3. サポート相談ボタン（固定） */}
-      <Card className="bg-gradient-to-r from-indigo-50 to-blue-50 border-indigo-200">
-        <CardContent className="p-6 text-center">
-          <MessageCircle className="w-10 h-10 mx-auto mb-3 text-indigo-600" />
-          <p className="text-sm text-gray-600 mb-4">
-            困っていることや相談したいことはありますか？
-          </p>
-          <Button className="bg-indigo-600 hover:bg-indigo-700">
-            <MessageCircle className="w-4 h-4 mr-2" />
-            サポート相談
-          </Button>
-        </CardContent>
-      </Card>
-
-      {/* 4. 重要連絡（管理者から） */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Bell className="w-5 h-5 mr-2 text-orange-500" />
-            重要連絡
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center py-4 text-gray-500">
-            <p className="text-sm">新しい連絡はありません</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* 5. 稟議カード */}
-      <ApprovalCard approvalStats={approvalStats} />
-
-      {/* 6. 小さな成長（承認ワンポイント） */}
-      <Card className="bg-gradient-to-r from-yellow-50 to-amber-50 border-yellow-200">
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Sparkles className="w-5 h-5 mr-2 text-yellow-600" />
-            小さな成長
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-gray-700">
-            今週もチェックインを続けています！自分のコンディションを把握することは大切な一歩です。
-          </p>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-// ========== 管理者用ダッシュボード ==========
-function ManagerDashboard({
-  teamData,
-  interventions,
-  orgMetrics,
-  approvalStats,
-}: {
-  teamData: { userId: string; userName: string; score: number; level: MeterColor }[];
-  interventions: Intervention[];
-  orgMetrics: {
-    avgFatigue: number;
-    avgMentalLoad: number;
-    alertCount: { yellow: number; red: number };
-    burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
-  } | null;
-  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
-}) {
-  const redCount = teamData.filter(m => m.level === 'red').length;
-  const yellowCount = teamData.filter(m => m.level === 'yellow').length;
-  const pendingInterventions = interventions.filter(i => i.status === 'open');
-
-  return (
-    <div className="space-y-6">
-      {/* 上段2カラム */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* 左：チーム余裕ヒートマップ */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center">
-              <Users className="w-5 h-5 mr-2 text-blue-600" />
-              チーム余裕ヒートマップ
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {/* サマリー */}
-            <div className="grid grid-cols-3 gap-2 mb-4">
-              <div className={`p-3 rounded-lg text-center ${redCount > 0 ? 'bg-red-100' : 'bg-gray-50'}`}>
-                <p className={`text-2xl font-bold ${redCount > 0 ? 'text-red-600' : 'text-gray-400'}`}>
-                  {redCount}
-                </p>
-                <p className="text-xs text-gray-600">サポートが必要</p>
-              </div>
-              <div className={`p-3 rounded-lg text-center ${yellowCount > 0 ? 'bg-yellow-100' : 'bg-gray-50'}`}>
-                <p className={`text-2xl font-bold ${yellowCount > 0 ? 'text-yellow-600' : 'text-gray-400'}`}>
-                  {yellowCount}
-                </p>
-                <p className="text-xs text-gray-600">余裕少なめ</p>
-              </div>
-              <div className="p-3 rounded-lg text-center bg-green-50">
-                <p className="text-2xl font-bold text-green-600">
-                  {teamData.length - redCount - yellowCount}
-                </p>
-                <p className="text-xs text-gray-600">余裕あり</p>
-              </div>
-            </div>
-
-            {/* メンバー一覧 */}
-            <div className="space-y-2 max-h-64 overflow-y-auto">
-              {teamData.map((member) => (
-                <div
-                  key={member.userId}
-                  className={`flex items-center justify-between p-2 rounded-lg ${METER_COLORS[member.level].bg}`}
-                >
-                  <span className="text-sm font-medium">{member.userName}</span>
-                  <Badge className={`${METER_COLORS[member.level].bg} ${METER_COLORS[member.level].text}`}>
-                    {METER_LABELS[member.level]}
-                  </Badge>
-                </div>
-              ))}
-              {teamData.length === 0 && (
-                <p className="text-center text-gray-500 py-4">チームデータがありません</p>
-              )}
-            </div>
-            <Link href="/dashboard/os/team" className="text-sm text-blue-600 hover:underline flex items-center mt-3">
-              詳細を見る <ArrowRight className="w-4 h-4 ml-1" />
-            </Link>
-          </CardContent>
-        </Card>
-
-        {/* 右：サポート待ちリスト */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center">
-              <AlertTriangle className="w-5 h-5 mr-2 text-orange-500" />
-              サポート待ちリスト
-              {pendingInterventions.length > 0 && (
-                <Badge className="ml-2 bg-red-100 text-red-700">{pendingInterventions.length}</Badge>
-              )}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {pendingInterventions.length > 0 ? (
-              <div className="space-y-2 max-h-64 overflow-y-auto">
-                {pendingInterventions.map((item) => (
-                  <div
-                    key={item.id}
-                    className={`p-3 rounded-lg border ${
-                      item.severity === 'red' ? 'bg-red-50 border-red-200' :
-                      item.severity === 'yellow' ? 'bg-yellow-50 border-yellow-200' :
-                      'bg-gray-50 border-gray-200'
-                    }`}
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm font-medium">{item.targetName || item.title}</span>
-                      <Badge className={
-                        item.severity === 'red' ? 'bg-red-100 text-red-700' :
-                        item.severity === 'yellow' ? 'bg-yellow-100 text-yellow-700' :
-                        'bg-gray-100 text-gray-700'
-                      }>
-                        {item.severity === 'red' ? 'サポートが必要' : item.severity === 'yellow' ? '余裕少なめ' : '確認'}
-                      </Badge>
-                    </div>
-                    <p className="text-xs text-gray-500 mt-1">{item.title}</p>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="text-center py-8">
-                <CheckCircle className="w-10 h-10 text-green-500 mx-auto mb-2" />
-                <p className="text-sm text-gray-500">未対応のサポートはありません</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* 稟議カード */}
-      <ApprovalCard approvalStats={approvalStats} isLeader />
-
-      {/* 下段 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {/* 現場ボトルネック */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">現場ボトルネック</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-gray-500 text-center py-4">
-              特に問題なし
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* 承認の見える化 */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">承認の見える化</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-gray-500 text-center py-4">
-              支援のための行動ログ
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* WBR宿題 */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center">
-              <Calendar className="w-4 h-4 mr-2" />
-              WBR宿題
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Link href="/dashboard/wbr" className="text-sm text-blue-600 hover:underline flex items-center">
-              WBRを確認する <ArrowRight className="w-4 h-4 ml-1" />
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
-}
-
-// ========== 吉田用（Exec）ダッシュボード ==========
-function ExecDashboard({
-  teamData,
-  interventions,
-  orgMetrics,
-  salesMetrics,
-  occupancyRate,
-  approvalStats,
-}: {
-  teamData: { userId: string; userName: string; score: number; level: MeterColor }[];
-  interventions: Intervention[];
-  orgMetrics: {
-    avgFatigue: number;
-    avgMentalLoad: number;
-    alertCount: { yellow: number; red: number };
-    burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
-  } | null;
-  salesMetrics: {
-    accounts: number;
-    activeDeals: number;
-    completedDeals: number;
-    totalDeals: number;
-    cvRate: number | null;
-    expectedMoveIns: number;
-    rankA: number;
-    rankB: number;
-    rankC: number;
-    rankD: number;
-  };
-  occupancyRate: number | null;
-  approvalStats: { draft: number; submitted: number; returned: number; pendingApproval: number };
-}) {
-  const redCount = teamData.filter(m => m.level === 'red').length;
-  const yellowCount = teamData.filter(m => m.level === 'yellow').length;
-  // 安全な介入実施率計算（総介入数0の場合はnull、100%ではない）
-  const doneCount = interventions.filter(i => i.status === 'done').length;
-  const interventionRate = calcInterventionRate(doneCount, interventions.length);
-
-  return (
-    <div className="space-y-6">
-      {/* 経営KPIサマリー */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Card className="p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-500">稼働率</p>
-              <p className="text-2xl font-bold text-blue-600">
-                {formatPercent(occupancyRate)}
-              </p>
-            </div>
-            <Building2 className="w-8 h-8 text-blue-300" />
-          </div>
-        </Card>
-        <Card className="p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-500">入居見込み</p>
-              <p className="text-2xl font-bold text-green-600">{salesMetrics.expectedMoveIns}</p>
-            </div>
-            <Target className="w-8 h-8 text-green-300" />
-          </div>
-        </Card>
-        <Card className={`p-4 ${redCount > 0 ? 'bg-red-50' : yellowCount > 0 ? 'bg-yellow-50' : ''}`}>
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-500">赤/黄</p>
-              <p className={`text-2xl font-bold ${redCount > 0 ? 'text-red-600' : yellowCount > 0 ? 'text-yellow-600' : 'text-green-600'}`}>
-                {teamData.length > 0 ? `${redCount}/${yellowCount}` : '--'}
-              </p>
-            </div>
-            <AlertTriangle className={`w-8 h-8 ${redCount > 0 ? 'text-red-300' : 'text-gray-300'}`} />
-          </div>
-        </Card>
-        <Card className="p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-500">介入実施率</p>
-              <p className="text-2xl font-bold text-purple-600">
-                {formatPercent(interventionRate)}
-              </p>
-            </div>
-            <CheckCircle className="w-8 h-8 text-purple-300" />
-          </div>
-        </Card>
-      </div>
-
-      {/* 営業OSカード */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Briefcase className="w-5 h-5 mr-2 text-blue-600" />
-            営業OS
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-4 gap-4 mb-4">
-            <div className="text-center p-3 bg-blue-50 rounded-lg">
-              <p className="text-2xl font-bold text-blue-600">{salesMetrics.accounts}</p>
-              <p className="text-xs text-gray-600">LD（営業先）</p>
-            </div>
-            <div className="text-center p-3 bg-purple-50 rounded-lg">
-              <p className="text-2xl font-bold text-purple-600">{salesMetrics.activeDeals}</p>
-              <p className="text-xs text-gray-600">V（進行中）</p>
-            </div>
-            <div className="text-center p-3 bg-green-50 rounded-lg">
-              <p className="text-2xl font-bold text-green-600">{salesMetrics.completedDeals}</p>
-              <p className="text-xs text-gray-600">M（成約）</p>
-            </div>
-            <div className="text-center p-3 bg-gray-50 rounded-lg">
-              <p className="text-2xl font-bold text-gray-600">{formatPercent(salesMetrics.cvRate)}</p>
-              <p className="text-xs text-gray-600">CV率</p>
-            </div>
-          </div>
-
-          {/* 入居確率分布 */}
-          <div className="flex gap-2 mb-4">
-            <span className="px-3 py-1 bg-green-100 text-green-800 text-sm rounded">A: {salesMetrics.rankA}</span>
-            <span className="px-3 py-1 bg-blue-100 text-blue-800 text-sm rounded">B: {salesMetrics.rankB}</span>
-            <span className="px-3 py-1 bg-yellow-100 text-yellow-800 text-sm rounded">C: {salesMetrics.rankC}</span>
-            <span className="px-3 py-1 bg-gray-100 text-gray-800 text-sm rounded">D: {salesMetrics.rankD}</span>
-          </div>
-
-          <Link href="/dashboard/sales/pipeline" className="text-sm text-blue-600 hover:underline flex items-center">
-            パイプライン詳細 <ArrowRight className="w-4 h-4 ml-1" />
-          </Link>
-        </CardContent>
-      </Card>
-
-      {/* 経営数字（吉田のみ） */}
-      <Card className="border-indigo-200 bg-indigo-50">
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <BarChart2 className="w-5 h-5 mr-2 text-indigo-600" />
-            経営数字
-            <Badge className="ml-2 bg-indigo-100 text-indigo-700">吉田専用</Badge>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-3 gap-4">
-            <div className="text-center p-3 bg-white rounded-lg">
-              <p className="text-xl font-bold text-indigo-600">-</p>
-              <p className="text-xs text-gray-600">期待粗利</p>
-            </div>
-            <div className="text-center p-3 bg-white rounded-lg">
-              <p className="text-xl font-bold text-indigo-600">-</p>
-              <p className="text-xs text-gray-600">回収月数</p>
-            </div>
-            <div className="text-center p-3 bg-white rounded-lg">
-              <p className="text-xl font-bold text-indigo-600">-</p>
-              <p className="text-xs text-gray-600">CAC上限</p>
-            </div>
-          </div>
-          <p className="text-xs text-gray-500 mt-3">※ 経営数字は今後のPRで実装予定</p>
-        </CardContent>
-      </Card>
-
-      {/* 組織コンディション */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Heart className="w-5 h-5 mr-2 text-red-500" />
-            組織コンディション
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-3 gap-2 mb-4">
-            <div className={`p-3 rounded-lg text-center ${redCount > 0 ? 'bg-red-100' : 'bg-gray-50'}`}>
-              <p className={`text-2xl font-bold ${redCount > 0 ? 'text-red-600' : 'text-gray-400'}`}>
-                {redCount}
-              </p>
-              <p className="text-xs text-gray-600">サポートが必要</p>
-            </div>
-            <div className={`p-3 rounded-lg text-center ${yellowCount > 0 ? 'bg-yellow-100' : 'bg-gray-50'}`}>
-              <p className={`text-2xl font-bold ${yellowCount > 0 ? 'text-yellow-600' : 'text-gray-400'}`}>
-                {yellowCount}
-              </p>
-              <p className="text-xs text-gray-600">余裕少なめ</p>
-            </div>
-            <div className="p-3 rounded-lg text-center bg-green-50">
-              <p className="text-2xl font-bold text-green-600">
-                {teamData.length - redCount - yellowCount}
-              </p>
-              <p className="text-xs text-gray-600">余裕あり</p>
-            </div>
-          </div>
-          <Link href="/dashboard/os/team" className="text-sm text-blue-600 hover:underline flex items-center">
-            チーム詳細 <ArrowRight className="w-4 h-4 ml-1" />
-          </Link>
-        </CardContent>
-      </Card>
-
-      {/* 稟議カード */}
-      <ApprovalCard approvalStats={approvalStats} isLeader />
-
-      {/* WBRサマリ */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center">
-            <Calendar className="w-5 h-5 mr-2 text-gray-600" />
-            WBRサマリ
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Link href="/dashboard/wbr" className="text-sm text-blue-600 hover:underline flex items-center">
-            今週のWBRを確認する <ArrowRight className="w-4 h-4 ml-1" />
-          </Link>
-        </CardContent>
-      </Card>
-    </div>
   );
 }

--- a/src/components/dashboard/AIVPSummaryCard.tsx
+++ b/src/components/dashboard/AIVPSummaryCard.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import Link from 'next/link';
+import { Bot, AlertCircle, ChevronRight, Sparkles } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui';
+import type { AIVPSummary, DashboardRole } from '@/types/dashboard-kpi';
+
+interface AIVPSummaryCardProps {
+  summary: AIVPSummary | null;
+  role: DashboardRole;
+  loading?: boolean;
+}
+
+export function AIVPSummaryCard({ summary, role, loading }: AIVPSummaryCardProps) {
+  if (loading) {
+    return (
+      <Card className="mb-8">
+        <CardContent className="p-6">
+          <div className="animate-pulse">
+            <div className="h-6 bg-zinc-200 rounded w-1/3 mb-4" />
+            <div className="h-4 bg-zinc-100 rounded w-2/3" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!summary) {
+    return (
+      <Card className="mb-8 border-zinc-200">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center">
+              <Bot className="w-5 h-5 text-zinc-400" />
+            </div>
+            <div>
+              <p className="text-sm text-zinc-500">AI副社長からのサマリー</p>
+              <p className="text-zinc-400 text-sm">データを取得中...</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasAlerts = summary.alertCount > 0;
+  const highPriorityActions = summary.priorityActions.filter(a => a.priority === 'high' || a.isAlert);
+
+  return (
+    <Card className={`mb-8 ${hasAlerts ? 'border-red-200 bg-red-50/30' : 'border-zinc-200'}`}>
+      <CardContent className="p-6">
+        {/* ヘッダー */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+              hasAlerts ? 'bg-red-100' : 'bg-zinc-100'
+            }`}>
+              {hasAlerts ? (
+                <AlertCircle className="w-5 h-5 text-red-600" />
+              ) : (
+                <Sparkles className="w-5 h-5 text-zinc-600" />
+              )}
+            </div>
+            <div>
+              <p className="text-xs text-zinc-500 mb-0.5">AI副社長</p>
+              <h2 className={`text-base font-medium ${hasAlerts ? 'text-red-800' : 'text-zinc-900'}`}>
+                {summary.headline}
+              </h2>
+            </div>
+          </div>
+          {hasAlerts && (
+            <span className="px-2 py-1 bg-red-100 text-red-700 text-xs font-medium rounded">
+              {summary.alertCount}件のアラート
+            </span>
+          )}
+        </div>
+
+        {/* 優先アクション */}
+        {highPriorityActions.length > 0 && (
+          <div className="space-y-2">
+            {highPriorityActions.slice(0, 3).map((action) => (
+              <Link
+                key={action.id}
+                href={action.href}
+                className={`flex items-center justify-between p-3 rounded-lg transition-colors ${
+                  action.isAlert
+                    ? 'bg-red-100 hover:bg-red-200'
+                    : 'bg-zinc-100 hover:bg-zinc-200'
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm font-medium ${
+                    action.isAlert ? 'text-red-800' : 'text-zinc-800'
+                  }`}>
+                    {action.title}
+                  </p>
+                  <p className={`text-xs truncate ${
+                    action.isAlert ? 'text-red-600' : 'text-zinc-500'
+                  }`}>
+                    {action.description}
+                  </p>
+                </div>
+                <ChevronRight className={`w-4 h-4 ml-2 flex-shrink-0 ${
+                  action.isAlert ? 'text-red-400' : 'text-zinc-400'
+                }`} />
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* アクションがない場合 */}
+        {highPriorityActions.length === 0 && (
+          <div className="text-center py-2">
+            <p className="text-sm text-zinc-500">
+              現在、優先対応が必要な項目はありません
+            </p>
+          </div>
+        )}
+
+        {/* フッター */}
+        <div className="mt-4 pt-3 border-t border-zinc-200 flex items-center justify-between">
+          <p className="text-xs text-zinc-400">
+            {summary.updatedAt.toLocaleString('ja-JP', {
+              month: 'numeric',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })} 更新
+          </p>
+          <Link
+            href="/admin/ai-vp"
+            className="text-xs text-zinc-500 hover:text-zinc-700 flex items-center"
+          >
+            詳細を見る
+            <ChevronRight className="w-3 h-3 ml-0.5" />
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/KPICard.tsx
+++ b/src/components/dashboard/KPICard.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui';
+import type { KPIValue, KPIDefinition, KPIStatus } from '@/types/dashboard-kpi';
+
+interface KPICardProps {
+  kpi: KPIValue;
+  definition: KPIDefinition;
+  loading?: boolean;
+}
+
+export function KPICard({ kpi, definition, loading }: KPICardProps) {
+  if (loading) {
+    return (
+      <Card className="h-full">
+        <CardContent className="p-5">
+          <div className="animate-pulse">
+            <div className="h-4 bg-zinc-200 rounded w-1/2 mb-3" />
+            <div className="h-8 bg-zinc-100 rounded w-1/3 mb-2" />
+            <div className="h-3 bg-zinc-100 rounded w-2/3" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isAlert = kpi.status === 'warning' || kpi.status === 'critical';
+
+  return (
+    <Link href={definition.href} className="block h-full">
+      <Card className={`h-full transition-all hover:shadow-md cursor-pointer ${
+        getCardStyle(kpi.status)
+      }`}>
+        <CardContent className="p-5 h-full flex flex-col">
+          {/* ラベル */}
+          <div className="flex items-center justify-between mb-3">
+            <p className={`text-sm font-medium ${getLabelStyle(kpi.status)}`}>
+              {definition.label}
+            </p>
+            {isAlert && (
+              <span className={`w-2 h-2 rounded-full ${
+                kpi.status === 'critical' ? 'bg-red-500' : 'bg-amber-500'
+              }`} />
+            )}
+          </div>
+
+          {/* 数値 */}
+          <div className="flex items-baseline gap-1.5 mb-2">
+            <span className={`text-3xl font-bold tracking-tight ${getValueStyle(kpi.status)}`}>
+              {formatValue(kpi.value)}
+            </span>
+            {definition.unit && (
+              <span className={`text-sm ${getUnitStyle(kpi.status)}`}>
+                {definition.unit}
+              </span>
+            )}
+            {kpi.trend && (
+              <span className="ml-1">
+                {kpi.trend === 'up' && <TrendingUp className="w-4 h-4 text-zinc-400" />}
+                {kpi.trend === 'down' && <TrendingDown className="w-4 h-4 text-zinc-400" />}
+                {kpi.trend === 'stable' && <Minus className="w-4 h-4 text-zinc-300" />}
+              </span>
+            )}
+          </div>
+
+          {/* 意味（必須表示） */}
+          <p className={`text-sm flex-1 ${getMeaningStyle(kpi.status)}`}>
+            {kpi.meaning}
+          </p>
+
+          {/* アクションリンク */}
+          <div className={`mt-3 pt-2 border-t flex items-center justify-end ${
+            isAlert ? 'border-red-200' : 'border-zinc-100'
+          }`}>
+            <span className={`text-xs flex items-center ${
+              isAlert ? 'text-red-600' : 'text-zinc-400'
+            }`}>
+              {isAlert ? '対応する' : '詳細'}
+              <ChevronRight className="w-3 h-3 ml-0.5" />
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+// ======== スタイルヘルパー ========
+
+function getCardStyle(status: KPIStatus): string {
+  switch (status) {
+    case 'critical':
+      return 'border-red-300 bg-red-50/50';
+    case 'warning':
+      return 'border-amber-200 bg-amber-50/30';
+    default:
+      return 'border-zinc-200 bg-white';
+  }
+}
+
+function getLabelStyle(status: KPIStatus): string {
+  switch (status) {
+    case 'critical':
+      return 'text-red-700';
+    case 'warning':
+      return 'text-amber-700';
+    default:
+      return 'text-zinc-600';
+  }
+}
+
+function getValueStyle(status: KPIStatus): string {
+  switch (status) {
+    case 'critical':
+      return 'text-red-600';
+    case 'warning':
+      return 'text-amber-600';
+    default:
+      return 'text-zinc-900';
+  }
+}
+
+function getUnitStyle(status: KPIStatus): string {
+  switch (status) {
+    case 'critical':
+      return 'text-red-500';
+    case 'warning':
+      return 'text-amber-500';
+    default:
+      return 'text-zinc-500';
+  }
+}
+
+function getMeaningStyle(status: KPIStatus): string {
+  switch (status) {
+    case 'critical':
+      return 'text-red-600';
+    case 'warning':
+      return 'text-amber-600';
+    default:
+      return 'text-zinc-500';
+  }
+}
+
+function formatValue(value: number | null): string {
+  if (value === null) return '--';
+  if (Number.isInteger(value)) return value.toString();
+  return value.toFixed(1);
+}
+
+// ======== KPIグリッド ========
+
+interface KPIGridProps {
+  kpis: KPIValue[];
+  definitions: Record<string, KPIDefinition>;
+  loading?: boolean;
+  maxItems?: number;
+}
+
+export function KPIGrid({ kpis, definitions, loading, maxItems = 6 }: KPIGridProps) {
+  const displayKpis = kpis.slice(0, maxItems);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {[...Array(maxItems)].map((_, i) => (
+          <KPICard
+            key={i}
+            kpi={{
+              id: 'loading',
+              value: null,
+              meaning: '',
+              status: 'normal',
+            }}
+            definition={{
+              id: 'loading',
+              label: '',
+              description: '',
+              href: '#',
+              roles: [],
+            }}
+            loading
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      {displayKpis.map((kpi) => {
+        const definition = definitions[kpi.id];
+        if (!definition) return null;
+        return (
+          <KPICard
+            key={kpi.id}
+            kpi={kpi}
+            definition={definition}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/dashboard/kpi-fetcher.ts
+++ b/src/lib/dashboard/kpi-fetcher.ts
@@ -1,0 +1,486 @@
+// ======== AA-HUB ダッシュボード KPIデータ取得 ========
+
+import { DEFAULT_TENANT_ID } from '@/lib/firebase';
+import { getCheckinHistory, getChaosDashboardMetrics, getInterventions } from '@/lib/chaos';
+import { getSalesDeals, getSalesAccounts } from '@/lib/sales';
+import { getProspects, applyProspectTimeScope } from '@/lib/prospect';
+import { getFacilitiesWithVacancy } from '@/lib/vacancy';
+import { getRingisByUser, getPendingRingis } from '@/lib/ringi';
+import { calculateBatchMoveInProbability, calculateExpectedMoveIns } from '@/lib/scoring';
+import { safeRate, calcOccupancyRate, calcInterventionRate, formatPercent } from '@/lib/dashboard/calc';
+import { getMeterColor, METER_LABELS, type MeterColor } from '@/types/chaos';
+import {
+  type DashboardRole,
+  type KPIValue,
+  type AIVPSummary,
+  type AIVPAction,
+  KPI_DEFINITIONS,
+  ROLE_KPI_CONFIG,
+  getKPIStatus,
+  getKPIMeaning,
+} from '@/types/dashboard-kpi';
+import type { User } from '@/types';
+
+// ======== KPIフェッチャー ========
+
+export interface KPIFetchResult {
+  kpis: KPIValue[];
+  aiSummary: AIVPSummary | null;
+  errors: string[];
+}
+
+/**
+ * 役割に応じたKPIデータを取得
+ */
+export async function fetchKPIData(
+  user: User,
+  role: DashboardRole
+): Promise<KPIFetchResult> {
+  const kpiIds = ROLE_KPI_CONFIG[role];
+  const errors: string[] = [];
+  const kpis: KPIValue[] = [];
+
+  // 必要なデータを並列取得
+  const [
+    checkinData,
+    chaosData,
+    interventionData,
+    ringiData,
+    salesData,
+    occupancyData,
+  ] = await Promise.all([
+    fetchCheckinData(user).catch(e => { errors.push('checkin'); return null; }),
+    fetchChaosData().catch(e => { errors.push('chaos'); return null; }),
+    fetchInterventionData().catch(e => { errors.push('intervention'); return null; }),
+    fetchRingiData(user, role).catch(e => { errors.push('ringi'); return null; }),
+    role === 'exec' ? fetchSalesData().catch(e => { errors.push('sales'); return null; }) : null,
+    role === 'exec' ? fetchOccupancyData().catch(e => { errors.push('occupancy'); return null; }) : null,
+  ]);
+
+  // 各KPIの値を計算
+  for (const kpiId of kpiIds) {
+    const definition = KPI_DEFINITIONS[kpiId];
+    if (!definition) continue;
+
+    const kpiValue = calculateKPIValue(
+      kpiId,
+      { checkinData, chaosData, interventionData, ringiData, salesData, occupancyData },
+      user,
+      role
+    );
+
+    kpis.push(kpiValue);
+  }
+
+  // AI副社長サマリーを生成
+  const aiSummary = generateAISummary(kpis, role, { chaosData, interventionData, ringiData });
+
+  return { kpis, aiSummary, errors };
+}
+
+// ======== データ取得関数 ========
+
+interface CheckinData {
+  todayCheckin: any;
+  todayScore: number | null;
+  todayMeterColor: MeterColor | null;
+  checkinCount: number;
+}
+
+async function fetchCheckinData(user: User): Promise<CheckinData> {
+  const history = await getCheckinHistory(user.id, 7);
+  const todayCheckin = history[0];
+
+  let todayScore: number | null = null;
+  let todayMeterColor: MeterColor | null = null;
+
+  if (todayCheckin) {
+    todayScore = Math.round(
+      ((todayCheckin.physicalFatigue + todayCheckin.mentalFatigue + todayCheckin.anxiety +
+        todayCheckin.decisionLoad + (4 - todayCheckin.sleep) + (4 - todayCheckin.consulted)) / 6) * 25
+    );
+    todayMeterColor = getMeterColor(todayScore);
+  }
+
+  return {
+    todayCheckin,
+    todayScore,
+    todayMeterColor,
+    checkinCount: history.length,
+  };
+}
+
+interface ChaosData {
+  avgFatigue: number;
+  avgMentalLoad: number;
+  alertCount: { yellow: number; red: number };
+  burnoutRiskHeatmap: { userId: string; userName: string; score: number; level: string }[];
+  teamData: { userId: string; userName: string; score: number; level: MeterColor }[];
+}
+
+async function fetchChaosData(): Promise<ChaosData> {
+  const chaosData = await getChaosDashboardMetrics(DEFAULT_TENANT_ID);
+
+  const teamData = chaosData.organization.burnoutRiskHeatmap.map(m => ({
+    userId: m.userId,
+    userName: m.userName,
+    score: m.score,
+    level: getMeterColor(m.score),
+  }));
+
+  return {
+    ...chaosData.organization,
+    teamData,
+  };
+}
+
+interface InterventionData {
+  total: number;
+  done: number;
+  open: number;
+  rate: number | null;
+}
+
+async function fetchInterventionData(): Promise<InterventionData> {
+  const interventions = await getInterventions('open', 100);
+  const done = interventions.filter(i => i.status === 'done').length;
+  const open = interventions.filter(i => i.status === 'open').length;
+
+  return {
+    total: interventions.length,
+    done,
+    open,
+    rate: calcInterventionRate(done, interventions.length),
+  };
+}
+
+interface RingiData {
+  draft: number;
+  submitted: number;
+  returned: number;
+  pendingApproval: number;
+}
+
+async function fetchRingiData(user: User, role: DashboardRole): Promise<RingiData> {
+  const myRingis = await getRingisByUser(user.id, user.tenantId);
+  const draft = myRingis.filter(r => r.status === 'draft').length;
+  const submitted = myRingis.filter(r => r.status === 'submitted').length;
+  const returned = myRingis.filter(r => r.status === 'returned').length;
+
+  let pendingApproval = 0;
+  if (role !== 'staff') {
+    try {
+      const pending = await getPendingRingis(user.tenantId, user.branchId);
+      pendingApproval = pending.length;
+    } catch (e) {
+      console.error('[KPI:ringi] pendingRingis failed', e);
+    }
+  }
+
+  return { draft, submitted, returned, pendingApproval };
+}
+
+interface SalesData {
+  accounts: number;
+  activeDeals: number;
+  completedDeals: number;
+  totalDeals: number;
+  cvRate: number | null;
+  expectedMoveIns: number;
+}
+
+async function fetchSalesData(): Promise<SalesData> {
+  const [dealsData, accountsData, prospectsData] = await Promise.all([
+    getSalesDeals(DEFAULT_TENANT_ID),
+    getSalesAccounts(DEFAULT_TENANT_ID),
+    getProspects(DEFAULT_TENANT_ID),
+  ]);
+
+  const activeDeals = dealsData.filter(d => !['請求書到着', '失注'].includes(d.status));
+  const completedDeals = dealsData.filter(d => d.status === '請求書到着');
+  const cvRate = safeRate(completedDeals.length, dealsData.length);
+
+  // 入居見込み計算
+  const kpiTargetProspects = applyProspectTimeScope(prospectsData);
+  const activeProspects = kpiTargetProspects.filter(
+    p => p.status !== '見送り' && p.status !== 'クローズ' && p.status !== '入居決定'
+  );
+  const scoringResults = calculateBatchMoveInProbability(activeProspects);
+  const expectedMoveIns = calculateExpectedMoveIns(scoringResults);
+
+  return {
+    accounts: accountsData.length,
+    activeDeals: activeDeals.length,
+    completedDeals: completedDeals.length,
+    totalDeals: dealsData.length,
+    cvRate,
+    expectedMoveIns,
+  };
+}
+
+interface OccupancyData {
+  rate: number | null;
+  totalCapacity: number;
+  totalVacant: number;
+}
+
+async function fetchOccupancyData(): Promise<OccupancyData> {
+  const facilitiesData = await getFacilitiesWithVacancy(DEFAULT_TENANT_ID);
+  const totalCapacity = facilitiesData.reduce((sum, f) => sum + (f.facility.capacity || 0), 0);
+  const totalVacant = facilitiesData.reduce((sum, f) => sum + (f.vacancy?.vacantCount ?? 0), 0);
+  const rate = calcOccupancyRate(totalCapacity, totalVacant);
+
+  return { rate, totalCapacity, totalVacant };
+}
+
+// ======== KPI値計算 ========
+
+interface AllData {
+  checkinData: CheckinData | null;
+  chaosData: ChaosData | null;
+  interventionData: InterventionData | null;
+  ringiData: RingiData | null;
+  salesData: SalesData | null;
+  occupancyData: OccupancyData | null;
+}
+
+function calculateKPIValue(
+  kpiId: string,
+  data: AllData,
+  user: User,
+  role: DashboardRole
+): KPIValue {
+  const definition = KPI_DEFINITIONS[kpiId];
+  let value: number | null = null;
+  let meaning = 'データなし';
+  let status: 'normal' | 'warning' | 'critical' = 'normal';
+
+  switch (kpiId) {
+    // スタッフ向け
+    case 'my_checkin':
+      if (data.checkinData?.todayScore !== null) {
+        value = data.checkinData?.todayScore ?? null;
+        status = getKPIStatus(value, definition);
+        meaning = data.checkinData?.todayMeterColor
+          ? METER_LABELS[data.checkinData.todayMeterColor]
+          : 'チェックインしてください';
+      } else {
+        meaning = 'チェックインしてください';
+      }
+      break;
+
+    case 'my_tasks':
+      value = 0; // TODO: タスク数を実装
+      status = getKPIStatus(value, definition);
+      meaning = getKPIMeaning(kpiId, value, status);
+      break;
+
+    case 'my_approvals':
+      if (data.ringiData) {
+        value = data.ringiData.returned + data.ringiData.submitted;
+        status = data.ringiData.returned > 0 ? 'warning' : 'normal';
+        meaning = data.ringiData.returned > 0
+          ? `${data.ringiData.returned}件の差戻しあり`
+          : value > 0 ? `${data.ringiData.submitted}件申請中` : '申請なし';
+      }
+      break;
+
+    case 'my_overtime':
+      value = 0; // TODO: 残業時間を実装
+      status = getKPIStatus(value, definition);
+      meaning = getKPIMeaning(kpiId, value, status);
+      break;
+
+    case 'team_support':
+      value = null;
+      meaning = '相談はこちらから';
+      break;
+
+    case 'announcements':
+      value = 0;
+      meaning = '新着なし';
+      break;
+
+    // マネージャー向け
+    case 'team_condition':
+      if (data.chaosData) {
+        const redCount = data.chaosData.teamData.filter(m => m.level === 'red').length;
+        const yellowCount = data.chaosData.teamData.filter(m => m.level === 'yellow').length;
+        value = redCount + yellowCount;
+        status = redCount > 0 ? 'critical' : yellowCount > 0 ? 'warning' : 'normal';
+        meaning = redCount > 0
+          ? `${redCount}人が要サポート`
+          : yellowCount > 0 ? `${yellowCount}人が余裕少なめ` : 'チームは順調';
+      }
+      break;
+
+    case 'pending_approvals':
+      if (data.ringiData) {
+        value = data.ringiData.pendingApproval;
+        status = getKPIStatus(value, definition);
+        meaning = getKPIMeaning(kpiId, value, status);
+      }
+      break;
+
+    case 'team_overtime':
+      value = 0; // TODO: チーム残業を実装
+      status = getKPIStatus(value, definition);
+      meaning = getKPIMeaning(kpiId, value, status);
+      break;
+
+    case 'support_queue':
+      if (data.interventionData) {
+        value = data.interventionData.open;
+        status = getKPIStatus(value, definition);
+        meaning = getKPIMeaning(kpiId, value, status);
+      }
+      break;
+
+    case 'intervention_rate':
+      if (data.interventionData) {
+        value = data.interventionData.rate;
+        status = getKPIStatus(value, definition);
+        meaning = getKPIMeaning(kpiId, value, status);
+      }
+      break;
+
+    case 'wbr_tasks':
+      value = 0; // TODO: WBRタスクを実装
+      status = getKPIStatus(value, definition);
+      meaning = getKPIMeaning(kpiId, value, status);
+      break;
+
+    // 経営向け
+    case 'occupancy_rate':
+      if (data.occupancyData) {
+        value = data.occupancyData.rate;
+        status = getKPIStatus(value, definition);
+        meaning = getKPIMeaning(kpiId, value, status);
+      }
+      break;
+
+    case 'expected_moveins':
+      if (data.salesData) {
+        value = data.salesData.expectedMoveIns;
+        meaning = `今月${value}件の見込み`;
+      }
+      break;
+
+    case 'org_condition':
+      if (data.chaosData) {
+        const redCount = data.chaosData.teamData.filter(m => m.level === 'red').length;
+        const yellowCount = data.chaosData.teamData.filter(m => m.level === 'yellow').length;
+        value = redCount + yellowCount;
+        status = redCount > 0 ? 'critical' : yellowCount > 0 ? 'warning' : 'normal';
+        meaning = `赤${redCount}/黄${yellowCount}`;
+      }
+      break;
+
+    case 'human_risk':
+      value = 0; // TODO: 人材リスクスコアを実装
+      status = getKPIStatus(value, definition);
+      meaning = getKPIMeaning(kpiId, value, status);
+      break;
+
+    case 'cashflow':
+      value = null; // TODO: キャッシュフローを実装
+      meaning = '準備中';
+      break;
+
+    default:
+      meaning = '未実装';
+  }
+
+  return {
+    id: kpiId,
+    value,
+    meaning,
+    status,
+  };
+}
+
+// ======== AI副社長サマリー生成 ========
+
+function generateAISummary(
+  kpis: KPIValue[],
+  role: DashboardRole,
+  data: {
+    chaosData: ChaosData | null;
+    interventionData: InterventionData | null;
+    ringiData: RingiData | null;
+  }
+): AIVPSummary {
+  const alertKpis = kpis.filter(k => k.status === 'critical' || k.status === 'warning');
+  const criticalKpis = kpis.filter(k => k.status === 'critical');
+
+  // ヘッドライン生成
+  let headline: string;
+  if (criticalKpis.length > 0) {
+    const kpiLabels = criticalKpis.map(k => KPI_DEFINITIONS[k.id]?.label).filter(Boolean);
+    headline = `${kpiLabels.slice(0, 2).join('と')}に対応が必要です`;
+  } else if (alertKpis.length > 0) {
+    headline = `${alertKpis.length}件の注意項目があります`;
+  } else {
+    headline = '現在、特に問題はありません';
+  }
+
+  // 優先アクション生成
+  const priorityActions: AIVPAction[] = [];
+
+  // 差戻し稟議
+  if (data.ringiData && data.ringiData.returned > 0) {
+    priorityActions.push({
+      id: 'ringi_returned',
+      title: `差戻し稟議 ${data.ringiData.returned}件`,
+      description: '再提出が必要な稟議があります',
+      href: '/dashboard/approvals',
+      priority: 'high',
+      isAlert: true,
+    });
+  }
+
+  // 承認待ち
+  if (data.ringiData && data.ringiData.pendingApproval > 0 && role !== 'staff') {
+    priorityActions.push({
+      id: 'pending_approval',
+      title: `承認待ち ${data.ringiData.pendingApproval}件`,
+      description: '承認依頼が届いています',
+      href: '/admin/ringi',
+      priority: data.ringiData.pendingApproval >= 5 ? 'high' : 'medium',
+      isAlert: data.ringiData.pendingApproval >= 5,
+    });
+  }
+
+  // サポートが必要なメンバー
+  if (data.chaosData && role !== 'staff') {
+    const redCount = data.chaosData.teamData.filter(m => m.level === 'red').length;
+    if (redCount > 0) {
+      priorityActions.push({
+        id: 'team_support',
+        title: `要サポート ${redCount}人`,
+        description: 'フォローが必要なメンバーがいます',
+        href: '/dashboard/os/team',
+        priority: 'high',
+        isAlert: true,
+      });
+    }
+  }
+
+  // 未対応の介入
+  if (data.interventionData && data.interventionData.open > 0 && role !== 'staff') {
+    priorityActions.push({
+      id: 'intervention_open',
+      title: `サポート待ち ${data.interventionData.open}件`,
+      description: '対応が必要なサポートがあります',
+      href: '/dashboard/os/team',
+      priority: data.interventionData.open >= 3 ? 'high' : 'medium',
+    });
+  }
+
+  return {
+    headline,
+    priorityActions: priorityActions.slice(0, 3),
+    alertCount: alertKpis.length,
+    updatedAt: new Date(),
+  };
+}

--- a/src/types/dashboard-kpi.ts
+++ b/src/types/dashboard-kpi.ts
@@ -1,0 +1,392 @@
+// ======== AA-HUB ダッシュボード KPI 型定義 ========
+
+import type { LucideIcon } from 'lucide-react';
+
+// ======== 役割 ========
+
+export type DashboardRole = 'staff' | 'manager' | 'exec';
+
+// ======== KPI状態 ========
+
+export type KPIStatus = 'normal' | 'warning' | 'critical';
+
+// ======== KPI定義 ========
+
+export interface KPIDefinition {
+  id: string;
+  label: string;
+  description: string;
+  unit?: string;
+  href: string;
+  roles: DashboardRole[];
+  // 異常判定の閾値
+  thresholds?: {
+    warning?: number;
+    critical?: number;
+    // 閾値を超えたら異常か、下回ったら異常か
+    direction: 'above' | 'below';
+  };
+}
+
+// ======== KPI値 ========
+
+export interface KPIValue {
+  id: string;
+  value: number | null;
+  meaning: string;
+  status: KPIStatus;
+  trend?: 'up' | 'down' | 'stable';
+  // 前期比（%）
+  change?: number;
+}
+
+// ======== AI副社長サマリー ========
+
+export interface AIVPSummary {
+  // 一言サマリー
+  headline: string;
+  // 優先アクション（最大3つ）
+  priorityActions: AIVPAction[];
+  // アラート数
+  alertCount: number;
+  // 最終更新
+  updatedAt: Date;
+}
+
+export interface AIVPAction {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  priority: 'high' | 'medium' | 'low';
+  // 異常フラグ
+  isAlert?: boolean;
+}
+
+// ======== ダッシュボードデータ ========
+
+export interface DashboardData {
+  role: DashboardRole;
+  aiSummary: AIVPSummary | null;
+  kpis: KPIValue[];
+  // 読み込み中フラグ
+  loading: boolean;
+  // エラー
+  error: string | null;
+}
+
+// ======== 役割別KPI設定 ========
+
+export const ROLE_KPI_CONFIG: Record<DashboardRole, string[]> = {
+  // スタッフ: 自分に関するKPI
+  staff: [
+    'my_checkin',        // 今日のコンディション
+    'my_tasks',          // 期限タスク
+    'my_approvals',      // 稟議状況
+    'my_overtime',       // 今月の残業
+    'team_support',      // サポート相談
+    'announcements',     // 重要連絡
+  ],
+  // マネージャー: チームに関するKPI
+  manager: [
+    'team_condition',    // チームコンディション
+    'pending_approvals', // 承認待ち
+    'team_overtime',     // チーム残業
+    'support_queue',     // サポート待ち
+    'intervention_rate', // 介入実施率
+    'wbr_tasks',         // WBR宿題
+  ],
+  // 経営: 全社KPI
+  exec: [
+    'occupancy_rate',    // 稼働率
+    'expected_moveins',  // 入居見込み
+    'org_condition',     // 組織コンディション
+    'human_risk',        // 人材リスク
+    'pending_approvals', // 承認待ち
+    'cashflow',          // キャッシュフロー
+  ],
+};
+
+// ======== KPI定義マスタ ========
+
+export const KPI_DEFINITIONS: Record<string, KPIDefinition> = {
+  // === スタッフ向け ===
+  my_checkin: {
+    id: 'my_checkin',
+    label: '今日のコンディション',
+    description: '本日の余裕メーター',
+    href: '/dashboard/os/checkin',
+    roles: ['staff'],
+  },
+  my_tasks: {
+    id: 'my_tasks',
+    label: '期限タスク',
+    description: '期限が近いタスク数',
+    unit: '件',
+    href: '/dashboard/ai/todos',
+    roles: ['staff'],
+    thresholds: { warning: 3, critical: 5, direction: 'above' },
+  },
+  my_approvals: {
+    id: 'my_approvals',
+    label: '稟議',
+    description: '申請中・差戻し',
+    unit: '件',
+    href: '/dashboard/approvals',
+    roles: ['staff', 'manager', 'exec'],
+    thresholds: { warning: 1, critical: 3, direction: 'above' },
+  },
+  my_overtime: {
+    id: 'my_overtime',
+    label: '今月の残業',
+    description: '当月の残業時間',
+    unit: '時間',
+    href: '/dashboard/attendance/overtime/new',
+    roles: ['staff'],
+    thresholds: { warning: 30, critical: 45, direction: 'above' },
+  },
+  team_support: {
+    id: 'team_support',
+    label: 'サポート相談',
+    description: '困っていることはありませんか？',
+    href: '/dashboard/chaos/checkin',
+    roles: ['staff'],
+  },
+  announcements: {
+    id: 'announcements',
+    label: '重要連絡',
+    description: '管理者からのお知らせ',
+    unit: '件',
+    href: '/dashboard/alerts/birthdays',
+    roles: ['staff'],
+    thresholds: { warning: 1, critical: 3, direction: 'above' },
+  },
+
+  // === マネージャー向け ===
+  team_condition: {
+    id: 'team_condition',
+    label: 'チームコンディション',
+    description: 'サポートが必要なメンバー',
+    unit: '人',
+    href: '/dashboard/os/team',
+    roles: ['manager', 'exec'],
+    thresholds: { warning: 1, critical: 2, direction: 'above' },
+  },
+  pending_approvals: {
+    id: 'pending_approvals',
+    label: '承認待ち',
+    description: '未処理の承認依頼',
+    unit: '件',
+    href: '/admin/ringi',
+    roles: ['manager', 'exec'],
+    thresholds: { warning: 3, critical: 5, direction: 'above' },
+  },
+  team_overtime: {
+    id: 'team_overtime',
+    label: 'チーム残業',
+    description: '45時間超のメンバー',
+    unit: '人',
+    href: '/admin/attendance/dashboard',
+    roles: ['manager'],
+    thresholds: { warning: 1, critical: 3, direction: 'above' },
+  },
+  support_queue: {
+    id: 'support_queue',
+    label: 'サポート待ち',
+    description: '対応が必要なサポート',
+    unit: '件',
+    href: '/dashboard/os/team',
+    roles: ['manager'],
+    thresholds: { warning: 1, critical: 3, direction: 'above' },
+  },
+  intervention_rate: {
+    id: 'intervention_rate',
+    label: '介入実施率',
+    description: 'サポート対応の完了率',
+    unit: '%',
+    href: '/dashboard/os/team',
+    roles: ['manager', 'exec'],
+    thresholds: { warning: 70, critical: 50, direction: 'below' },
+  },
+  wbr_tasks: {
+    id: 'wbr_tasks',
+    label: 'WBR宿題',
+    description: '週次レビューの残タスク',
+    unit: '件',
+    href: '/dashboard/wbr',
+    roles: ['manager'],
+    thresholds: { warning: 2, critical: 5, direction: 'above' },
+  },
+
+  // === 経営向け ===
+  occupancy_rate: {
+    id: 'occupancy_rate',
+    label: '稼働率',
+    description: '施設全体の入居率',
+    unit: '%',
+    href: '/dashboard/vacancy',
+    roles: ['exec'],
+    thresholds: { warning: 85, critical: 75, direction: 'below' },
+  },
+  expected_moveins: {
+    id: 'expected_moveins',
+    label: '入居見込み',
+    description: '今月の入居予測数',
+    unit: '件',
+    href: '/dashboard/prospects',
+    roles: ['exec'],
+  },
+  org_condition: {
+    id: 'org_condition',
+    label: '組織コンディション',
+    description: '赤/黄メンバー数',
+    href: '/dashboard/os/team',
+    roles: ['exec'],
+    thresholds: { warning: 2, critical: 4, direction: 'above' },
+  },
+  human_risk: {
+    id: 'human_risk',
+    label: '人材リスク',
+    description: '組織の不安定化リスク',
+    unit: '点',
+    href: '/dashboard/ai-vp/human-risk',
+    roles: ['exec'],
+    thresholds: { warning: 50, critical: 70, direction: 'above' },
+  },
+  cashflow: {
+    id: 'cashflow',
+    label: 'キャッシュフロー',
+    description: '今月の資金繰り予測',
+    unit: '万円',
+    href: '/dashboard/admin',
+    roles: ['exec'],
+  },
+};
+
+// ======== ユーティリティ ========
+
+/**
+ * KPIのステータスを判定
+ */
+export function getKPIStatus(
+  value: number | null,
+  definition: KPIDefinition
+): KPIStatus {
+  if (value === null) return 'normal';
+  if (!definition.thresholds) return 'normal';
+
+  const { warning, critical, direction } = definition.thresholds;
+
+  if (direction === 'above') {
+    if (critical !== undefined && value >= critical) return 'critical';
+    if (warning !== undefined && value >= warning) return 'warning';
+  } else {
+    if (critical !== undefined && value <= critical) return 'critical';
+    if (warning !== undefined && value <= warning) return 'warning';
+  }
+
+  return 'normal';
+}
+
+/**
+ * KPIの意味テキストを生成
+ */
+export function getKPIMeaning(
+  kpiId: string,
+  value: number | null,
+  status: KPIStatus
+): string {
+  if (value === null) return 'データなし';
+
+  const meanings: Record<string, Record<KPIStatus, string>> = {
+    my_checkin: {
+      normal: '順調です',
+      warning: '少し疲れ気味',
+      critical: 'サポートが必要かも',
+    },
+    my_tasks: {
+      normal: 'タスクは余裕あり',
+      warning: '期限が近いものあり',
+      critical: '優先対応が必要',
+    },
+    my_approvals: {
+      normal: '申請なし',
+      warning: '差戻しあり',
+      critical: '対応が必要',
+    },
+    my_overtime: {
+      normal: '適正範囲',
+      warning: '上限に近づいています',
+      critical: '上限超過の恐れ',
+    },
+    team_condition: {
+      normal: 'チームは順調',
+      warning: 'フォローが必要なメンバーあり',
+      critical: '早急なサポートが必要',
+    },
+    pending_approvals: {
+      normal: '承認待ちなし',
+      warning: '承認待ちあり',
+      critical: '滞留しています',
+    },
+    team_overtime: {
+      normal: '適正範囲',
+      warning: '残業過多のメンバーあり',
+      critical: '早急な対応が必要',
+    },
+    support_queue: {
+      normal: 'サポート待ちなし',
+      warning: '対応が必要',
+      critical: '早急な対応が必要',
+    },
+    intervention_rate: {
+      normal: '順調に対応中',
+      warning: '対応が遅れ気味',
+      critical: '対応が滞っています',
+    },
+    wbr_tasks: {
+      normal: '完了済み',
+      warning: '残タスクあり',
+      critical: '未完了が多い',
+    },
+    occupancy_rate: {
+      normal: '順調',
+      warning: '空室が増加傾向',
+      critical: '要営業強化',
+    },
+    expected_moveins: {
+      normal: '見込みあり',
+      warning: '見込み少なめ',
+      critical: '要営業強化',
+    },
+    org_condition: {
+      normal: '組織は安定',
+      warning: '注意が必要なチームあり',
+      critical: '早急なフォローが必要',
+    },
+    human_risk: {
+      normal: '安定',
+      warning: '注意が必要',
+      critical: '介入検討が必要',
+    },
+    cashflow: {
+      normal: '余裕あり',
+      warning: '注意が必要',
+      critical: '要確認',
+    },
+  };
+
+  return meanings[kpiId]?.[status] || (status === 'normal' ? '正常' : '要確認');
+}
+
+/**
+ * 役割のラベルを取得
+ */
+export function getRoleLabel(role: DashboardRole): string {
+  const labels: Record<DashboardRole, string> = {
+    staff: 'スタッフ',
+    manager: 'マネージャー',
+    exec: '経営',
+  };
+  return labels[role];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -299,3 +299,6 @@ export * from './request-engine';
 
 // 入居者管理関連の型をre-export
 export * from './resident';
+
+// ダッシュボードKPI関連の型をre-export
+export * from './dashboard-kpi';


### PR DESCRIPTION
- 役割別（staff/manager/exec）KPI切り替え対応
- KPIカードコンポーネント（数値＋意味＋アクションリンク）
- AI副社長サマリーカード（最上段配置）
- 異常系のみ色表示（通常は白/グレー）
- カードベース・余白重視のデザイン
- KPIは最大6つまで表示

https://claude.ai/code/session_01Y6sU6UcgL1Qo7sEXM1XAoW

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
