### PR TITLE
feat: Ticket 123 営業タスク完了時の結果入力（reasonコード）＋学習用ログ

### DIFF
--- a/src/app/api/tickets/[id]/complete-sales-task/route.ts
+++ b/src/app/api/tickets/[id]/complete-sales-task/route.ts
@@ -1,0 +1,96 @@
+/**
+ * 営業タスク完了API
+ *
+ * POST /api/tickets/[id]/complete-sales-task
+ *
+ * Ticket 123: 営業タスク完了時の結果入力
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { completeSalesTask } from '@/lib/tickets/repo';
+import type { AppRole } from '@/config/appRoles';
+import type { SalesTaskResultCode } from '@/lib/tickets/types';
+
+// デモユーザー情報（本番ではセッションから取得）
+const DEMO_USER = {
+  id: 'user_003',
+  name: '鈴木花子',
+  role: 'manager' as AppRole,
+};
+
+const VALID_RESULT_CODES: SalesTaskResultCode[] = [
+  'contacted_success',
+  'no_answer',
+  'wrong_number',
+  'not_interested',
+  'needs_more_time',
+  'tour_scheduled',
+  'applied',
+  'accepted',
+  'rejected',
+  'other',
+];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { resultCode, resultNote, nextFollowUpAt } = body;
+
+    // resultCode バリデーション（必須）
+    if (!resultCode) {
+      return NextResponse.json(
+        { error: '結果コード（resultCode）は必須です' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_RESULT_CODES.includes(resultCode)) {
+      return NextResponse.json(
+        { error: '無効な結果コードです' },
+        { status: 400 }
+      );
+    }
+
+    // nextFollowUpAt バリデーション（任意、ISO日付形式）
+    if (nextFollowUpAt && isNaN(Date.parse(nextFollowUpAt))) {
+      return NextResponse.json(
+        { error: '次回フォローアップ日時が不正です' },
+        { status: 400 }
+      );
+    }
+
+    const viewer = { userId: DEMO_USER.id, role: DEMO_USER.role };
+    const result = completeSalesTask(
+      id,
+      {
+        resultCode,
+        resultNote: resultNote ?? undefined,
+        nextFollowUpAt: nextFollowUpAt ?? undefined,
+      },
+      viewer
+    );
+
+    if (!result.success) {
+      const statusCode = result.error === 'チケットが見つかりません' ? 404 : 403;
+      return NextResponse.json(
+        { error: result.error },
+        { status: statusCode }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      ticket: result.ticket,
+    });
+  } catch (error) {
+    console.error('complete-sales-task POST error:', error);
+    return NextResponse.json(
+      { error: '営業タスクの完了に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/tickets/[id]/page.tsx
+++ b/src/app/dashboard/tickets/[id]/page.tsx
@@ -37,6 +37,7 @@ import type {
   TicketStatus,
   VacancyInquiryStage,
   ApplicationChannel,
+  SalesTaskResultCode,
 } from '@/lib/tickets/types';
 import {
   TICKET_STATUS_CONFIG,
@@ -44,6 +45,7 @@ import {
   TICKET_CATEGORY_CONFIG,
   TICKET_EVENT_ACTION_LABELS,
   VACANCY_INQUIRY_STAGE_CONFIG,
+  SALES_TASK_RESULT_CONFIG,
 } from '@/lib/tickets/types';
 import type { ReplyTemplate, TemplateVariable } from '@/lib/replyTemplates/types';
 
@@ -122,6 +124,19 @@ export default function TicketDetailPage() {
     { id: string; name: string; unitType: string; availableCount: number }[]
   >([]);
   const [vacancyUnitsLoading, setVacancyUnitsLoading] = useState(false);
+
+  // Ticket 123: 営業タスク完了
+  const [showCompleteSalesTaskModal, setShowCompleteSalesTaskModal] = useState(false);
+  const [completeSalesTaskLoading, setCompleteSalesTaskLoading] = useState(false);
+  const [completeSalesTaskForm, setCompleteSalesTaskForm] = useState<{
+    resultCode: SalesTaskResultCode | '';
+    resultNote: string;
+    nextFollowUpAt: string;
+  }>({
+    resultCode: '',
+    resultNote: '',
+    nextFollowUpAt: '',
+  });
 
   const fetchTicket = useCallback(async () => {
     try {
@@ -408,6 +423,64 @@ export default function TicketDetailPage() {
     setSelectedTemplate(null);
     setTemplateVariables({});
     setExpandedContent(null);
+  };
+
+  // Ticket 123: 営業タスク完了可能かどうかを判定
+  const canCompleteSalesTask = (t: Ticket): boolean => {
+    if (t.relatedType !== 'sales_next_action') return false;
+    // 既にクローズ済みなら不可
+    if (t.status === 'closed' || t.status === 'archived') return false;
+    return true;
+  };
+
+  // Ticket 123: 営業タスク完了の送信
+  const handleCompleteSalesTaskSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (completeSalesTaskLoading) return;
+    if (!completeSalesTaskForm.resultCode) {
+      alert('結果コードを選択してください');
+      return;
+    }
+
+    setCompleteSalesTaskLoading(true);
+    try {
+      const body: Record<string, unknown> = {
+        resultCode: completeSalesTaskForm.resultCode,
+      };
+
+      if (completeSalesTaskForm.resultNote) {
+        body.resultNote = completeSalesTaskForm.resultNote;
+      }
+      if (completeSalesTaskForm.nextFollowUpAt) {
+        body.nextFollowUpAt = completeSalesTaskForm.nextFollowUpAt;
+      }
+
+      const res = await fetch(`/api/tickets/${id}/complete-sales-task`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (res.ok) {
+        setShowCompleteSalesTaskModal(false);
+        setCompleteSalesTaskForm({
+          resultCode: '',
+          resultNote: '',
+          nextFollowUpAt: '',
+        });
+        // データを再取得
+        fetchTicket();
+        fetchEvents();
+      } else {
+        const data = await res.json();
+        alert(data.error || '営業タスクの完了に失敗しました');
+      }
+    } catch (err) {
+      console.error('Failed to complete sales task:', err);
+      alert('営業タスクの完了に失敗しました');
+    } finally {
+      setCompleteSalesTaskLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -947,6 +1020,79 @@ export default function TicketDetailPage() {
               </Card>
             )}
 
+            {/* Ticket 123: 営業タスク完了（sales_next_actionの場合） */}
+            {ticket.relatedType === 'sales_next_action' && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <ClipboardCheck className="w-4 h-4" />
+                    営業タスク
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {/* 完了済みの場合は結果表示 */}
+                  {ticket.metaJson?.resultCode && (
+                    <div className="space-y-2 text-sm mb-3 p-3 bg-zinc-50 rounded-lg border border-zinc-200">
+                      <div className="flex items-center gap-2">
+                        <CheckCircle className="w-4 h-4 text-green-600" />
+                        <span className="font-medium">完了</span>
+                      </div>
+                      <div className="text-zinc-600">
+                        <span className="text-xs text-zinc-400">結果:</span>{' '}
+                        <span className={SALES_TASK_RESULT_CONFIG[ticket.metaJson.resultCode as SalesTaskResultCode]?.color || ''}>
+                          {SALES_TASK_RESULT_CONFIG[ticket.metaJson.resultCode as SalesTaskResultCode]?.label || ticket.metaJson.resultCode}
+                        </span>
+                      </div>
+                      {ticket.metaJson.completedAt && (
+                        <div className="text-zinc-600">
+                          <span className="text-xs text-zinc-400">完了日時:</span>{' '}
+                          {new Date(ticket.metaJson.completedAt as string).toLocaleDateString('ja-JP', {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </div>
+                      )}
+                      {ticket.metaJson.resultNote && (
+                        <div className="text-zinc-600">
+                          <span className="text-xs text-zinc-400">メモ:</span>{' '}
+                          {ticket.metaJson.resultNote as string}
+                        </div>
+                      )}
+                      {ticket.metaJson.nextFollowUpAt && (
+                        <div className="text-zinc-600">
+                          <span className="text-xs text-zinc-400">次回フォロー:</span>{' '}
+                          {new Date(ticket.metaJson.nextFollowUpAt as string).toLocaleDateString('ja-JP', {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* 完了ボタン */}
+                  {canCompleteSalesTask(ticket) && (
+                    <>
+                      <p className="text-zinc-500 text-sm mb-3">
+                        営業タスクを完了したら結果を記録してください
+                      </p>
+                      <button
+                        onClick={() => setShowCompleteSalesTaskModal(true)}
+                        className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors text-sm"
+                      >
+                        <CheckCircle className="w-4 h-4" />
+                        完了する
+                      </button>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
             {/* 詳細情報 */}
             <Card>
               <CardHeader>
@@ -1478,6 +1624,116 @@ export default function TicketDetailPage() {
                   <button
                     type="button"
                     onClick={() => setShowAcceptModal(false)}
+                    className="px-4 py-2 border border-zinc-200 rounded-lg hover:bg-zinc-50 transition-colors text-sm"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        )}
+
+        {/* Ticket 123: 営業タスク完了モーダル */}
+        {showCompleteSalesTaskModal && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-xl w-full max-w-md mx-4 p-6 max-h-[90vh] overflow-y-auto">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-bold">営業タスクを完了</h3>
+                <button
+                  onClick={() => setShowCompleteSalesTaskModal(false)}
+                  className="p-1 hover:bg-zinc-100 rounded"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+
+              <form onSubmit={handleCompleteSalesTaskSubmit} className="space-y-4">
+                {/* 結果コード（必須） */}
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 mb-1">
+                    結果 <span className="text-red-500">*</span>
+                  </label>
+                  <select
+                    value={completeSalesTaskForm.resultCode}
+                    onChange={(e) =>
+                      setCompleteSalesTaskForm((prev) => ({
+                        ...prev,
+                        resultCode: e.target.value as SalesTaskResultCode | '',
+                      }))
+                    }
+                    className="w-full px-3 py-2 border border-zinc-200 rounded-lg text-sm"
+                    required
+                  >
+                    <option value="">選択してください</option>
+                    {Object.entries(SALES_TASK_RESULT_CONFIG).map(([code, config]) => (
+                      <option key={code} value={code}>
+                        {config.icon} {config.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* 結果メモ（任意） */}
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 mb-1">
+                    メモ
+                  </label>
+                  <textarea
+                    value={completeSalesTaskForm.resultNote}
+                    onChange={(e) =>
+                      setCompleteSalesTaskForm((prev) => ({
+                        ...prev,
+                        resultNote: e.target.value,
+                      }))
+                    }
+                    placeholder="対応内容や結果の詳細を入力"
+                    rows={3}
+                    className="w-full px-3 py-2 border border-zinc-200 rounded-lg text-sm resize-none"
+                  />
+                </div>
+
+                {/* 次回フォローアップ日（任意） */}
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 mb-1">
+                    次回フォローアップ日
+                  </label>
+                  <input
+                    type="date"
+                    value={completeSalesTaskForm.nextFollowUpAt}
+                    onChange={(e) =>
+                      setCompleteSalesTaskForm((prev) => ({
+                        ...prev,
+                        nextFollowUpAt: e.target.value,
+                      }))
+                    }
+                    className="w-full px-3 py-2 border border-zinc-200 rounded-lg text-sm"
+                  />
+                  <p className="text-xs text-zinc-500 mt-1">
+                    検討継続などの場合に次の連絡予定日を入力
+                  </p>
+                </div>
+
+                <div className="bg-indigo-50 p-3 rounded-lg text-sm">
+                  <p className="text-indigo-700 font-medium mb-1">確認事項</p>
+                  <ul className="text-indigo-600 text-xs space-y-1 list-disc list-inside">
+                    <li>タスクが完了（クローズ）されます</li>
+                    <li>結果は分析・学習に使用されます</li>
+                  </ul>
+                </div>
+
+                <div className="flex gap-2 pt-2">
+                  <button
+                    type="submit"
+                    disabled={completeSalesTaskLoading || !completeSalesTaskForm.resultCode}
+                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors text-sm"
+                  >
+                    <CheckCircle className="w-4 h-4" />
+                    {completeSalesTaskLoading ? '処理中...' : '完了を確定'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowCompleteSalesTaskModal(false)}
                     className="px-4 py-2 border border-zinc-200 rounded-lg hover:bg-zinc-50 transition-colors text-sm"
                   >
                     キャンセル

--- a/src/lib/tickets/repo.ts
+++ b/src/lib/tickets/repo.ts
@@ -876,6 +876,125 @@ export function getSlaBreachedTickets(): Ticket[] {
     .filter(isSlaBreached);
 }
 
+// ========== Ticket 123: 営業タスク完了 ==========
+
+import type { SalesTaskResultCode } from './types';
+
+export interface CompleteSalesTaskRequest {
+  resultCode: SalesTaskResultCode;
+  resultNote?: string;
+  nextFollowUpAt?: string;
+}
+
+export interface CompleteSalesTaskResult {
+  success: boolean;
+  error?: string;
+  ticket?: Ticket;
+}
+
+/**
+ * 営業タスク（sales_next_action）を完了させる
+ *
+ * - resultCode が必須
+ * - チケットステータスを closed に変更
+ * - meta に結果情報を保存
+ * - events に sales_task_completed を記録
+ * - originTicketId がある場合、元チケットへの連動処理（任意）
+ */
+export function completeSalesTask(
+  ticketId: string,
+  data: CompleteSalesTaskRequest,
+  viewer: ViewerContext
+): CompleteSalesTaskResult {
+  const ticket = ticketsStore.get(ticketId);
+
+  if (!ticket) {
+    return { success: false, error: 'チケットが見つかりません' };
+  }
+
+  // sales_next_action チケットのみ対象
+  if (ticket.relatedType !== 'sales_next_action') {
+    return { success: false, error: 'このチケットは営業タスクではありません' };
+  }
+
+  // 既にクローズ済みなら不可
+  if (ticket.status === 'closed' || ticket.status === 'archived') {
+    return { success: false, error: 'このチケットは既にクローズ済みです' };
+  }
+
+  // RBAC: assignee または manager以上
+  const isAssignee = ticket.assigneeUserId === viewer.userId;
+  const isManager = ['manager', 'executive', 'admin'].includes(viewer.role);
+
+  if (!isAssignee && !isManager) {
+    return { success: false, error: '営業タスクを完了する権限がありません' };
+  }
+
+  const now = new Date().toISOString();
+  const beforeStatus = ticket.status;
+  const beforeMeta = { ...(ticket.metaJson || {}) };
+
+  // meta を更新
+  const newMeta = {
+    ...ticket.metaJson,
+    resultCode: data.resultCode,
+    resultNote: data.resultNote ?? undefined,
+    completedAt: now,
+    nextFollowUpAt: data.nextFollowUpAt ?? undefined,
+  };
+  ticket.metaJson = newMeta;
+
+  // ステータスを closed に変更
+  ticket.status = 'closed';
+  ticket.closedAt = now;
+  ticket.updatedAt = now;
+
+  // イベント記録
+  recordEvent(
+    ticketId,
+    'sales_task_completed',
+    viewer.userId,
+    { status: beforeStatus, meta: beforeMeta },
+    { status: 'closed', meta: newMeta, resultCode: data.resultCode },
+    data.resultNote || null
+  );
+
+  // 元チケットがある場合、結果に応じたステージ更新（任意）
+  const originTicketId = ticket.metaJson?.originTicketId as string | undefined;
+  if (originTicketId) {
+    const originTicket = ticketsStore.get(originTicketId);
+    if (originTicket && originTicket.pipeline === 'vacancy_inquiry') {
+      // 結果コードに応じたステージ更新提案
+      // tour_scheduled → tour_scheduled
+      // applied → applied
+      // accepted → accepted
+      const stageMapping: Partial<Record<SalesTaskResultCode, VacancyInquiryStage>> = {
+        tour_scheduled: 'tour_scheduled',
+        applied: 'applied',
+        accepted: 'accepted',
+        rejected: 'rejected',
+      };
+
+      const suggestedStage = stageMapping[data.resultCode];
+      if (suggestedStage && originTicket.stage !== suggestedStage) {
+        // コメントを追加して記録（自動更新はしない）
+        const comment: TicketComment = {
+          id: generateCommentId(),
+          ticketId: originTicketId,
+          userId: viewer.userId,
+          userName: getUserName(viewer.userId),
+          message: `営業タスク完了: ${data.resultCode}${data.resultNote ? ` - ${data.resultNote}` : ''}`,
+          createdAt: now,
+        };
+        commentsStore.set(comment.id, comment);
+        originTicket.updatedAt = now;
+      }
+    }
+  }
+
+  return { success: true, ticket };
+}
+
 // ========== コメント追加 ==========
 
 export function addTicketComment(

--- a/src/lib/tickets/types.ts
+++ b/src/lib/tickets/types.ts
@@ -49,6 +49,90 @@ export type TicketRelatedType =
   | null;
 
 /**
+ * Ticket 123: 営業タスク結果コード
+ */
+export type SalesTaskResultCode =
+  | 'contacted_success'   // 連絡成功
+  | 'no_answer'           // 不在
+  | 'wrong_number'        // 番号違い
+  | 'not_interested'      // 興味なし
+  | 'needs_more_time'     // 検討継続
+  | 'tour_scheduled'      // 内覧日程確定
+  | 'applied'             // 申込へ
+  | 'accepted'            // 受入決定
+  | 'rejected'            // 失注
+  | 'other';              // その他
+
+/**
+ * Ticket 123: 営業タスク結果コード表示設定
+ */
+export const SALES_TASK_RESULT_CONFIG: Record<
+  SalesTaskResultCode,
+  { label: string; color: string; bg: string; icon: string }
+> = {
+  contacted_success: {
+    label: '連絡成功',
+    color: 'text-green-700',
+    bg: 'bg-green-50',
+    icon: '✓',
+  },
+  no_answer: {
+    label: '不在',
+    color: 'text-amber-700',
+    bg: 'bg-amber-50',
+    icon: '📞',
+  },
+  wrong_number: {
+    label: '番号違い',
+    color: 'text-red-700',
+    bg: 'bg-red-50',
+    icon: '✗',
+  },
+  not_interested: {
+    label: '興味なし',
+    color: 'text-zinc-700',
+    bg: 'bg-zinc-50',
+    icon: '−',
+  },
+  needs_more_time: {
+    label: '検討継続',
+    color: 'text-blue-700',
+    bg: 'bg-blue-50',
+    icon: '⏳',
+  },
+  tour_scheduled: {
+    label: '内覧日程確定',
+    color: 'text-purple-700',
+    bg: 'bg-purple-50',
+    icon: '📅',
+  },
+  applied: {
+    label: '申込へ',
+    color: 'text-yellow-700',
+    bg: 'bg-yellow-50',
+    icon: '📝',
+  },
+  accepted: {
+    label: '受入決定',
+    color: 'text-green-700',
+    bg: 'bg-green-50',
+    icon: '🎉',
+  },
+  rejected: {
+    label: '失注',
+    color: 'text-red-700',
+    bg: 'bg-red-50',
+    icon: '✗',
+  },
+  other: {
+    label: 'その他',
+    color: 'text-zinc-600',
+    bg: 'bg-zinc-50',
+    icon: '•',
+  },
+};
+
+/**
  * Ticket 071: パイプラインタイプ
  */
 export type TicketPipeline = 'vacancy_inquiry' | null;
@@ -79,6 +163,7 @@ export type TicketEventAction =
   | 'merge_inquiry'     // Ticket 079: 重複問い合わせ統合
   | 'mark_applied'      // Ticket 084: 申込記録
   | 'mark_accepted'     // Ticket 085: 受入決定
+  | 'sales_task_completed'  // Ticket 123: 営業タスク完了
   | 'comment'
   | 'resolve'
   | 'close'
@@ -105,6 +190,12 @@ export interface TicketMeta {
   acceptedNote?: string;             // 受入決定メモ
   reservedVacancyUnitId?: string;    // 予約確定した空室ユニットID
   acceptedByUserId?: string;         // 受入決定した担当者ID
+  // Ticket 123: 営業タスク完了結果
+  originTicketId?: string;           // 元の問い合わせチケットID
+  resultCode?: SalesTaskResultCode;  // 結果コード
+  resultNote?: string;               // 結果メモ
+  completedAt?: string;              // 完了日時（ISO）
+  nextFollowUpAt?: string;           // 次回フォローアップ日時（ISO）
   [key: string]: unknown;
 }
 
@@ -386,6 +477,7 @@ export const TICKET_EVENT_ACTION_LABELS: Record<TicketEventAction, string> = {
   merge_inquiry: '問い合わせ統合', // Ticket 079
   mark_applied: '申込記録',       // Ticket 084
   mark_accepted: '受入決定',      // Ticket 085
+  sales_task_completed: '営業タスク完了', // Ticket 123
   comment: 'コメント',
   resolve: '解決',
   close: 'クローズ',


### PR DESCRIPTION
- types.ts: SalesTaskResultCode 型追加（10種類の結果コード）
- types.ts: SALES_TASK_RESULT_CONFIG 表示設定追加
- types.ts: TicketMeta に resultCode/resultNote/completedAt/nextFollowUpAt 追加
- types.ts: TicketEventAction に sales_task_completed 追加
- repo.ts: completeSalesTask 関数追加（結果保存・イベント記録・元チケット連動）
- API: POST /api/tickets/[id]/complete-sales-task 追加
- UI: ticket詳細に営業タスク完了モーダル追加

https://claude.ai/code/session_01YP8BoySPijdSxjr3kmb7uj

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
