### PR TITLE
fix: SalesTaskResultCode → SalesResultCode 型安全変換マッパー追加

### DIFF
--- a/src/lib/tickets/repo.ts
+++ b/src/lib/tickets/repo.ts
@@ -879,6 +879,7 @@ export function getSlaBreachedTickets(): Ticket[] {
 // ========== Ticket 123: 営業タスク完了 ==========
 
 import type { SalesTaskResultCode } from './types';
+import { mapTaskResultToSalesResult } from './types';
 
 export interface CompleteSalesTaskRequest {
   resultCode: SalesTaskResultCode;
@@ -934,10 +935,12 @@ export function completeSalesTask(
   const beforeStatus = ticket.status;
   const beforeMeta = { ...(ticket.metaJson || {}) };
 
-  // meta を更新
+  // meta を更新（正規化結果コードも保存）
+  const normalizedResultCode = mapTaskResultToSalesResult(data.resultCode);
   const newMeta = {
     ...ticket.metaJson,
     resultCode: data.resultCode,
+    normalizedResultCode,
     resultNote: data.resultNote ?? undefined,
     completedAt: now,
     nextFollowUpAt: data.nextFollowUpAt ?? undefined,

--- a/src/lib/tickets/types.ts
+++ b/src/lib/tickets/types.ts
@@ -133,6 +133,48 @@ export const SALES_TASK_RESULT_CONFIG: Record<
 };
 
 /**
+ * Ticket 123: 営業タスク結果コード（正規化版）
+ * metaJson 保存用の正規化された結果コード
+ */
+export type SalesResultCode =
+  | 'success'   // 成功系（connected_success, tour_scheduled, applied, accepted）
+  | 'failure'   // 失敗系（wrong_number, not_interested, rejected）
+  | 'pending'   // 継続系（no_answer, needs_more_time）
+  | 'other';    // その他
+
+/**
+ * Ticket 123: SalesTaskResultCode → SalesResultCode 変換マッパー
+ * 型安全にタスク結果を正規化結果に変換する
+ */
+export function mapTaskResultToSalesResult(
+  input: SalesTaskResultCode | undefined
+): SalesResultCode | undefined {
+  if (!input) return undefined;
+
+  switch (input) {
+    // 成功系
+    case 'contacted_success':
+    case 'tour_scheduled':
+    case 'applied':
+    case 'accepted':
+      return 'success';
+    // 失敗系
+    case 'wrong_number':
+    case 'not_interested':
+    case 'rejected':
+      return 'failure';
+    // 継続系
+    case 'no_answer':
+    case 'needs_more_time':
+      return 'pending';
+    // その他
+    case 'other':
+    default:
+      return 'other';
+  }
+}
+
+/**
  * Ticket 071: パイプラインタイプ
  */
 export type TicketPipeline = 'vacancy_inquiry' | null;
@@ -191,11 +233,12 @@ export interface TicketMeta {
   reservedVacancyUnitId?: string;    // 予約確定した空室ユニットID
   acceptedByUserId?: string;         // 受入決定した担当者ID
   // Ticket 123: 営業タスク完了結果
-  originTicketId?: string;           // 元の問い合わせチケットID
-  resultCode?: SalesTaskResultCode;  // 結果コード
-  resultNote?: string;               // 結果メモ
-  completedAt?: string;              // 完了日時（ISO）
-  nextFollowUpAt?: string;           // 次回フォローアップ日時（ISO）
+  originTicketId?: string;              // 元の問い合わせチケットID
+  resultCode?: SalesTaskResultCode;     // 結果コード（詳細・表示用）
+  normalizedResultCode?: SalesResultCode; // 結果コード（正規化・分析用）
+  resultNote?: string;                  // 結果メモ
+  completedAt?: string;                 // 完了日時（ISO）
+  nextFollowUpAt?: string;              // 次回フォローアップ日時（ISO）
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
- types.ts: SalesResultCode 型追加（success/failure/pending/other）
- types.ts: mapTaskResultToSalesResult() マッパー関数追加
- types.ts: TicketMeta に normalizedResultCode フィールド追加
- repo.ts: completeSalesTask で正規化結果コードも保存

型安全・将来拡張可能な実装、as any / as unknown 使用なし

https://claude.ai/code/session_01YP8BoySPijdSxjr3kmb7uj

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
