### PR TITLE
feat: Launch Mode 実装（先行カットオーバー用4機能公開）

### DIFF
--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Link from 'next/link';
+import { Users, Building2, Clock, CheckCircle, ArrowLeft } from 'lucide-react';
+import { LAUNCH_NAV_ITEMS } from '@/config/launchRoutes';
+
+const iconMap: Record<string, React.ElementType> = {
+  Users,
+  Building2,
+  Clock,
+  CheckCircle,
+};
+
+export default function ComingSoonPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center p-4">
+      <div className="max-w-2xl w-full">
+        {/* メインカード */}
+        <div className="bg-white rounded-2xl shadow-xl p-8 md:p-12 text-center">
+          {/* アイコン */}
+          <div className="w-20 h-20 mx-auto mb-6 bg-slate-100 rounded-full flex items-center justify-center">
+            <svg
+              className="w-10 h-10 text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
+              />
+            </svg>
+          </div>
+
+          {/* タイトル */}
+          <h1 className="text-3xl md:text-4xl font-bold text-slate-800 mb-4">
+            準備中
+          </h1>
+
+          {/* 説明文 */}
+          <p className="text-slate-600 text-lg mb-8 leading-relaxed">
+            この機能は現在開発中です。
+            <br className="hidden sm:block" />
+            先行公開中の機能をご利用ください。
+          </p>
+
+          {/* 区切り線 */}
+          <div className="border-t border-slate-200 my-8" />
+
+          {/* 利用可能な機能 */}
+          <p className="text-sm text-slate-500 mb-6 font-medium">
+            ご利用いただける機能
+          </p>
+
+          {/* 4機能ボタン */}
+          <div className="grid grid-cols-2 gap-4">
+            {LAUNCH_NAV_ITEMS.map((item) => {
+              const Icon = iconMap[item.icon] || Users;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="group flex flex-col items-center p-6 bg-slate-50 hover:bg-blue-50 rounded-xl transition-all duration-200 border border-slate-200 hover:border-blue-300 hover:shadow-md"
+                >
+                  <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center mb-3 shadow-sm group-hover:shadow group-hover:bg-blue-100 transition-all">
+                    <Icon className="w-6 h-6 text-slate-600 group-hover:text-blue-600 transition-colors" />
+                  </div>
+                  <span className="font-semibold text-slate-700 group-hover:text-blue-700 transition-colors">
+                    {item.label}
+                  </span>
+                  <span className="text-xs text-slate-400 mt-1">
+                    {item.description}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+
+          {/* ホームへ戻る */}
+          <div className="mt-8 pt-6 border-t border-slate-200">
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center gap-2 text-slate-500 hover:text-slate-700 transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span>ホームに戻る</span>
+            </Link>
+          </div>
+        </div>
+
+        {/* フッター */}
+        <p className="text-center text-sm text-slate-400 mt-6">
+          順次機能を追加していきます。ご理解のほどお願いいたします。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { getChaosViewLevel, hasMinRole } from '@/lib/auth';
 import { RoleHomePage } from '@/components/roleHome';
 import { Card, CardContent } from '@/components/ui';
+import { LaunchModeDashboard } from '@/components/launchMode';
+import { LAUNCH_MODE } from '@/config/launchMode';
 import type { AppRole } from '@/config/appRoles';
 import type { UserRole } from '@/types';
 import {
@@ -309,8 +311,15 @@ function DashboardContent() {
  * Task 053: Role Home を /dashboard に完全接続
  * - getEffectiveRole(asRole) を使って role を確定
  * - asRole は admin のみ有効（URLクエリ ?asRole=staff 等）
+ *
+ * Launch Mode: NEXT_PUBLIC_LAUNCH_MODE=true の場合、4機能専用UIを表示
  */
 export default function DashboardPage() {
+  // Launch Mode の場合は専用ダッシュボードを表示
+  if (LAUNCH_MODE) {
+    return <LaunchModeDashboard />;
+  }
+
   return (
     <Suspense
       fallback={

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,11 +5,27 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
-import { Home, FileText, BarChart3, Trophy, Settings, LogOut, Clock, Users, ClipboardList, Lightbulb, Star, Shield, ChevronDown, Building2, Megaphone, UserPlus, Brain, Briefcase, Activity, Bot } from 'lucide-react';
+import { Home, FileText, BarChart3, Trophy, Settings, LogOut, Clock, Users, ClipboardList, Lightbulb, Star, Shield, ChevronDown, Building2, Megaphone, UserPlus, Brain, Briefcase, Activity, Bot, Sparkles } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications/NotificationBell';
 import { RoleSwitcher } from '@/components/navigation/RoleSwitcher';
 import { cn } from '@/lib/utils';
 import { isAiVpOwner } from '@/lib/auth';
+import { LAUNCH_MODE } from '@/config/launchMode';
+
+// Launch Mode で許可するナビゲーションのhref
+const LAUNCH_MODE_NAV_HREFS = [
+  '/dashboard',
+  '/attendance',
+  '/dashboard/approvals',
+  '/dashboard/prospects',
+  '/dashboard/vacancy',
+];
+
+// Launch Mode で許可する管理メニューのhref
+const LAUNCH_MODE_ADMIN_HREFS = [
+  '/admin/attendance/dashboard',
+  '/dashboard/admin/ringi',
+];
 
 export function Header() {
   const { user, isLeaderOrAbove, signOut } = useAuth();
@@ -39,7 +55,7 @@ export function Header() {
 
   // メニュー順序（確定版）:
   // 1.打刻 2.稟議 3.入居希望 4.営業進捗 5.空室 6.改善 7.ランク 8.経営OS 9.報告(ヒヤリ)
-  const navItems = [
+  const allNavItems = [
     { href: '/dashboard', label: 'ホーム', icon: Home },
     { href: '/attendance', label: '打刻', icon: Clock },
     { href: '/dashboard/approvals', label: '承認', icon: ClipboardList },
@@ -52,7 +68,7 @@ export function Header() {
     { href: '/submit', label: '報告', icon: FileText },
   ];
 
-  const adminItems = [
+  const allAdminItems = [
     { href: '/admin/incidents', label: '報告管理', icon: BarChart3 },
     { href: '/admin/attendance/dashboard', label: '勤怠管理', icon: Clock },
     { href: '/dashboard/admin/ringi', label: '稟議管理', icon: ClipboardList },
@@ -63,6 +79,15 @@ export function Header() {
     { href: '/admin/employees', label: '従業員', icon: Users },
     { href: '/admin/settings', label: '設定', icon: Settings },
   ];
+
+  // Launch Mode: 許可されたナビゲーションのみ表示
+  const navItems = LAUNCH_MODE
+    ? allNavItems.filter(item => LAUNCH_MODE_NAV_HREFS.includes(item.href))
+    : allNavItems;
+
+  const adminItems = LAUNCH_MODE
+    ? allAdminItems.filter(item => LAUNCH_MODE_ADMIN_HREFS.includes(item.href))
+    : allAdminItems;
 
   const handleSignOut = async () => {
     await signOut();
@@ -156,8 +181,8 @@ export function Header() {
               </div>
             )}
 
-            {/* AI副社長 (吉田専用) */}
-            {isAiVpOwner(user?.email) && (
+            {/* AI副社長 (吉田専用) - Launch Mode では非表示 */}
+            {!LAUNCH_MODE && isAiVpOwner(user?.email) && (
               <>
                 <Link
                   href="/dashboard/ai/inbox"
@@ -184,6 +209,14 @@ export function Header() {
                   <span>AI抽出</span>
                 </Link>
               </>
+            )}
+
+            {/* Launch Mode バッジ */}
+            {LAUNCH_MODE && (
+              <div className="ml-2 px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-medium rounded-full flex items-center gap-1">
+                <Sparkles className="w-3 h-3" />
+                Launch Mode
+              </div>
             )}
           </nav>
 

--- a/src/components/launchMode/LaunchModeDashboard.tsx
+++ b/src/components/launchMode/LaunchModeDashboard.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import Link from 'next/link';
+import { Users, Building2, Clock, CheckCircle, Sparkles, ChevronRight } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { LAUNCH_NAV_ITEMS } from '@/config/launchRoutes';
+import { getEnvironmentLabel } from '@/config/launchMode';
+
+const iconMap: Record<string, React.ElementType> = {
+  Users,
+  Building2,
+  Clock,
+  CheckCircle,
+};
+
+// カラーテーマ（各機能）
+const colorThemes: Record<string, { bg: string; hover: string; icon: string; border: string }> = {
+  '/dashboard/prospects': {
+    bg: 'bg-blue-50',
+    hover: 'hover:bg-blue-100 hover:border-blue-300',
+    icon: 'text-blue-600',
+    border: 'border-blue-200',
+  },
+  '/dashboard/vacancy': {
+    bg: 'bg-emerald-50',
+    hover: 'hover:bg-emerald-100 hover:border-emerald-300',
+    icon: 'text-emerald-600',
+    border: 'border-emerald-200',
+  },
+  '/attendance': {
+    bg: 'bg-amber-50',
+    hover: 'hover:bg-amber-100 hover:border-amber-300',
+    icon: 'text-amber-600',
+    border: 'border-amber-200',
+  },
+  '/dashboard/approvals': {
+    bg: 'bg-violet-50',
+    hover: 'hover:bg-violet-100 hover:border-violet-300',
+    icon: 'text-violet-600',
+    border: 'border-violet-200',
+  },
+};
+
+/**
+ * Launch Mode ダッシュボード
+ *
+ * 先行公開4機能（入居希望・空室・打刻・承認）に特化したUI
+ */
+export function LaunchModeDashboard() {
+  const { user } = useAuth();
+  const envLabel = getEnvironmentLabel();
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900" />
+          <p className="text-sm text-slate-500">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      {/* ヘッダーエリア */}
+      <div className="bg-white border-b border-slate-200">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <h1 className="text-2xl font-bold text-slate-800">
+                  こんにちは、{user.name || user.email?.split('@')[0]}さん
+                </h1>
+              </div>
+              <p className="text-slate-500 text-sm">
+                今日も一日よろしくお願いします
+              </p>
+            </div>
+
+            {/* 環境バッジ */}
+            <div className="flex items-center gap-2">
+              <span className="px-2.5 py-1 bg-slate-100 text-slate-600 text-xs font-medium rounded-full">
+                {envLabel}
+              </span>
+              <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-medium rounded-full flex items-center gap-1">
+                <Sparkles className="w-3 h-3" />
+                Launch Mode
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* セクションタイトル */}
+        <div className="mb-6">
+          <h2 className="text-lg font-semibold text-slate-700">
+            ご利用いただける機能
+          </h2>
+          <p className="text-sm text-slate-500 mt-1">
+            業務に必要な機能をお選びください
+          </p>
+        </div>
+
+        {/* 4機能カード */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          {LAUNCH_NAV_ITEMS.map((item) => {
+            const Icon = iconMap[item.icon] || Users;
+            const theme = colorThemes[item.href] || colorThemes['/dashboard/prospects'];
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`group block p-6 rounded-2xl border-2 transition-all duration-200 ${theme.bg} ${theme.border} ${theme.hover} hover:shadow-lg hover:-translate-y-0.5`}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-start gap-4">
+                    <div className={`w-14 h-14 bg-white rounded-xl flex items-center justify-center shadow-sm group-hover:shadow transition-shadow`}>
+                      <Icon className={`w-7 h-7 ${theme.icon}`} />
+                    </div>
+                    <div>
+                      <h3 className="text-xl font-bold text-slate-800 mb-1 group-hover:text-slate-900">
+                        {item.label}
+                      </h3>
+                      <p className="text-sm text-slate-600">
+                        {item.description}
+                      </p>
+                      <p className="text-xs text-slate-400 mt-2 font-medium">
+                        {item.labelEn}
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-slate-600 group-hover:translate-x-1 transition-all" />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+
+        {/* 補足情報 */}
+        <div className="bg-slate-50 rounded-xl p-6 border border-slate-200">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 bg-slate-200 rounded-lg flex items-center justify-center flex-shrink-0">
+              <Sparkles className="w-5 h-5 text-slate-600" />
+            </div>
+            <div>
+              <h3 className="font-semibold text-slate-700 mb-1">
+                その他の機能について
+              </h3>
+              <p className="text-sm text-slate-500 leading-relaxed">
+                現在、先行公開として上記4機能をご利用いただけます。
+                その他の機能は順次追加していく予定です。
+                ご不便をおかけしますが、今しばらくお待ちください。
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* フッター */}
+      <div className="border-t border-slate-200 bg-white mt-auto">
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          <p className="text-center text-xs text-slate-400">
+            お困りの際は管理者までお問い合わせください
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/launchMode/index.ts
+++ b/src/components/launchMode/index.ts
@@ -1,0 +1,1 @@
+export { LaunchModeDashboard } from './LaunchModeDashboard';

--- a/src/components/navigation/MobileBottomNav.tsx
+++ b/src/components/navigation/MobileBottomNav.tsx
@@ -26,9 +26,23 @@ import {
   Bot,
   Brain,
   LogOut,
+  Sparkles,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { isAiVpOwner } from '@/lib/auth';
+import { LAUNCH_MODE } from '@/config/launchMode';
+
+// Launch Mode で許可するその他メニューのhref
+const LAUNCH_MODE_MORE_HREFS = [
+  '/dashboard/prospects',
+  '/dashboard/vacancy',
+];
+
+// Launch Mode で許可する管理メニューのhref
+const LAUNCH_MODE_ADMIN_HREFS = [
+  '/admin/attendance/dashboard',
+  '/dashboard/admin/ringi',
+];
 
 interface NavItem {
   href: string;
@@ -70,7 +84,7 @@ export function MobileBottomNav() {
   });
 
   // その他メニューの中身
-  const moreItems: NavItem[] = [
+  const allMoreItems: NavItem[] = [
     { href: '/submit', label: '報告', icon: FileText },
     { href: '/dashboard/prospects', label: '入居希望', icon: UserPlus },
     { href: '/sales', label: '営業', icon: Briefcase },
@@ -80,8 +94,13 @@ export function MobileBottomNav() {
     { href: '/dashboard/os', label: '経営OS', icon: Activity },
   ];
 
+  // Launch Mode: 許可されたその他メニューのみ表示
+  const moreItems = LAUNCH_MODE
+    ? allMoreItems.filter(item => LAUNCH_MODE_MORE_HREFS.includes(item.href))
+    : allMoreItems;
+
   // 管理者メニュー（その他内）
-  const adminMoreItems: NavItem[] = isLeaderOrAbove
+  const allAdminMoreItems: NavItem[] = isLeaderOrAbove
     ? [
         { href: '/admin/incidents', label: '報告管理', icon: BarChart3 },
         { href: '/admin/attendance/dashboard', label: '勤怠管理', icon: Clock },
@@ -95,8 +114,13 @@ export function MobileBottomNav() {
       ]
     : [];
 
-  // AI副社長メニュー
-  const aiVpItems: NavItem[] = isAiVpOwner(user?.email)
+  // Launch Mode: 許可された管理メニューのみ表示
+  const adminMoreItems = LAUNCH_MODE
+    ? allAdminMoreItems.filter(item => LAUNCH_MODE_ADMIN_HREFS.includes(item.href))
+    : allAdminMoreItems;
+
+  // AI副社長メニュー - Launch Mode では非表示
+  const aiVpItems: NavItem[] = !LAUNCH_MODE && isAiVpOwner(user?.email)
     ? [
         { href: '/dashboard/ai/inbox', label: 'AI受信箱', icon: Bot },
         { href: '/admin/ai-vp', label: 'AI抽出', icon: Brain },
@@ -148,7 +172,15 @@ export function MobileBottomNav() {
           <div className="absolute bottom-16 left-0 right-0 bg-white rounded-t-2xl max-h-[70vh] overflow-y-auto animate-slide-up safe-bottom">
             {/* ヘッダー */}
             <div className="sticky top-0 bg-white border-b border-zinc-100 px-4 py-3 flex items-center justify-between">
-              <span className="text-base font-semibold text-zinc-900">その他のメニュー</span>
+              <div className="flex items-center gap-2">
+                <span className="text-base font-semibold text-zinc-900">その他のメニュー</span>
+                {LAUNCH_MODE && (
+                  <span className="px-2 py-0.5 bg-blue-100 text-blue-700 text-xs font-medium rounded-full flex items-center gap-1">
+                    <Sparkles className="w-3 h-3" />
+                    Launch
+                  </span>
+                )}
+              </div>
               <button
                 onClick={() => setMoreMenuOpen(false)}
                 className="p-2 -mr-2 rounded-full hover:bg-zinc-100"

--- a/src/config/launchMode.ts
+++ b/src/config/launchMode.ts
@@ -1,0 +1,25 @@
+/**
+ * Launch Mode 設定
+ *
+ * 先行カットオーバー用：4機能のみ公開（入居希望／空室／打刻／承認）
+ *
+ * NEXT_PUBLIC_LAUNCH_MODE=true で有効化
+ */
+
+export const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE === 'true';
+
+/**
+ * Launch Mode が有効かどうかを判定
+ */
+export function isLaunchMode(): boolean {
+  return LAUNCH_MODE;
+}
+
+/**
+ * 環境表示用ラベル
+ */
+export function getEnvironmentLabel(): 'Production' | 'Preview' | 'Development' {
+  if (process.env.VERCEL_ENV === 'production') return 'Production';
+  if (process.env.VERCEL_ENV === 'preview') return 'Preview';
+  return 'Development';
+}

--- a/src/config/launchRoutes.ts
+++ b/src/config/launchRoutes.ts
@@ -1,0 +1,138 @@
+/**
+ * Launch Mode 公開ルート定義
+ *
+ * 先行カットオーバーで公開する4機能:
+ * 1. 入居希望 (Prospects)
+ * 2. 空室 (Vacancies)
+ * 3. 打刻 (Attendance)
+ * 4. 承認 (Approvals/Ringi)
+ */
+
+/**
+ * 常に許可するルート（認証・静的アセット等）
+ */
+export const ALWAYS_ALLOWED_ROUTES = [
+  // 認証関連
+  '/login',
+  '/api/auth',
+  '/terminated',
+  '/onboarding',
+
+  // Launch Mode 専用
+  '/coming-soon',
+
+  // 静的アセット・システム
+  '/_next',
+  '/favicon.ico',
+  '/api/health',
+];
+
+/**
+ * Launch Mode で許可するルート（4機能）
+ */
+export const LAUNCH_ALLOWED_ROUTES = [
+  // ホーム（Launch Mode用ダッシュボード）
+  '/dashboard',
+
+  // 入居希望 (Prospects)
+  '/dashboard/prospects',
+
+  // 空室 (Vacancies)
+  '/dashboard/vacancy',
+  '/dashboard/vacancies',
+  '/dashboard/vacancy-inquiries',
+  '/vacancies',
+
+  // 打刻 (Attendance)
+  '/attendance',
+  '/admin/attendance',
+
+  // 承認 (Approvals/Ringi)
+  '/dashboard/approvals',
+  '/ringi',
+  '/dashboard/admin/ringi',
+  '/admin/ringi',
+
+  // 通知設定（共通機能）
+  '/settings/notifications',
+
+  // API エンドポイント（機能に必要なもの）
+  '/api/prospects',
+  '/api/vacancies',
+  '/api/vacancy',
+  '/api/attendance',
+  '/api/approvals',
+  '/api/ringi',
+  '/api/tickets',
+  '/api/users',
+  '/api/notifications',
+  '/api/business-units',
+];
+
+/**
+ * パスが Launch Mode で許可されているか判定
+ */
+export function isAllowedInLaunchMode(pathname: string): boolean {
+  // 常に許可するルート
+  for (const route of ALWAYS_ALLOWED_ROUTES) {
+    if (pathname === route || pathname.startsWith(route + '/') || pathname.startsWith(route)) {
+      return true;
+    }
+  }
+
+  // Launch Mode 許可ルート
+  for (const route of LAUNCH_ALLOWED_ROUTES) {
+    if (pathname === route || pathname.startsWith(route + '/') || pathname.startsWith(route + '?')) {
+      return true;
+    }
+  }
+
+  // API は基本的に許可（UI側で制御）
+  if (pathname.startsWith('/api/')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Launch Mode のナビゲーション項目
+ */
+export interface LaunchNavItem {
+  label: string;
+  labelEn: string;
+  href: string;
+  icon: string;
+  description: string;
+}
+
+export const LAUNCH_NAV_ITEMS: LaunchNavItem[] = [
+  {
+    label: '入居希望',
+    labelEn: 'Prospects',
+    href: '/dashboard/prospects',
+    icon: 'Users',
+    description: '入居希望者の管理',
+  },
+  {
+    label: '空室',
+    labelEn: 'Vacancies',
+    href: '/dashboard/vacancy',
+    icon: 'Building2',
+    description: '空室状況の確認',
+  },
+  {
+    label: '打刻',
+    labelEn: 'Attendance',
+    href: '/attendance',
+    icon: 'Clock',
+    description: '出退勤の記録',
+  },
+  {
+    label: '承認',
+    labelEn: 'Approvals',
+    href: '/dashboard/approvals',
+    icon: 'CheckCircle',
+    description: '申請の承認',
+  },
+];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { isAllowedInLaunchMode } from '@/config/launchRoutes';
+
+// ======== Launch Mode ========
+
+const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE === 'true';
 
 // ======== セキュリティヘッダー ========
 
@@ -99,6 +104,14 @@ export function middleware(request: NextRequest) {
     pathname.match(/\.(ico|svg|png|jpg|jpeg|gif|webp|css|js|woff2?)$/)
   ) {
     return NextResponse.next();
+  }
+
+  // ======== Launch Mode ルーティングブロック ========
+  if (LAUNCH_MODE && !isAllowedInLaunchMode(pathname)) {
+    // 未公開ページは /coming-soon にリダイレクト
+    const url = request.nextUrl.clone();
+    url.pathname = '/coming-soon';
+    return NextResponse.redirect(url);
   }
 
   const response = NextResponse.next();


### PR DESCRIPTION
## 概要
NEXT_PUBLIC_LAUNCH_MODE=true で以下4機能のみ公開:
- 入居希望 (/dashboard/prospects)
- 空室 (/dashboard/vacancy)
- 打刻 (/attendance)
- 承認 (/dashboard/approvals)

## 変更内容

### 新規ファイル
- src/config/launchMode.ts: Launch Mode トグル設定
- src/config/launchRoutes.ts: 許可ルート定義
- src/app/coming-soon/page.tsx: 準備中ページ
- src/components/launchMode/LaunchModeDashboard.tsx: 4機能専用ダッシュボード

### 変更ファイル
- src/middleware.ts: ルーティングブロック追加
- src/app/dashboard/page.tsx: Launch Mode 分岐
- src/components/Header.tsx: ナビ項目フィルタリング
- src/components/navigation/MobileBottomNav.tsx: モバイルナビフィルタリング

## 動作
- LAUNCH_MODE=true: 4機能のみ表示、他URLは/coming-soonへリダイレクト
- LAUNCH_MODE=false: 既存全機能が利用可能（回帰なし）

https://claude.ai/code/session_01YP8BoySPijdSxjr3kmb7uj

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
