### PR TITLE
fix: Launch Mode 再監査 - /launch 専用ページ + 強制リダイレクト

### DIFF
--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { redirect } from 'next/navigation';
+import { Users, Building2, Clock, CheckCircle, Sparkles, ChevronRight, LogOut } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { LAUNCH_MODE } from '@/config/launchMode';
+
+// Launch Mode が無効な場合は /dashboard へリダイレクト
+// Note: クライアントコンポーネントでのリダイレクトは useEffect で処理
+
+/**
+ * Launch Mode 専用トップページ
+ *
+ * 4機能のみを大きなカードで表示
+ * - 入居希望 (Prospects)
+ * - 空室 (Vacancies)
+ * - 打刻 (Attendance)
+ * - 承認 (Approvals)
+ */
+
+interface FeatureCard {
+  id: string;
+  href: string;
+  label: string;
+  labelEn: string;
+  description: string;
+  icon: React.ElementType;
+  theme: {
+    bg: string;
+    border: string;
+    hover: string;
+    iconBg: string;
+    iconColor: string;
+  };
+}
+
+const FEATURE_CARDS: FeatureCard[] = [
+  {
+    id: 'prospects',
+    href: '/dashboard/prospects',
+    label: '入居希望',
+    labelEn: 'Prospects',
+    description: '入居希望者の管理・対応',
+    icon: Users,
+    theme: {
+      bg: 'bg-blue-50',
+      border: 'border-blue-200',
+      hover: 'hover:bg-blue-100 hover:border-blue-400 hover:shadow-blue-100',
+      iconBg: 'bg-blue-100',
+      iconColor: 'text-blue-600',
+    },
+  },
+  {
+    id: 'vacancy',
+    href: '/dashboard/vacancy',
+    label: '空室',
+    labelEn: 'Vacancies',
+    description: '空室状況の確認・管理',
+    icon: Building2,
+    theme: {
+      bg: 'bg-emerald-50',
+      border: 'border-emerald-200',
+      hover: 'hover:bg-emerald-100 hover:border-emerald-400 hover:shadow-emerald-100',
+      iconBg: 'bg-emerald-100',
+      iconColor: 'text-emerald-600',
+    },
+  },
+  {
+    id: 'attendance',
+    href: '/attendance',
+    label: '打刻',
+    labelEn: 'Attendance',
+    description: '出退勤の記録・確認',
+    icon: Clock,
+    theme: {
+      bg: 'bg-amber-50',
+      border: 'border-amber-200',
+      hover: 'hover:bg-amber-100 hover:border-amber-400 hover:shadow-amber-100',
+      iconBg: 'bg-amber-100',
+      iconColor: 'text-amber-600',
+    },
+  },
+  {
+    id: 'approvals',
+    href: '/dashboard/approvals',
+    label: '承認',
+    labelEn: 'Approvals',
+    description: '申請の確認・承認',
+    icon: CheckCircle,
+    theme: {
+      bg: 'bg-violet-50',
+      border: 'border-violet-200',
+      hover: 'hover:bg-violet-100 hover:border-violet-400 hover:shadow-violet-100',
+      iconBg: 'bg-violet-100',
+      iconColor: 'text-violet-600',
+    },
+  },
+];
+
+export default function LaunchPage() {
+  const { user, signOut, loading } = useAuth();
+
+  // Launch Mode が無効な場合は /dashboard へリダイレクト
+  if (!LAUNCH_MODE) {
+    redirect('/dashboard');
+  }
+
+  // ローディング中
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900" />
+          <p className="text-sm text-slate-500">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // 未認証の場合は認証ページへ
+  if (!user) {
+    redirect('/auth/signin');
+  }
+
+  const handleSignOut = async () => {
+    await signOut();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 flex flex-col">
+      {/* ミニマルヘッダー */}
+      <header className="bg-white/80 backdrop-blur-md border-b border-slate-200 sticky top-0 z-50">
+        <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="/launch" className="flex items-center gap-2">
+              <Image
+                src="/logo-icon.svg"
+                alt="AA-HUB"
+                width={28}
+                height={28}
+                className="h-7 w-7"
+              />
+              <span className="text-base font-bold text-slate-900">AA-HUB</span>
+            </Link>
+            <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full flex items-center gap-1">
+              <Sparkles className="w-3 h-3" />
+              Launch Mode
+            </span>
+          </div>
+
+          {/* ユーザーメニュー */}
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-slate-600 hidden sm:block">
+              {user.name || user.email?.split('@')[0]}
+            </span>
+            <button
+              onClick={handleSignOut}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
+              <LogOut className="w-4 h-4" />
+              <span className="hidden sm:inline">ログアウト</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main className="flex-1 flex flex-col justify-center py-8 px-4">
+        <div className="max-w-4xl mx-auto w-full">
+          {/* 挨拶 */}
+          <div className="text-center mb-8">
+            <h1 className="text-2xl sm:text-3xl font-bold text-slate-800 mb-2">
+              こんにちは、{user.name || user.email?.split('@')[0]}さん
+            </h1>
+            <p className="text-slate-500">
+              ご利用いただける機能をお選びください
+            </p>
+          </div>
+
+          {/* 4機能カード */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+            {FEATURE_CARDS.map((card) => {
+              const Icon = card.icon;
+              return (
+                <Link
+                  key={card.id}
+                  href={card.href}
+                  className={`group block p-6 sm:p-8 rounded-2xl border-2 transition-all duration-200 ${card.theme.bg} ${card.theme.border} ${card.theme.hover} hover:shadow-xl hover:-translate-y-1`}
+                >
+                  <div className="flex items-start gap-4">
+                    <div className={`w-14 h-14 sm:w-16 sm:h-16 ${card.theme.iconBg} rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-105 transition-transform`}>
+                      <Icon className={`w-7 h-7 sm:w-8 sm:h-8 ${card.theme.iconColor}`} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <h2 className="text-xl sm:text-2xl font-bold text-slate-800 group-hover:text-slate-900">
+                          {card.label}
+                        </h2>
+                        <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-slate-600 group-hover:translate-x-1 transition-all flex-shrink-0" />
+                      </div>
+                      <p className="text-sm text-slate-600 mt-1">
+                        {card.description}
+                      </p>
+                      <p className="text-xs text-slate-400 mt-2 font-medium uppercase tracking-wider">
+                        {card.labelEn}
+                      </p>
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          {/* 補足情報 */}
+          <div className="mt-8 p-4 bg-slate-100 rounded-xl text-center">
+            <p className="text-sm text-slate-500">
+              その他の機能は順次追加予定です。ご不便をおかけしますがお待ちください。
+            </p>
+          </div>
+        </div>
+      </main>
+
+      {/* フッター */}
+      <footer className="py-4 text-center border-t border-slate-200">
+        <p className="text-xs text-slate-400">
+          お困りの際は管理者までお問い合わせください
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,16 +12,16 @@ import { cn } from '@/lib/utils';
 import { isAiVpOwner } from '@/lib/auth';
 import { LAUNCH_MODE } from '@/config/launchMode';
 
-// Launch Mode で許可するナビゲーションのhref
+// Launch Mode で許可するナビゲーションのhref（4機能 + ホーム）
 const LAUNCH_MODE_NAV_HREFS = [
-  '/dashboard',
-  '/attendance',
-  '/dashboard/approvals',
+  '/launch',
   '/dashboard/prospects',
   '/dashboard/vacancy',
+  '/attendance',
+  '/dashboard/approvals',
 ];
 
-// Launch Mode で許可する管理メニューのhref
+// Launch Mode で許可する管理メニューのhref（リーダー以上のみ）
 const LAUNCH_MODE_ADMIN_HREFS = [
   '/admin/attendance/dashboard',
   '/dashboard/admin/ringi',
@@ -53,7 +53,16 @@ export function Header() {
 
   if (!user) return null;
 
-  // メニュー順序（確定版）:
+  // Launch Mode: 4機能 + ホームのみ表示
+  const launchModeNavItems = [
+    { href: '/launch', label: 'ホーム', icon: Home },
+    { href: '/dashboard/prospects', label: '入居希望', icon: UserPlus },
+    { href: '/dashboard/vacancy', label: '空室', icon: Building2 },
+    { href: '/attendance', label: '打刻', icon: Clock },
+    { href: '/dashboard/approvals', label: '承認', icon: ClipboardList },
+  ];
+
+  // 通常モード: メニュー順序（確定版）
   // 1.打刻 2.稟議 3.入居希望 4.営業進捗 5.空室 6.改善 7.ランク 8.経営OS 9.報告(ヒヤリ)
   const allNavItems = [
     { href: '/dashboard', label: 'ホーム', icon: Home },
@@ -80,10 +89,8 @@ export function Header() {
     { href: '/admin/settings', label: '設定', icon: Settings },
   ];
 
-  // Launch Mode: 許可されたナビゲーションのみ表示
-  const navItems = LAUNCH_MODE
-    ? allNavItems.filter(item => LAUNCH_MODE_NAV_HREFS.includes(item.href))
-    : allNavItems;
+  // Launch Mode: 専用ナビゲーション、通常モード: 全ナビゲーション
+  const navItems = LAUNCH_MODE ? launchModeNavItems : allNavItems;
 
   const adminItems = LAUNCH_MODE
     ? allAdminItems.filter(item => LAUNCH_MODE_ADMIN_HREFS.includes(item.href))

--- a/src/components/navigation/MobileBottomNav.tsx
+++ b/src/components/navigation/MobileBottomNav.tsx
@@ -32,16 +32,25 @@ import { cn } from '@/lib/utils';
 import { isAiVpOwner } from '@/lib/auth';
 import { LAUNCH_MODE } from '@/config/launchMode';
 
-// Launch Mode で許可するその他メニューのhref
+// Launch Mode で許可するその他メニューのhref（4機能）
 const LAUNCH_MODE_MORE_HREFS = [
   '/dashboard/prospects',
   '/dashboard/vacancy',
 ];
 
-// Launch Mode で許可する管理メニューのhref
+// Launch Mode で許可する管理メニューのhref（リーダー以上のみ）
 const LAUNCH_MODE_ADMIN_HREFS = [
   '/admin/attendance/dashboard',
   '/dashboard/admin/ringi',
+];
+
+// Launch Mode 専用のメインナビゲーション
+const LAUNCH_MODE_MAIN_NAV = [
+  { href: '/launch', label: 'ホーム', icon: Home, matchPaths: ['/launch'] },
+  { href: '/dashboard/prospects', label: '入居希望', icon: UserPlus, matchPaths: ['/dashboard/prospects'] },
+  { href: '/dashboard/vacancy', label: '空室', icon: Building2, matchPaths: ['/dashboard/vacancy'] },
+  { href: '/attendance', label: '打刻', icon: Clock, matchPaths: ['/attendance'] },
+  { href: '/dashboard/approvals', label: '承認', icon: ClipboardCheck, matchPaths: ['/dashboard/approvals'] },
 ];
 
 interface NavItem {
@@ -58,7 +67,43 @@ export function MobileBottomNav() {
 
   if (!user) return null;
 
-  // 主要ナビゲーション（5つまで）
+  // Launch Mode: 専用ナビゲーション（5機能のみ、管理/その他なし）
+  if (LAUNCH_MODE) {
+    const launchNavItems: NavItem[] = LAUNCH_MODE_MAIN_NAV;
+
+    const isActiveLaunch = (item: NavItem) => {
+      if (item.matchPaths && item.matchPaths.length > 0) {
+        return item.matchPaths.some((path) => pathname.startsWith(path));
+      }
+      return pathname === item.href;
+    };
+
+    return (
+      <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-zinc-200 md:hidden safe-bottom">
+        <div className="flex items-center justify-around h-16">
+          {launchNavItems.map((item) => {
+            const Icon = item.icon;
+            const active = isActiveLaunch(item);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors',
+                  active ? 'text-zinc-900' : 'text-zinc-400'
+                )}
+              >
+                <Icon className={cn('w-6 h-6', active && 'text-zinc-900')} />
+                <span className="text-[10px] font-medium">{item.label}</span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+    );
+  }
+
+  // 通常モード: 主要ナビゲーション（5つまで）
   const mainNavItems: NavItem[] = [
     { href: '/dashboard', label: 'ホーム', icon: Home, matchPaths: ['/dashboard'] },
     { href: '/attendance', label: '打刻', icon: Clock, matchPaths: ['/attendance'] },

--- a/src/config/launchRoutes.ts
+++ b/src/config/launchRoutes.ts
@@ -19,6 +19,7 @@ export const ALWAYS_ALLOWED_ROUTES = [
   '/onboarding',
 
   // Launch Mode 専用
+  '/launch',
   '/coming-soon',
 
   // 静的アセット・システム

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -107,11 +107,20 @@ export function middleware(request: NextRequest) {
   }
 
   // ======== Launch Mode ルーティングブロック ========
-  if (LAUNCH_MODE && !isAllowedInLaunchMode(pathname)) {
+  if (LAUNCH_MODE) {
+    // /dashboard → /launch へ強制リダイレクト
+    if (pathname === '/dashboard' || pathname === '/dashboard/') {
+      const url = request.nextUrl.clone();
+      url.pathname = '/launch';
+      return NextResponse.redirect(url);
+    }
+
     // 未公開ページは /coming-soon にリダイレクト
-    const url = request.nextUrl.clone();
-    url.pathname = '/coming-soon';
-    return NextResponse.redirect(url);
+    if (!isAllowedInLaunchMode(pathname)) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/coming-soon';
+      return NextResponse.redirect(url);
+    }
   }
 
   const response = NextResponse.next();


### PR DESCRIPTION
- /launch ページを新規作成（4機能カードのミニマルデザイン）
- /dashboard → /launch へのmiddlewareリダイレクト追加
- Header: Launch Mode専用ナビゲーション (5項目のみ)
- MobileBottomNav: Launch Mode時は専用UI（管理/その他メニュー非表示）
- launchRoutes: /launch を許可ルートに追加

LAUNCH_MODE=true で4機能のみ表示、false で通常UI

https://claude.ai/code/session_01YP8BoySPijdSxjr3kmb7uj

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
