### PR TITLE
feat: Googleスプレッドシート→Firestore空室インポート機能

### DIFF
--- a/src/app/api/admin/vacancy-import/apply/route.ts
+++ b/src/app/api/admin/vacancy-import/apply/route.ts
@@ -1,0 +1,56 @@
+/**
+ * 空室インポート Apply API
+ *
+ * POST /api/admin/vacancy-import/apply
+ * スプレッドシートから読み込み、Firestore に反映
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchSheetRows } from '@/lib/vacancyImport/sheetsClient';
+import { normalizeRow } from '@/lib/vacancyImport/normalizeRow';
+import { apply } from '@/lib/vacancyImport/applyVacancySnapshot';
+import type { AppRole } from '@/config/appRoles';
+
+const ALLOWED_ROLES: AppRole[] = ['admin', 'executive'];
+
+export async function POST(request: NextRequest) {
+  try {
+    const role = (request.headers.get('x-user-role') || 'staff') as AppRole;
+    if (!ALLOWED_ROLES.includes(role)) {
+      return NextResponse.json(
+        { error: 'この操作には管理者権限が必要です' },
+        { status: 403 },
+      );
+    }
+
+    const { rows } = await fetchSheetRows();
+    if (rows.length === 0) {
+      return NextResponse.json({
+        success: true,
+        summary: { total: 0, created: 0, updated: 0, skipped: 0 },
+      });
+    }
+
+    const normalized = rows
+      .map((r) => normalizeRow(r.values, r.rowNumber))
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    const result = await apply(normalized);
+
+    return NextResponse.json({
+      success: true,
+      summary: {
+        total: result.total,
+        created: result.created,
+        updated: result.updated,
+        skipped: result.skipped,
+      },
+    });
+  } catch (error) {
+    console.error('[vacancy-import/apply]', error);
+    return NextResponse.json(
+      { error: '適用に失敗しました', detail: error instanceof Error ? error.message : 'Unknown' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/vacancy-import/dry-run/route.ts
+++ b/src/app/api/admin/vacancy-import/dry-run/route.ts
@@ -1,0 +1,61 @@
+/**
+ * 空室インポート Dry-run API
+ *
+ * POST /api/admin/vacancy-import/dry-run
+ * スプレッドシートから読み込み、差分プレビューを返却（書き込みなし）
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchSheetRows } from '@/lib/vacancyImport/sheetsClient';
+import { normalizeRow } from '@/lib/vacancyImport/normalizeRow';
+import { dryRun } from '@/lib/vacancyImport/applyVacancySnapshot';
+import type { AppRole } from '@/config/appRoles';
+
+const ALLOWED_ROLES: AppRole[] = ['admin', 'executive'];
+
+export async function POST(request: NextRequest) {
+  try {
+    const role = (request.headers.get('x-user-role') || 'staff') as AppRole;
+    if (!ALLOWED_ROLES.includes(role)) {
+      return NextResponse.json(
+        { error: 'この操作には管理者権限が必要です' },
+        { status: 403 },
+      );
+    }
+
+    const { headers, rows } = await fetchSheetRows();
+    if (rows.length === 0) {
+      return NextResponse.json({
+        success: true,
+        headers,
+        result: { total: 0, created: 0, updated: 0, skipped: 0, diffs: [] },
+      });
+    }
+
+    const normalized = rows
+      .map((r) => normalizeRow(r.values, r.rowNumber))
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    const result = await dryRun(normalized);
+
+    return NextResponse.json({
+      success: true,
+      headers,
+      rowCount: rows.length,
+      normalizedCount: normalized.length,
+      result: {
+        total: result.total,
+        created: result.created,
+        updated: result.updated,
+        skipped: result.skipped,
+        diffs: result.diffs,
+      },
+    });
+  } catch (error) {
+    console.error('[vacancy-import/dry-run]', error);
+    return NextResponse.json(
+      { error: 'dry-run に失敗しました', detail: error instanceof Error ? error.message : 'Unknown' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cron/vacancy-sheet-sync/route.ts
+++ b/src/app/api/cron/vacancy-sheet-sync/route.ts
@@ -1,0 +1,72 @@
+/**
+ * 空室スプレッドシート同期 Cron API
+ *
+ * GET /api/cron/vacancy-sheet-sync
+ * VACANCY_SOURCE === "sheet" のときのみ実行
+ * CRON_SECRET 必須
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchSheetRows } from '@/lib/vacancyImport/sheetsClient';
+import { normalizeRow } from '@/lib/vacancyImport/normalizeRow';
+import { apply } from '@/lib/vacancyImport/applyVacancySnapshot';
+
+function verifyCronRequest(request: NextRequest): boolean {
+  const authHeader = request.headers.get('authorization');
+  if (process.env.CRON_SECRET) {
+    return authHeader === `Bearer ${process.env.CRON_SECRET}`;
+  }
+  if (process.env.NODE_ENV === 'development') {
+    return true;
+  }
+  return false;
+}
+
+export async function GET(request: NextRequest) {
+  if (!verifyCronRequest(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const vacancySource = process.env.VACANCY_SOURCE || 'sheet';
+  if (vacancySource !== 'sheet') {
+    return NextResponse.json({
+      success: true,
+      skipped: true,
+      reason: `VACANCY_SOURCE=${vacancySource}, not "sheet"`,
+    });
+  }
+
+  try {
+    console.log('[Cron:vacancy-sheet-sync] Starting...');
+
+    const { rows } = await fetchSheetRows();
+    const normalized = rows
+      .map((r) => normalizeRow(r.values, r.rowNumber))
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    const result = await apply(normalized, 'sheet');
+
+    console.log('[Cron:vacancy-sheet-sync] Done:', {
+      total: result.total,
+      created: result.created,
+      updated: result.updated,
+      skipped: result.skipped,
+    });
+
+    return NextResponse.json({
+      success: true,
+      summary: {
+        total: result.total,
+        created: result.created,
+        updated: result.updated,
+        skipped: result.skipped,
+      },
+    });
+  } catch (error) {
+    console.error('[Cron:vacancy-sheet-sync] Error:', error);
+    return NextResponse.json(
+      { error: '同期に失敗しました', detail: error instanceof Error ? error.message : 'Unknown' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/vacancyImport/applyVacancySnapshot.ts
+++ b/src/lib/vacancyImport/applyVacancySnapshot.ts
@@ -1,0 +1,322 @@
+/**
+ * スプレッドシートスナップショットの適用ロジック
+ *
+ * - UPSERT vacancy_units
+ * - 上書き判定: sourcePriority / sourceUpdatedAt
+ * - 差分がある場合のみ vacancy_updates にログ保存
+ * - systemImporter からも同じ関数を呼べる設計
+ */
+
+import { getAdminDb } from '@/lib/firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
+import type { VacancyUnit, VacancyUpdate, VacancySource } from '@/lib/vacancyUnits/types';
+import { SOURCE_PRIORITY } from '@/lib/vacancyUnits/types';
+import { toUnitKey } from '@/lib/vacancyUnits/unitKey';
+import type { NormalizedRow, SheetVacancyStatus } from './normalizeRow';
+
+const UNITS_COLLECTION = 'vacancy_units';
+const UPDATES_COLLECTION = 'vacancy_updates';
+
+// ========== 型 ==========
+
+export interface ImportItem {
+  unitKey: string;
+  row: NormalizedRow;
+}
+
+export interface DiffField {
+  before: unknown;
+  after: unknown;
+}
+
+export interface DiffEntry {
+  unitKey: string;
+  action: 'create' | 'update' | 'skip';
+  skipReason?: string;
+  fields?: Record<string, DiffField>;
+  row: NormalizedRow;
+}
+
+export interface ApplyResult {
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  diffs: DiffEntry[];
+}
+
+// ========== ヘルパー ==========
+
+function sheetStatusToUnitStatus(s: SheetVacancyStatus): 'active' | 'paused' {
+  return s === 'available' ? 'active' : 'paused';
+}
+
+function sheetStatusToAvailableCount(s: SheetVacancyStatus): number {
+  return s === 'available' ? 1 : 0;
+}
+
+function generateId(): string {
+  return `vu_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * 既存ユニットを unitKey (buildingName slug + roomNo) でインデックス
+ */
+async function loadExistingByUnitKey(): Promise<Map<string, VacancyUnit>> {
+  const db = getAdminDb();
+  const snap = await db.collection(UNITS_COLLECTION).get();
+  const map = new Map<string, VacancyUnit>();
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const building = data.buildingName ?? '';
+    const roomNo = data.roomNo ?? '';
+    if (building && roomNo) {
+      const key = toUnitKey(building, roomNo);
+      map.set(key, docToUnit(doc));
+    }
+  }
+
+  return map;
+}
+
+function docToUnit(doc: FirebaseFirestore.DocumentSnapshot): VacancyUnit {
+  const data = doc.data()!;
+  return {
+    id: data.id ?? doc.id,
+    businessUnitId: data.businessUnitId ?? '',
+    buildingName: data.buildingName ?? '',
+    area: data.area ?? '',
+    roomType: data.roomType ?? '',
+    capacity: data.capacity ?? 0,
+    availableCount: data.availableCount ?? 0,
+    availableFrom: data.availableFrom ?? null,
+    conditionsJson: data.conditionsJson ?? {},
+    priceRangeJson: data.priceRangeJson ?? {},
+    status: data.status ?? 'active',
+    updatedAt: data.updatedAt ?? new Date().toISOString(),
+    updatedByUserId: data.updatedByUserId ?? 'system',
+    updatedByUserName: data.updatedByUserName,
+    createdAt: data.createdAt ?? new Date().toISOString(),
+    source: data.source,
+    sourcePriority: data.sourcePriority,
+    sourceUpdatedAt: data.sourceUpdatedAt,
+    roomNo: data.roomNo,
+    residentName: data.residentName,
+    residentKana: data.residentKana,
+    careLevel: data.careLevel,
+    notes: data.notes,
+  };
+}
+
+/**
+ * 差分計算（比較対象フィールド）
+ */
+function computeDiff(
+  existing: VacancyUnit,
+  row: NormalizedRow,
+): Record<string, DiffField> | null {
+  const diff: Record<string, DiffField> = {};
+
+  const pairs: [string, unknown, unknown][] = [
+    ['buildingName', existing.buildingName, row.facilityName],
+    ['roomNo', existing.roomNo, row.roomNo],
+    ['status', existing.status, sheetStatusToUnitStatus(row.status)],
+    ['availableCount', existing.availableCount, sheetStatusToAvailableCount(row.status)],
+    ['availableFrom', existing.availableFrom, row.moveInDate],
+    ['residentName', existing.residentName ?? '', row.residentName],
+    ['residentKana', existing.residentKana ?? '', row.residentKana],
+    ['careLevel', existing.careLevel ?? '', row.careLevel],
+    ['notes', existing.notes ?? '', row.notes],
+  ];
+
+  for (const [field, before, after] of pairs) {
+    if (String(before ?? '') !== String(after ?? '')) {
+      diff[field] = { before, after };
+    }
+  }
+
+  return Object.keys(diff).length > 0 ? diff : null;
+}
+
+/**
+ * 上書き可否を判定
+ */
+function canOverwrite(
+  existing: VacancyUnit,
+  source: VacancySource,
+  sourceUpdatedAt: string,
+): boolean {
+  const existingPriority = existing.sourcePriority ?? 0;
+  const incomingPriority = SOURCE_PRIORITY[source];
+
+  // 優先度が低ければスキップ
+  if (incomingPriority < existingPriority) return false;
+
+  // 優先度が高ければ上書き
+  if (incomingPriority > existingPriority) return true;
+
+  // 同一優先度: sourceUpdatedAt が新しければ上書き
+  const existingTs = existing.sourceUpdatedAt ?? existing.updatedAt;
+  return sourceUpdatedAt >= existingTs;
+}
+
+// ========== メインロジック ==========
+
+/**
+ * dry-run: 差分プレビューのみ（Firestoreに書き込まない）
+ */
+export async function dryRun(
+  rows: NormalizedRow[],
+  source: VacancySource = 'sheet',
+): Promise<ApplyResult> {
+  return applyInternal(rows, source, true);
+}
+
+/**
+ * apply: 実際にFirestoreに書き込む
+ */
+export async function apply(
+  rows: NormalizedRow[],
+  source: VacancySource = 'sheet',
+): Promise<ApplyResult> {
+  return applyInternal(rows, source, false);
+}
+
+async function applyInternal(
+  rows: NormalizedRow[],
+  source: VacancySource,
+  dryRunMode: boolean,
+): Promise<ApplyResult> {
+  const existing = await loadExistingByUnitKey();
+  const timestamp = now();
+  const sourceUpdatedAt = timestamp;
+
+  const result: ApplyResult = {
+    total: rows.length,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    diffs: [],
+  };
+
+  const db = dryRunMode ? null : getAdminDb();
+
+  for (const row of rows) {
+    const unitKey = toUnitKey(row.facilityName, row.roomNo);
+    const ex = existing.get(unitKey);
+
+    if (!ex) {
+      // 新規作成
+      const newUnit: VacancyUnit = {
+        id: generateId(),
+        businessUnitId: '',
+        buildingName: row.facilityName,
+        area: '',
+        roomType: '',
+        capacity: 1,
+        availableCount: sheetStatusToAvailableCount(row.status),
+        availableFrom: row.moveInDate,
+        conditionsJson: {},
+        priceRangeJson: {},
+        status: sheetStatusToUnitStatus(row.status),
+        updatedAt: timestamp,
+        updatedByUserId: 'system:sheet-import',
+        createdAt: timestamp,
+        source,
+        sourcePriority: SOURCE_PRIORITY[source],
+        sourceUpdatedAt: row.moveInDate ?? timestamp,
+        roomNo: row.roomNo,
+        residentName: row.residentName,
+        residentKana: row.residentKana,
+        careLevel: row.careLevel,
+        notes: row.notes,
+      };
+
+      result.created++;
+      result.diffs.push({ unitKey, action: 'create', row });
+
+      if (db) {
+        await db.collection(UNITS_COLLECTION).doc(newUnit.id).set({
+          ...newUnit,
+          _updatedAt: Timestamp.fromDate(new Date(timestamp)),
+          _createdAt: Timestamp.fromDate(new Date(timestamp)),
+        });
+      }
+      continue;
+    }
+
+    // 上書き可否チェック
+    if (!canOverwrite(ex, source, row.moveInDate ?? timestamp)) {
+      result.skipped++;
+      result.diffs.push({
+        unitKey,
+        action: 'skip',
+        skipReason: `priority: existing=${ex.sourcePriority ?? 0} (${ex.source ?? 'unknown'}), incoming=${SOURCE_PRIORITY[source]} (${source})`,
+        row,
+      });
+      continue;
+    }
+
+    // 差分計算
+    const diff = computeDiff(ex, row);
+    if (!diff) {
+      result.skipped++;
+      result.diffs.push({
+        unitKey,
+        action: 'skip',
+        skipReason: 'no changes',
+        row,
+      });
+      continue;
+    }
+
+    // 更新
+    const patch: Partial<VacancyUnit> = {
+      buildingName: row.facilityName,
+      roomNo: row.roomNo,
+      status: sheetStatusToUnitStatus(row.status),
+      availableCount: sheetStatusToAvailableCount(row.status),
+      availableFrom: row.moveInDate,
+      residentName: row.residentName,
+      residentKana: row.residentKana,
+      careLevel: row.careLevel,
+      notes: row.notes,
+      updatedAt: timestamp,
+      updatedByUserId: 'system:sheet-import',
+      source,
+      sourcePriority: SOURCE_PRIORITY[source],
+      sourceUpdatedAt: row.moveInDate ?? timestamp,
+    };
+
+    result.updated++;
+    result.diffs.push({ unitKey, action: 'update', fields: diff, row });
+
+    if (db) {
+      await db.collection(UNITS_COLLECTION).doc(ex.id).update({
+        ...patch,
+        _updatedAt: Timestamp.now(),
+      });
+
+      // 変更ログ
+      const updateLog: VacancyUpdate = {
+        id: `vupd_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        vacancyUnitId: ex.id,
+        businessUnitId: ex.businessUnitId,
+        changedFieldsJson: diff,
+        createdAt: timestamp,
+        createdByUserId: 'system:sheet-import',
+      };
+      await db.collection(UPDATES_COLLECTION).doc(updateLog.id).set({
+        ...updateLog,
+        _createdAt: Timestamp.fromDate(new Date(timestamp)),
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/lib/vacancyImport/normalizeRow.ts
+++ b/src/lib/vacancyImport/normalizeRow.ts
@@ -1,0 +1,87 @@
+/**
+ * スプレッドシート行の正規化
+ *
+ * 列定義（0-indexed）:
+ *   B(1): 建物名 → facilityName
+ *   C(2): 部屋番号 → roomNo
+ *   D(3): 部屋ステータス → status
+ *   E(4): 入居者様氏名 → residentName
+ *   F(5): しめい → residentKana
+ *   G(6): 入居（予定）日 → moveInDate
+ *   H(7): 備考 → notes
+ *   I(8): 介護度（入居想定） → careLevel
+ */
+
+export type SheetVacancyStatus = 'occupied' | 'reserved' | 'available' | 'other';
+
+export interface NormalizedRow {
+  facilityName: string;
+  roomNo: string;
+  status: SheetVacancyStatus;
+  rawStatus: string;
+  residentName: string;
+  residentKana: string;
+  moveInDate: string | null;
+  notes: string;
+  careLevel: string;
+  rowNumber: number;
+}
+
+const STATUS_MAP: Record<string, SheetVacancyStatus> = {
+  '1.入居中': 'occupied',
+  '2.入居予定': 'reserved',
+  '3.予約済': 'reserved',
+  '5.空室': 'available',
+};
+
+function normalizeStatus(raw: string): SheetVacancyStatus {
+  const trimmed = raw.trim();
+  return STATUS_MAP[trimmed] ?? 'other';
+}
+
+/**
+ * 日付文字列を ISO 形式に正規化（YYYY-MM-DD）
+ * 対応: "2026/01/15", "2026-01-15", "R8.1.15" 等
+ */
+function normalizeDate(raw: string): string | null {
+  if (!raw) return null;
+
+  // YYYY/MM/DD or YYYY-MM-DD
+  const isoMatch = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})/);
+  if (isoMatch) {
+    const [, y, m, d] = isoMatch;
+    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  }
+
+  return null;
+}
+
+function col(values: string[], index: number): string {
+  return (values[index] ?? '').trim();
+}
+
+/**
+ * 1行を正規化。roomNo が空の行は null を返す（スキップ対象）
+ */
+export function normalizeRow(
+  values: string[],
+  rowNumber: number,
+): NormalizedRow | null {
+  const roomNo = col(values, 2); // C列
+  if (!roomNo) return null;
+
+  const rawStatus = col(values, 3);
+
+  return {
+    facilityName: col(values, 1), // B列
+    roomNo,
+    status: normalizeStatus(rawStatus),
+    rawStatus,
+    residentName: col(values, 4), // E列
+    residentKana: col(values, 5), // F列
+    moveInDate: normalizeDate(col(values, 6)), // G列
+    notes: col(values, 7), // H列
+    careLevel: col(values, 8), // I列
+    rowNumber,
+  };
+}

--- a/src/lib/vacancyImport/sheetsClient.ts
+++ b/src/lib/vacancyImport/sheetsClient.ts
@@ -1,0 +1,62 @@
+/**
+ * Google Sheets クライアント
+ *
+ * Service Account 認証で Sheets API v4 を使用。
+ * 環境変数:
+ *   GOOGLE_SERVICE_ACCOUNT_JSON — JSON キーファイルの中身
+ *   VACANCY_SHEET_ID — スプレッドシートID（デフォルトあり）
+ *   VACANCY_SHEET_TAB — タブ名（デフォルト: 入居状況）
+ */
+
+import { google } from 'googleapis';
+
+const DEFAULT_SHEET_ID = '1y00PmqtKRCsyrvaH8ydO3QbzVbFXGEVA2dpKOUDJMaY';
+const DEFAULT_TAB_NAME = '入居状況';
+
+function getAuth() {
+  const json = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+  if (!json) throw new Error('GOOGLE_SERVICE_ACCOUNT_JSON is not set');
+  const creds = JSON.parse(json);
+  return new google.auth.GoogleAuth({
+    credentials: creds,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+}
+
+export interface SheetRow {
+  /** 0-indexed row values (A=0, B=1, ...) */
+  values: string[];
+  /** 1-indexed row number in the sheet */
+  rowNumber: number;
+}
+
+/**
+ * スプレッドシートの全行を取得（1行目はヘッダ）
+ * @returns ヘッダ行 + データ行
+ */
+export async function fetchSheetRows(): Promise<{
+  headers: string[];
+  rows: SheetRow[];
+}> {
+  const sheetId = process.env.VACANCY_SHEET_ID || DEFAULT_SHEET_ID;
+  const tabName = process.env.VACANCY_SHEET_TAB || DEFAULT_TAB_NAME;
+
+  const auth = getAuth();
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: sheetId,
+    range: `${tabName}!A:ZZ`,
+  });
+
+  const rawRows = res.data.values ?? [];
+  if (rawRows.length === 0) return { headers: [], rows: [] };
+
+  const headers = rawRows[0].map((v: unknown) => String(v ?? '').trim());
+  const rows: SheetRow[] = rawRows.slice(1).map((row, i) => ({
+    values: row.map((v: unknown) => String(v ?? '').trim()),
+    rowNumber: i + 2, // 1-indexed, skip header
+  }));
+
+  return { headers, rows };
+}

--- a/src/lib/vacancyUnits/repo.firestore.ts
+++ b/src/lib/vacancyUnits/repo.firestore.ts
@@ -210,5 +210,13 @@ function docToUnit(doc: FirebaseFirestore.DocumentSnapshot): VacancyUnit {
     updatedByUserId: data.updatedByUserId ?? 'system',
     updatedByUserName: data.updatedByUserName,
     createdAt: data.createdAt ?? new Date().toISOString(),
+    source: data.source,
+    sourcePriority: data.sourcePriority,
+    sourceUpdatedAt: data.sourceUpdatedAt,
+    roomNo: data.roomNo,
+    residentName: data.residentName,
+    residentKana: data.residentKana,
+    careLevel: data.careLevel,
+    notes: data.notes,
   };
 }

--- a/src/lib/vacancyUnits/types.ts
+++ b/src/lib/vacancyUnits/types.ts
@@ -18,6 +18,20 @@ import type { AppRole } from '@/config/appRoles';
 export type VacancyUnitStatus = 'active' | 'paused';
 
 /**
+ * データソース種別
+ */
+export type VacancySource = 'system' | 'manual' | 'sheet';
+
+/**
+ * ソース優先度（高い方が優先）
+ */
+export const SOURCE_PRIORITY: Record<VacancySource, number> = {
+  system: 100,
+  manual: 90,
+  sheet: 80,
+};
+
+/**
  * 介護度条件
  */
 export interface CareConditions {
@@ -59,6 +73,14 @@ export interface VacancyUnit {
   updatedByUserId: string;
   updatedByUserName?: string;
   createdAt: string;
+  source?: VacancySource;
+  sourcePriority?: number;
+  sourceUpdatedAt?: string;
+  roomNo?: string;
+  residentName?: string;
+  residentKana?: string;
+  careLevel?: string;
+  notes?: string;
 }
 
 /**

--- a/src/lib/vacancyUnits/unitKey.ts
+++ b/src/lib/vacancyUnits/unitKey.ts
@@ -1,0 +1,24 @@
+/**
+ * unitKey: facilityName を slug 化し roomNo と結合
+ *
+ * 例: "パシフィック横浜" + "201" → "パシフィック横浜:201"
+ *     slug("パシフィック横浜") → "パシフィック横浜" (日本語はそのまま)
+ *     slug("  A棟  ") → "a棟"
+ */
+
+/**
+ * facilityName を slug 化（小文字化・前後空白除去・記号除去）
+ */
+export function slugFacility(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s\-_./\\,;:!@#$%^&*()=+[\]{}|<>?'"~`]/g, '');
+}
+
+/**
+ * unitKey を生成: slug(facilityName) + ":" + roomNo
+ */
+export function toUnitKey(facilityName: string, roomNo: string): string {
+  return `${slugFacility(facilityName)}:${roomNo.trim()}`;
+}


### PR DESCRIPTION
- VacancyUnit型にsource/sourcePriority/sourceUpdatedAt等フィールド追加
- unitKey: facilityName slug + roomNo でユニット一意識別
- sheetsClient: Google Sheets API v4でスプレッドシート読み込み
- normalizeRow: 列マッピング・status正規化（occupied/reserved/available/other）
- applyVacancySnapshot: UPSERT + priority判定 + 差分ログ（dry-run/apply両対応）
- API: /admin/vacancy-import/dry-run（差分プレビュー）
- API: /admin/vacancy-import/apply（Firestore反映）
- Cron: /cron/vacancy-sheet-sync（VACANCY_SOURCE=sheet時のみ実行）

Build: GREEN / Tests: 516/516

https://claude.ai/code/session_01KTxEJwNw8mC1tWxJTZidY3

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
