### PR TITLE
design: 4機能（打刻/承認/入居希望/空室）UI刷新

### DIFF
--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -36,11 +36,11 @@ import {
 
 // 状態表示ラベル
 const STATUS_LABELS: Record<ClockStatus, { label: string; color: string; bgColor: string }> = {
-  not_started: { label: '未出勤', color: 'text-gray-700', bgColor: 'bg-gray-100' },
-  working: { label: '勤務中', color: 'text-green-700', bgColor: 'bg-green-100' },
-  on_break: { label: '休憩中', color: 'text-amber-700', bgColor: 'bg-amber-100' },
-  completed: { label: '退勤済', color: 'text-blue-700', bgColor: 'bg-blue-100' },
-  missing_out: { label: '退勤漏れ', color: 'text-red-700', bgColor: 'bg-red-100' },
+  not_started: { label: '未出勤', color: 'text-zinc-700', bgColor: 'bg-zinc-100' },
+  working: { label: '勤務中', color: 'text-emerald-700', bgColor: 'bg-emerald-50' },
+  on_break: { label: '休憩中', color: 'text-amber-700', bgColor: 'bg-amber-50' },
+  completed: { label: '退勤済', color: 'text-blue-700', bgColor: 'bg-blue-50' },
+  missing_out: { label: '退勤漏れ', color: 'text-red-700', bgColor: 'bg-red-50' },
 };
 
 // 打刻履歴アイテムの型
@@ -408,7 +408,7 @@ export default function AttendancePage() {
 
   return (
     <AuthGuard>
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-zinc-50">
         <Header />
 
         {/* トースト通知 */}
@@ -469,20 +469,20 @@ export default function AttendancePage() {
 
         <main className="max-w-lg mx-auto px-4 py-6 safe-area-inset-bottom pb-24">
           {/* A: ステータスカード */}
-          <Card className="mb-6 overflow-hidden">
-            <div className={`px-6 py-4 ${statusInfo.bgColor}`}>
+          <Card className="mb-5 overflow-hidden border-zinc-200">
+            <div className={`px-5 py-4 ${statusInfo.bgColor}`}>
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="text-sm text-gray-600">今の状態</div>
-                  <div className={`text-2xl font-bold ${statusInfo.color}`}>
+                  <div className="text-xs font-medium text-zinc-500 mb-0.5">今の状態</div>
+                  <div className={`text-xl font-bold ${statusInfo.color}`}>
                     {statusInfo.label}
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-3xl font-bold text-gray-800">
+                  <div className="text-3xl font-bold text-zinc-800 tabular-nums">
                     {currentTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
                   </div>
-                  <div className="text-sm text-gray-500">
+                  <div className="text-xs text-zinc-500">
                     {currentTime.toLocaleDateString('ja-JP', {
                       month: 'short',
                       day: 'numeric',
@@ -496,15 +496,15 @@ export default function AttendancePage() {
             <div className="p-4">
               {/* 勤務時間サマリー */}
               <div className="grid grid-cols-2 gap-3">
-                <div className="bg-gray-50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-gray-500 mb-1">出勤</div>
-                  <div className="text-lg font-bold text-gray-800">
+                <div className="bg-zinc-50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-zinc-500 mb-1">出勤</div>
+                  <div className="text-lg font-bold text-zinc-800 tabular-nums">
                     {state?.clockIn ? formatTimeJST(state.clockIn) : '--:--'}
                   </div>
                 </div>
-                <div className="bg-gray-50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-gray-500 mb-1">退勤</div>
-                  <div className="text-lg font-bold text-gray-800">
+                <div className="bg-zinc-50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-zinc-500 mb-1">退勤</div>
+                  <div className="text-lg font-bold text-zinc-800 tabular-nums">
                     {state?.clockOut ? formatTimeJST(state.clockOut) : '--:--'}
                   </div>
                 </div>
@@ -514,7 +514,7 @@ export default function AttendancePage() {
               {state?.totalWorkMinutes !== undefined && state.totalWorkMinutes > 0 && (
                 <div className="mt-3 bg-blue-50 rounded-xl p-3 text-center">
                   <div className="text-xs text-blue-600 mb-1">本日の勤務時間</div>
-                  <div className="text-xl font-bold text-blue-700">
+                  <div className="text-xl font-bold text-blue-700 tabular-nums">
                     {formatMinutesToHHMM(state.totalWorkMinutes)}
                   </div>
                 </div>
@@ -902,22 +902,22 @@ export default function AttendancePage() {
           )}
 
           {/* ナビゲーション */}
-          <div className="pt-4 border-t">
+          <div className="pt-4 border-t border-zinc-200">
             <div className="grid grid-cols-2 gap-3">
-              <Button
-                variant="secondary"
+              <button
                 onClick={() => router.push('/attendance/history')}
-                className="py-3"
+                className="flex items-center justify-center gap-2 py-3 px-4 bg-white border border-zinc-200 rounded-xl text-sm font-medium text-zinc-700 hover:bg-zinc-50 active:scale-[0.98] transition-all"
               >
+                <History className="w-4 h-4" />
                 勤務履歴
-              </Button>
-              <Button
-                variant="secondary"
+              </button>
+              <button
                 onClick={() => router.push('/attendance/overtime')}
-                className="py-3"
+                className="flex items-center justify-center gap-2 py-3 px-4 bg-white border border-zinc-200 rounded-xl text-sm font-medium text-zinc-700 hover:bg-zinc-50 active:scale-[0.98] transition-all"
               >
+                <Clock className="w-4 h-4" />
                 残業届
-              </Button>
+              </button>
             </div>
           </div>
         </main>

--- a/src/app/dashboard/approvals/page.tsx
+++ b/src/app/dashboard/approvals/page.tsx
@@ -361,33 +361,53 @@ export default function ApprovalsListPage() {
 
         {/* Summary Cards */}
         <div className="grid grid-cols-3 gap-3 mb-6">
-          <Card className="p-3 text-center">
-            <p className={`text-2xl font-bold ${error ? 'text-zinc-400' : 'text-zinc-900'}`}>
+          <Card className="p-3">
+            <div className="flex items-center gap-2 mb-1">
+              <div className="w-6 h-6 rounded-md bg-zinc-100 flex items-center justify-center">
+                <Edit className="w-3.5 h-3.5 text-zinc-500" />
+              </div>
+              <span className="text-xs text-zinc-500">下書き</span>
+            </div>
+            <p className={`text-2xl font-bold tabular-nums ${error ? 'text-zinc-400' : 'text-zinc-900'}`}>
               {displayCount(draftCount)}
             </p>
-            <p className="text-xs text-zinc-500">下書き</p>
           </Card>
           <Card
-            className={`p-3 text-center ${
+            className={`p-3 ${
               submittedCount && submittedCount > 0 ? 'bg-amber-50 border-amber-200' : ''
             }`}
           >
-            <p className={`text-2xl font-bold ${error ? 'text-zinc-400' : 'text-amber-600'}`}>
+            <div className="flex items-center gap-2 mb-1">
+              <div className="w-6 h-6 rounded-md bg-amber-100 flex items-center justify-center">
+                <Clock className="w-3.5 h-3.5 text-amber-600" />
+              </div>
+              <span className="text-xs text-zinc-500">申請中</span>
+            </div>
+            <p className={`text-2xl font-bold tabular-nums ${error ? 'text-zinc-400' : 'text-amber-600'}`}>
               {displayCount(submittedCount)}
             </p>
-            <p className="text-xs text-zinc-500">申請中</p>
           </Card>
           {returnedCount && returnedCount > 0 ? (
-            <Card className="p-3 text-center bg-orange-50 border-orange-200">
-              <p className="text-2xl font-bold text-orange-600">{displayCount(returnedCount)}</p>
-              <p className="text-xs text-orange-600">差戻し</p>
+            <Card className="p-3 bg-orange-50 border-orange-200">
+              <div className="flex items-center gap-2 mb-1">
+                <div className="w-6 h-6 rounded-md bg-orange-100 flex items-center justify-center">
+                  <RotateCcw className="w-3.5 h-3.5 text-orange-600" />
+                </div>
+                <span className="text-xs text-orange-600">差戻し</span>
+              </div>
+              <p className="text-2xl font-bold tabular-nums text-orange-600">{displayCount(returnedCount)}</p>
             </Card>
           ) : (
-            <Card className="p-3 text-center">
-              <p className={`text-2xl font-bold ${error ? 'text-zinc-400' : 'text-emerald-600'}`}>
+            <Card className="p-3">
+              <div className="flex items-center gap-2 mb-1">
+                <div className="w-6 h-6 rounded-md bg-emerald-100 flex items-center justify-center">
+                  <CheckCircle className="w-3.5 h-3.5 text-emerald-600" />
+                </div>
+                <span className="text-xs text-zinc-500">承認済</span>
+              </div>
+              <p className={`text-2xl font-bold tabular-nums ${error ? 'text-zinc-400' : 'text-emerald-600'}`}>
                 {displayCount(approvedCount)}
               </p>
-              <p className="text-xs text-zinc-500">承認済</p>
             </Card>
           )}
         </div>
@@ -445,45 +465,60 @@ export default function ApprovalsListPage() {
               const colors = RINGI_STATUS_COLORS[item.status];
               return (
                 <Link key={`${item.type}-${item.id}`} href={getItemLink(item)}>
-                  <Card className="p-4 hover:bg-zinc-50 transition-colors">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1 flex-wrap">
-                          <Badge
-                            className={`${
-                              item.type === 'RINGI'
-                                ? 'bg-blue-100 text-blue-700'
-                                : item.type === 'EXPENSE'
-                                ? 'bg-green-100 text-green-700'
-                                : 'bg-purple-100 text-purple-700'
-                            }`}
-                          >
-                            {typeIcon(item.type)}
-                            <span className="ml-1">{APPLICATION_TYPE_LABELS[item.type]}</span>
-                          </Badge>
-                          <Badge className={`${colors.bg} ${colors.text}`}>
-                            {statusIcon(item.status)}
-                            <span className="ml-1">{RINGI_STATUS_LABELS[item.status]}</span>
-                          </Badge>
-                          <span className="text-xs text-zinc-400">{getSubtitle(item)}</span>
-                          {item.urgency === '至急' && (
-                            <Badge className="bg-red-100 text-red-700 text-xs">至急</Badge>
+                  <Card className={`relative overflow-hidden hover:bg-zinc-50 transition-colors border-zinc-200 ${
+                    item.status === 'returned' ? 'border-l-orange-500' :
+                    item.status === 'submitted' ? 'border-l-amber-500' : ''
+                  }`}>
+                    {/* 左アクセントバー */}
+                    <div className={`absolute left-0 top-0 bottom-0 w-1 ${
+                      item.status === 'draft' ? 'bg-zinc-300' :
+                      item.status === 'submitted' ? 'bg-amber-500' :
+                      item.status === 'approved' ? 'bg-emerald-500' :
+                      item.status === 'rejected' ? 'bg-red-500' :
+                      item.status === 'returned' ? 'bg-orange-500' : 'bg-zinc-300'
+                    }`} />
+                    <div className="p-4 pl-5">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                            <Badge
+                              className={`${
+                                item.type === 'RINGI'
+                                  ? 'bg-blue-100 text-blue-700'
+                                  : item.type === 'EXPENSE'
+                                  ? 'bg-green-100 text-green-700'
+                                  : 'bg-purple-100 text-purple-700'
+                              }`}
+                            >
+                              {typeIcon(item.type)}
+                              <span className="ml-1">{APPLICATION_TYPE_LABELS[item.type]}</span>
+                            </Badge>
+                            <Badge className={`${colors.bg} ${colors.text}`}>
+                              {statusIcon(item.status)}
+                              <span className="ml-1">{RINGI_STATUS_LABELS[item.status]}</span>
+                            </Badge>
+                            {item.urgency === '至急' && (
+                              <Badge className="bg-red-100 text-red-700 text-xs">至急</Badge>
+                            )}
+                          </div>
+                          <h3 className="font-medium text-zinc-900 truncate">{item.title}</h3>
+                          {getSubtitle(item) && (
+                            <p className="text-xs text-zinc-400 mt-0.5">{getSubtitle(item)}</p>
                           )}
                         </div>
-                        <h3 className="font-medium text-zinc-900 truncate">{item.title}</h3>
-                      </div>
-                      <div className="text-right shrink-0">
-                        {item.amount && (
-                          <p className="text-sm font-medium text-zinc-900">
-                            ¥{item.amount.toLocaleString()}
-                          </p>
-                        )}
-                        {item.type === 'OVERTIME' && item.payload && (
-                          <p className="text-sm font-medium text-zinc-900">
-                            {(item.payload as OvertimePayload).hours}h
-                          </p>
-                        )}
-                        <p className="text-xs text-zinc-400 mt-1">{formatDate(item.createdAt)}</p>
+                        <div className="text-right shrink-0">
+                          {item.amount && (
+                            <p className="text-sm font-bold text-zinc-900 tabular-nums">
+                              ¥{item.amount.toLocaleString()}
+                            </p>
+                          )}
+                          {item.type === 'OVERTIME' && item.payload && (
+                            <p className="text-sm font-bold text-zinc-900 tabular-nums">
+                              {(item.payload as OvertimePayload).hours}h
+                            </p>
+                          )}
+                          <p className="text-xs text-zinc-400 mt-1">{formatDate(item.createdAt)}</p>
+                        </div>
                       </div>
                     </div>
                   </Card>

--- a/src/app/dashboard/prospects/page.tsx
+++ b/src/app/dashboard/prospects/page.tsx
@@ -181,59 +181,59 @@ export default function ProspectsPage() {
 
           {/* 統計カード */}
           {stats && (
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
-              <Card className="p-4">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+              <Card className="p-3 border-zinc-200">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-blue-100 rounded-lg">
-                    <Users className="w-5 h-5 text-blue-600" />
+                  <div className="w-10 h-10 bg-blue-500 rounded-xl flex items-center justify-center">
+                    <Users className="w-5 h-5 text-white" />
                   </div>
                   <div>
-                    <p className="text-2xl font-bold">{stats.total}</p>
-                    <p className="text-xs text-gray-500">総件数</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-900">{stats.total}</p>
+                    <p className="text-xs text-zinc-500">総件数</p>
                   </div>
                 </div>
               </Card>
-              <Card className="p-4">
+              <Card className="p-3 border-zinc-200">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-green-100 rounded-lg">
-                    <TrendingUp className="w-5 h-5 text-green-600" />
+                  <div className="w-10 h-10 bg-emerald-500 rounded-xl flex items-center justify-center">
+                    <TrendingUp className="w-5 h-5 text-white" />
                   </div>
                   <div>
-                    <p className="text-2xl font-bold">{stats.newThisWeek}</p>
-                    <p className="text-xs text-gray-500">今週の新規</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-900">{stats.newThisWeek}</p>
+                    <p className="text-xs text-zinc-500">今週の新規</p>
                   </div>
                 </div>
               </Card>
-              <Card className="p-4">
+              <Card className="p-3 border-zinc-200">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-purple-100 rounded-lg">
-                    <Calendar className="w-5 h-5 text-purple-600" />
+                  <div className="w-10 h-10 bg-violet-500 rounded-xl flex items-center justify-center">
+                    <Calendar className="w-5 h-5 text-white" />
                   </div>
                   <div>
-                    <p className="text-2xl font-bold">{stats.newThisMonth}</p>
-                    <p className="text-xs text-gray-500">今月の新規</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-900">{stats.newThisMonth}</p>
+                    <p className="text-xs text-zinc-500">今月の新規</p>
                   </div>
                 </div>
               </Card>
-              <Card className="p-4">
+              <Card className="p-3 border-zinc-200">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-orange-100 rounded-lg">
-                    <Clock className="w-5 h-5 text-orange-600" />
+                  <div className="w-10 h-10 bg-amber-500 rounded-xl flex items-center justify-center">
+                    <Clock className="w-5 h-5 text-white" />
                   </div>
                   <div>
-                    <p className="text-2xl font-bold">{stats.avgDaysElapsed}</p>
-                    <p className="text-xs text-gray-500">平均滞留日数</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-900">{stats.avgDaysElapsed}</p>
+                    <p className="text-xs text-zinc-500">平均滞留日数</p>
                   </div>
                 </div>
               </Card>
-              <Card className="p-4">
+              <Card className="p-3 border-zinc-200">
                 <div className="flex items-center gap-3">
-                  <div className="p-2 bg-green-100 rounded-lg">
-                    <Building2 className="w-5 h-5 text-green-600" />
+                  <div className="w-10 h-10 bg-emerald-500 rounded-xl flex items-center justify-center">
+                    <Building2 className="w-5 h-5 text-white" />
                   </div>
                   <div>
-                    <p className="text-2xl font-bold">{stats.byStatus['入居決定'] || 0}</p>
-                    <p className="text-xs text-gray-500">入居決定</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-900">{stats.byStatus['入居決定'] || 0}</p>
+                    <p className="text-xs text-zinc-500">入居決定</p>
                   </div>
                 </div>
               </Card>
@@ -328,82 +328,95 @@ export default function ProspectsPage() {
 
                 return (
                   <Link key={prospect.id} href={`/dashboard/prospects/${prospect.id}`}>
-                    <Card className="p-4 hover:bg-gray-50 transition-colors cursor-pointer">
-                      <div className="flex items-start gap-4">
-                        {/* ステータスバッジ */}
-                        <div className="flex flex-col gap-2">
-                          <span
-                            className={`px-2 py-1 rounded text-xs font-medium ${statusConfig.bgColor} ${statusConfig.color}`}
-                          >
-                            {prospect.status}
-                          </span>
-                          {isNew && (
-                            <Badge variant="info" className="text-xs">
-                              NEW
-                            </Badge>
-                          )}
-                          {hasDuplicates && (
-                            <Badge variant="warning" className="text-xs flex items-center gap-1">
-                              <AlertTriangle className="w-3 h-3" />
-                              重複?
-                            </Badge>
-                          )}
-                        </div>
-
-                        {/* 顧客情報 */}
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <h3 className="font-semibold text-gray-900 truncate">
-                              {prospect.customerName || '名前未登録'}
-                            </h3>
-                            {prospect.age && (
-                              <span className="text-sm text-gray-500">
-                                {prospect.age}歳
-                              </span>
+                    <Card className="relative overflow-hidden hover:bg-zinc-50 transition-colors cursor-pointer border-zinc-200">
+                      {/* 左アクセントバー */}
+                      <div className={`absolute left-0 top-0 bottom-0 w-1 ${
+                        prospect.status === '新規受付' ? 'bg-blue-500' :
+                        prospect.status === '折返し待ち' ? 'bg-amber-500' :
+                        prospect.status === '面談設定済' ? 'bg-violet-500' :
+                        prospect.status === '見学設定済' ? 'bg-violet-500' :
+                        prospect.status === '申込中' ? 'bg-orange-500' :
+                        prospect.status === '入居待ち' ? 'bg-emerald-500' :
+                        prospect.status === '見送り' || prospect.status === 'クローズ' ? 'bg-zinc-300' :
+                        'bg-zinc-300'
+                      }`} />
+                      <div className="p-4 pl-5">
+                        <div className="flex items-start gap-3">
+                          {/* ステータスバッジ */}
+                          <div className="flex flex-col gap-1.5 shrink-0">
+                            <span
+                              className={`px-2 py-1 rounded-md text-xs font-medium ${statusConfig.bgColor} ${statusConfig.color}`}
+                            >
+                              {prospect.status}
+                            </span>
+                            {isNew && (
+                              <Badge variant="info" className="text-xs">
+                                NEW
+                              </Badge>
                             )}
-                            {prospect.gender && (
-                              <span className="text-sm text-gray-500">
-                                {prospect.gender}
-                              </span>
-                            )}
-                            {prospect.careLevel && (
-                              <Badge variant="default" className="text-xs">
-                                {prospect.careLevel}
+                            {hasDuplicates && (
+                              <Badge variant="warning" className="text-xs flex items-center gap-1">
+                                <AlertTriangle className="w-3 h-3" />
+                                重複?
                               </Badge>
                             )}
                           </div>
 
-                          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600">
-                            {prospect.desiredFacility && (
-                              <span className="flex items-center gap-1">
-                                <Building2 className="w-3 h-3" />
-                                {prospect.desiredFacility}
-                              </span>
-                            )}
-                            {prospect.salesCompanyName && (
-                              <span>営業: {prospect.salesCompanyName}</span>
-                            )}
-                            {prospect.interviewDateTime && (
-                              <span className="flex items-center gap-1">
-                                <Calendar className="w-3 h-3" />
-                                面談: {prospect.interviewDateTime}
-                              </span>
-                            )}
+                          {/* 顧客情報 */}
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 mb-1">
+                              <h3 className="font-semibold text-zinc-900 truncate">
+                                {prospect.customerName || '名前未登録'}
+                              </h3>
+                              {prospect.age && (
+                                <span className="text-sm text-zinc-500">
+                                  {prospect.age}歳
+                                </span>
+                              )}
+                              {prospect.gender && (
+                                <span className="text-sm text-zinc-500">
+                                  {prospect.gender}
+                                </span>
+                              )}
+                              {prospect.careLevel && (
+                                <Badge variant="default" className="text-xs">
+                                  {prospect.careLevel}
+                                </Badge>
+                              )}
+                            </div>
+
+                            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-zinc-600">
+                              {prospect.desiredFacility && (
+                                <span className="flex items-center gap-1">
+                                  <Building2 className="w-3 h-3" />
+                                  {prospect.desiredFacility}
+                                </span>
+                              )}
+                              {prospect.salesCompanyName && (
+                                <span>営業: {prospect.salesCompanyName}</span>
+                              )}
+                              {prospect.interviewDateTime && (
+                                <span className="flex items-center gap-1">
+                                  <Calendar className="w-3 h-3" />
+                                  面談: {prospect.interviewDateTime}
+                                </span>
+                              )}
+                            </div>
+
+                            <div className="mt-2 text-xs text-zinc-400">
+                              受信: {prospect.receivedAt.toLocaleDateString('ja-JP')}
+                              {prospect.assigneeName && ` / 担当: ${prospect.assigneeName}`}
+                              {daysElapsed > 7 && (
+                                <span className="ml-2 text-orange-500 font-medium">
+                                  滞留{daysElapsed}日
+                                </span>
+                              )}
+                            </div>
                           </div>
 
-                          <div className="mt-2 text-xs text-gray-400">
-                            受信: {prospect.receivedAt.toLocaleDateString('ja-JP')}
-                            {prospect.assigneeName && ` / 担当: ${prospect.assigneeName}`}
-                            {daysElapsed > 7 && (
-                              <span className="ml-2 text-orange-500">
-                                滞留{daysElapsed}日
-                              </span>
-                            )}
-                          </div>
+                          {/* 詳細へ */}
+                          <ArrowRight className="w-5 h-5 text-zinc-300" />
                         </div>
-
-                        {/* 詳細へ */}
-                        <ArrowRight className="w-5 h-5 text-gray-400" />
                       </div>
                     </Card>
                   </Link>

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -582,65 +582,75 @@ function FacilityCard({ facility, summary, onClick }: FacilityCardProps) {
 
   return (
     <Card
-      className="p-4 hover:shadow-lg transition-shadow cursor-pointer border-l-4 border-l-blue-500"
+      className="relative overflow-hidden hover:shadow-md transition-all cursor-pointer border-zinc-200 active:scale-[0.99]"
       onClick={onClick}
     >
-      <div className="flex items-start justify-between mb-3">
-        <div>
-          <h3 className="font-bold text-lg flex items-center gap-2">
-            <Building2 className="w-5 h-5 text-blue-600" />
-            {facility.name}
-          </h3>
-          {facility.address && (
-            <p className="text-sm text-gray-500 mt-1 flex items-center gap-1">
-              <MapPin className="w-3 h-3" />
-              {facility.address}
-            </p>
-          )}
-        </div>
-        <ChevronRight className="w-5 h-5 text-gray-400" />
-      </div>
+      {/* 左アクセントバー */}
+      <div className={`absolute left-0 top-0 bottom-0 w-1 ${
+        occupancyRate === null ? 'bg-zinc-300' :
+        occupancyRate >= 95 ? 'bg-emerald-500' :
+        occupancyRate >= 85 ? 'bg-blue-500' :
+        occupancyRate >= 70 ? 'bg-amber-500' : 'bg-red-500'
+      }`} />
 
-      {/* サマリー数字 */}
-      <div className="grid grid-cols-4 gap-2 mb-3">
-        <div className="text-center p-2 bg-blue-50 rounded">
-          <div className="text-lg font-bold text-blue-600">{summary.available}</div>
-          <div className="text-xs text-gray-500">空室</div>
+      <div className="p-4 pl-5">
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <h3 className="font-bold text-base flex items-center gap-2 text-zinc-900">
+              <Building2 className="w-5 h-5 text-blue-600" />
+              {facility.name}
+            </h3>
+            {facility.address && (
+              <p className="text-xs text-zinc-500 mt-1 flex items-center gap-1">
+                <MapPin className="w-3 h-3" />
+                {facility.address}
+              </p>
+            )}
+          </div>
+          <ChevronRight className="w-5 h-5 text-zinc-300" />
         </div>
-        <div className="text-center p-2 bg-purple-50 rounded">
-          <div className="text-lg font-bold text-purple-600">{summary.locked}</div>
-          <div className="text-xs text-gray-500">ロック</div>
-        </div>
-        <div className="text-center p-2 bg-green-50 rounded">
-          <div className="text-lg font-bold text-green-600">{summary.occupied}</div>
-          <div className="text-xs text-gray-500">入居中</div>
-        </div>
-        <div className="text-center p-2 bg-yellow-50 rounded">
-          <div className="text-lg font-bold text-yellow-600">{summary.maintenance}</div>
-          <div className="text-xs text-gray-500">修繕</div>
-        </div>
-      </div>
 
-      {/* 稼働率バー */}
-      <div className="flex items-center gap-2">
-        <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
-          <div
-            className={`h-full ${
-              occupancyRate === null ? 'bg-gray-300' :
-              occupancyRate >= 95 ? 'bg-green-500' :
-              occupancyRate >= 85 ? 'bg-blue-500' :
-              occupancyRate >= 70 ? 'bg-yellow-500' : 'bg-red-500'
-            }`}
-            style={{ width: `${occupancyRate || 0}%` }}
-          />
+        {/* サマリー数字 */}
+        <div className="grid grid-cols-4 gap-2 mb-3">
+          <div className="text-center p-2 bg-blue-50 rounded-lg">
+            <div className="text-lg font-bold tabular-nums text-blue-600">{summary.available}</div>
+            <div className="text-[10px] text-zinc-500">空室</div>
+          </div>
+          <div className="text-center p-2 bg-violet-50 rounded-lg">
+            <div className="text-lg font-bold tabular-nums text-violet-600">{summary.locked}</div>
+            <div className="text-[10px] text-zinc-500">ロック</div>
+          </div>
+          <div className="text-center p-2 bg-emerald-50 rounded-lg">
+            <div className="text-lg font-bold tabular-nums text-emerald-600">{summary.occupied}</div>
+            <div className="text-[10px] text-zinc-500">入居中</div>
+          </div>
+          <div className="text-center p-2 bg-amber-50 rounded-lg">
+            <div className="text-lg font-bold tabular-nums text-amber-600">{summary.maintenance}</div>
+            <div className="text-[10px] text-zinc-500">修繕</div>
+          </div>
         </div>
-        <span className={`text-sm font-medium ${getOccupancyColor(occupancyRate)}`}>
-          {occupancyRate !== null ? `${occupancyRate}%` : '--'}
-        </span>
+
+        {/* 稼働率バー */}
+        <div className="flex items-center gap-2">
+          <div className="flex-1 h-2 bg-zinc-100 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${
+                occupancyRate === null ? 'bg-zinc-300' :
+                occupancyRate >= 95 ? 'bg-emerald-500' :
+                occupancyRate >= 85 ? 'bg-blue-500' :
+                occupancyRate >= 70 ? 'bg-amber-500' : 'bg-red-500'
+              }`}
+              style={{ width: `${occupancyRate || 0}%` }}
+            />
+          </div>
+          <span className={`text-sm font-bold tabular-nums ${getOccupancyColor(occupancyRate)}`}>
+            {occupancyRate !== null ? `${occupancyRate}%` : '--'}
+          </span>
+        </div>
+        <p className="text-xs text-zinc-400 mt-1">
+          稼働率 ({summary.occupied}/{summary.totalRooms}室)
+        </p>
       </div>
-      <p className="text-xs text-gray-400 mt-1">
-        稼働率 ({summary.occupied}/{summary.totalRooms}室)
-      </p>
     </Card>
   );
 }
@@ -890,43 +900,53 @@ export default function VacancyPage() {
           )}
 
           {/* 全体サマリー */}
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
-            <Card className="p-4 bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+            <Card className="p-3 border-zinc-200">
               <div className="flex items-center gap-2 mb-1">
-                <TrendingUp className="w-4 h-4 text-blue-600" />
-                <span className="text-xs font-medium text-gray-600">稼働率</span>
+                <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+                  <TrendingUp className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs font-medium text-zinc-500">稼働率</span>
               </div>
-              <div className={`text-2xl font-bold ${getOccupancyColor(totalSummary.occupancyRate)}`}>
+              <div className={`text-2xl font-bold tabular-nums ${getOccupancyColor(totalSummary.occupancyRate)}`}>
                 {totalSummary.occupancyRate !== null ? `${totalSummary.occupancyRate}%` : '--'}
               </div>
             </Card>
-            <Card className="p-4 bg-blue-50 border-blue-200">
+            <Card className="p-3 border-zinc-200">
               <div className="flex items-center gap-2 mb-1">
-                <Home className="w-4 h-4 text-blue-600" />
-                <span className="text-xs font-medium text-gray-600">空室</span>
+                <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+                  <Home className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs font-medium text-zinc-500">空室</span>
               </div>
-              <div className="text-2xl font-bold text-blue-600">{totalSummary.available}</div>
+              <div className="text-2xl font-bold tabular-nums text-blue-600">{totalSummary.available}</div>
             </Card>
-            <Card className="p-4 bg-purple-50 border-purple-200">
+            <Card className="p-3 border-zinc-200">
               <div className="flex items-center gap-2 mb-1">
-                <Lock className="w-4 h-4 text-purple-600" />
-                <span className="text-xs font-medium text-gray-600">ロック</span>
+                <div className="w-8 h-8 bg-violet-500 rounded-lg flex items-center justify-center">
+                  <Lock className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs font-medium text-zinc-500">ロック</span>
               </div>
-              <div className="text-2xl font-bold text-purple-600">{totalSummary.locked}</div>
+              <div className="text-2xl font-bold tabular-nums text-violet-600">{totalSummary.locked}</div>
             </Card>
-            <Card className="p-4 bg-green-50 border-green-200">
+            <Card className="p-3 border-zinc-200">
               <div className="flex items-center gap-2 mb-1">
-                <Users className="w-4 h-4 text-green-600" />
-                <span className="text-xs font-medium text-gray-600">入居中</span>
+                <div className="w-8 h-8 bg-emerald-500 rounded-lg flex items-center justify-center">
+                  <Users className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs font-medium text-zinc-500">入居中</span>
               </div>
-              <div className="text-2xl font-bold text-green-600">{totalSummary.occupied}</div>
+              <div className="text-2xl font-bold tabular-nums text-emerald-600">{totalSummary.occupied}</div>
             </Card>
-            <Card className="p-4 bg-yellow-50 border-yellow-200">
+            <Card className="p-3 border-zinc-200">
               <div className="flex items-center gap-2 mb-1">
-                <Wrench className="w-4 h-4 text-yellow-600" />
-                <span className="text-xs font-medium text-gray-600">修繕中</span>
+                <div className="w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+                  <Wrench className="w-4 h-4 text-white" />
+                </div>
+                <span className="text-xs font-medium text-zinc-500">修繕中</span>
               </div>
-              <div className="text-2xl font-bold text-yellow-600">{totalSummary.maintenance}</div>
+              <div className="text-2xl font-bold tabular-nums text-amber-600">{totalSummary.maintenance}</div>
             </Card>
           </div>
 

--- a/src/components/launchMode/LaunchModeDashboard.tsx
+++ b/src/components/launchMode/LaunchModeDashboard.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import Link from 'next/link';
-import { Users, Building2, Clock, CheckCircle, Sparkles, ChevronRight } from 'lucide-react';
+import {
+  Users,
+  Building2,
+  Clock,
+  CheckCircle,
+  ChevronRight,
+  Bell,
+} from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { LAUNCH_NAV_ITEMS } from '@/config/launchRoutes';
-import { getEnvironmentLabel } from '@/config/launchMode';
 
 const iconMap: Record<string, React.ElementType> = {
   Users,
@@ -13,159 +19,181 @@ const iconMap: Record<string, React.ElementType> = {
   CheckCircle,
 };
 
-// カラーテーマ（各機能）
-const colorThemes: Record<string, { bg: string; hover: string; icon: string; border: string }> = {
+// カードデザインテーマ
+const cardThemes: Record<
+  string,
+  {
+    gradient: string;
+    iconBg: string;
+    iconColor: string;
+    hoverBorder: string;
+    accentBar: string;
+  }
+> = {
   '/dashboard/prospects': {
-    bg: 'bg-blue-50',
-    hover: 'hover:bg-blue-100 hover:border-blue-300',
-    icon: 'text-blue-600',
-    border: 'border-blue-200',
+    gradient: 'from-blue-50 to-blue-100/50',
+    iconBg: 'bg-blue-500',
+    iconColor: 'text-white',
+    hoverBorder: 'hover:border-blue-300',
+    accentBar: 'bg-blue-500',
   },
   '/dashboard/vacancy': {
-    bg: 'bg-emerald-50',
-    hover: 'hover:bg-emerald-100 hover:border-emerald-300',
-    icon: 'text-emerald-600',
-    border: 'border-emerald-200',
+    gradient: 'from-emerald-50 to-emerald-100/50',
+    iconBg: 'bg-emerald-500',
+    iconColor: 'text-white',
+    hoverBorder: 'hover:border-emerald-300',
+    accentBar: 'bg-emerald-500',
   },
   '/attendance': {
-    bg: 'bg-amber-50',
-    hover: 'hover:bg-amber-100 hover:border-amber-300',
-    icon: 'text-amber-600',
-    border: 'border-amber-200',
+    gradient: 'from-amber-50 to-amber-100/50',
+    iconBg: 'bg-amber-500',
+    iconColor: 'text-white',
+    hoverBorder: 'hover:border-amber-300',
+    accentBar: 'bg-amber-500',
   },
   '/dashboard/approvals': {
-    bg: 'bg-violet-50',
-    hover: 'hover:bg-violet-100 hover:border-violet-300',
-    icon: 'text-violet-600',
-    border: 'border-violet-200',
+    gradient: 'from-violet-50 to-violet-100/50',
+    iconBg: 'bg-violet-500',
+    iconColor: 'text-white',
+    hoverBorder: 'hover:border-violet-300',
+    accentBar: 'bg-violet-500',
   },
 };
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 6) return 'お疲れさまです';
+  if (hour < 11) return 'おはようございます';
+  if (hour < 14) return 'こんにちは';
+  if (hour < 18) return 'お疲れさまです';
+  return 'お疲れさまです';
+}
+
+function formatDate(): string {
+  const now = new Date();
+  const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+  const weekday = weekdays[now.getDay()];
+  return `${month}月${day}日（${weekday}）`;
+}
 
 /**
  * Launch Mode ダッシュボード
  *
  * 先行公開4機能（入居希望・空室・打刻・承認）に特化したUI
+ * スマホ・ウェブ両対応のモダンデザイン
  */
 export function LaunchModeDashboard() {
   const { user } = useAuth();
-  const envLabel = getEnvironmentLabel();
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900" />
-          <p className="text-sm text-slate-500">読み込み中...</p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
+          <p className="text-sm text-zinc-500">読み込み中...</p>
         </div>
       </div>
     );
   }
 
+  const greeting = getGreeting();
+  const dateStr = formatDate();
+  const displayName = user.name || user.email?.split('@')[0];
+
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+    <div className="min-h-screen bg-zinc-50 pb-24 md:pb-8">
       {/* ヘッダーエリア */}
-      <div className="bg-white border-b border-slate-200">
-        <div className="max-w-4xl mx-auto px-4 py-6">
+      <div className="bg-white">
+        <div className="max-w-3xl mx-auto px-4 pt-6 pb-5">
+          {/* 日付 */}
+          <p className="text-xs font-medium text-zinc-400 mb-1">
+            {dateStr}
+          </p>
+
+          {/* 挨拶 */}
           <div className="flex items-center justify-between">
             <div>
-              <div className="flex items-center gap-2 mb-1">
-                <h1 className="text-2xl font-bold text-slate-800">
-                  こんにちは、{user.name || user.email?.split('@')[0]}さん
-                </h1>
-              </div>
-              <p className="text-slate-500 text-sm">
+              <h1 className="text-xl font-bold text-zinc-900">
+                {greeting}、{displayName}さん
+              </h1>
+              <p className="text-sm text-zinc-500 mt-0.5">
                 今日も一日よろしくお願いします
               </p>
             </div>
 
-            {/* 環境バッジ */}
-            <div className="flex items-center gap-2">
-              <span className="px-2.5 py-1 bg-slate-100 text-slate-600 text-xs font-medium rounded-full">
-                {envLabel}
-              </span>
-              <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-medium rounded-full flex items-center gap-1">
-                <Sparkles className="w-3 h-3" />
-                Launch Mode
-              </span>
-            </div>
+            {/* 通知アイコン（デスクトップのみ - モバイルはヘッダーにある） */}
+            <Link
+              href="/dashboard/notifications"
+              className="hidden md:flex w-10 h-10 items-center justify-center rounded-full bg-zinc-100 hover:bg-zinc-200 transition-colors"
+            >
+              <Bell className="w-5 h-5 text-zinc-600" />
+            </Link>
           </div>
         </div>
       </div>
 
       {/* メインコンテンツ */}
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        {/* セクションタイトル */}
-        <div className="mb-6">
-          <h2 className="text-lg font-semibold text-slate-700">
-            ご利用いただける機能
-          </h2>
-          <p className="text-sm text-slate-500 mt-1">
-            業務に必要な機能をお選びください
-          </p>
-        </div>
-
+      <div className="max-w-3xl mx-auto px-4 py-5">
         {/* 4機能カード */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {LAUNCH_NAV_ITEMS.map((item) => {
             const Icon = iconMap[item.icon] || Users;
-            const theme = colorThemes[item.href] || colorThemes['/dashboard/prospects'];
+            const theme = cardThemes[item.href] || cardThemes['/dashboard/prospects'];
 
             return (
               <Link
                 key={item.href}
                 href={item.href}
-                className={`group block p-6 rounded-2xl border-2 transition-all duration-200 ${theme.bg} ${theme.border} ${theme.hover} hover:shadow-lg hover:-translate-y-0.5`}
+                className={`group relative block overflow-hidden rounded-2xl border border-zinc-200 bg-white transition-all duration-200 ${theme.hoverBorder} hover:shadow-md active:scale-[0.98]`}
               >
-                <div className="flex items-start justify-between">
-                  <div className="flex items-start gap-4">
-                    <div className={`w-14 h-14 bg-white rounded-xl flex items-center justify-center shadow-sm group-hover:shadow transition-shadow`}>
-                      <Icon className={`w-7 h-7 ${theme.icon}`} />
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-bold text-slate-800 mb-1 group-hover:text-slate-900">
-                        {item.label}
-                      </h3>
-                      <p className="text-sm text-slate-600">
-                        {item.description}
-                      </p>
-                      <p className="text-xs text-slate-400 mt-2 font-medium">
-                        {item.labelEn}
-                      </p>
-                    </div>
+                {/* 左アクセントバー */}
+                <div className={`absolute left-0 top-0 bottom-0 w-1 ${theme.accentBar}`} />
+
+                <div className="flex items-center gap-4 p-4 pl-5">
+                  {/* アイコン */}
+                  <div
+                    className={`w-12 h-12 rounded-xl ${theme.iconBg} flex items-center justify-center flex-shrink-0 shadow-sm`}
+                  >
+                    <Icon className={`w-6 h-6 ${theme.iconColor}`} />
                   </div>
-                  <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-slate-600 group-hover:translate-x-1 transition-all" />
+
+                  {/* テキスト */}
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-base font-bold text-zinc-900 group-hover:text-zinc-800">
+                      {item.label}
+                    </h3>
+                    <p className="text-xs text-zinc-500 mt-0.5">
+                      {item.description}
+                    </p>
+                  </div>
+
+                  {/* 矢印 */}
+                  <ChevronRight className="w-5 h-5 text-zinc-300 group-hover:text-zinc-500 group-hover:translate-x-0.5 transition-all flex-shrink-0" />
                 </div>
               </Link>
             );
           })}
         </div>
 
-        {/* 補足情報 */}
-        <div className="bg-slate-50 rounded-xl p-6 border border-slate-200">
+        {/* お知らせエリア */}
+        <div className="mt-5 bg-white rounded-2xl border border-zinc-200 p-4">
           <div className="flex items-start gap-3">
-            <div className="w-10 h-10 bg-slate-200 rounded-lg flex items-center justify-center flex-shrink-0">
-              <Sparkles className="w-5 h-5 text-slate-600" />
+            <div className="w-8 h-8 bg-zinc-100 rounded-lg flex items-center justify-center flex-shrink-0">
+              <Bell className="w-4 h-4 text-zinc-500" />
             </div>
             <div>
-              <h3 className="font-semibold text-slate-700 mb-1">
-                その他の機能について
+              <h3 className="text-sm font-semibold text-zinc-700">
+                ご利用ガイド
               </h3>
-              <p className="text-sm text-slate-500 leading-relaxed">
-                現在、先行公開として上記4機能をご利用いただけます。
-                その他の機能は順次追加していく予定です。
-                ご不便をおかけしますが、今しばらくお待ちください。
+              <p className="text-xs text-zinc-500 mt-1 leading-relaxed">
+                現在、上記4つの機能をご利用いただけます。
+                その他の機能は順次追加予定です。
+                操作でお困りの際は管理者までお問い合わせください。
               </p>
             </div>
           </div>
-        </div>
-      </div>
-
-      {/* フッター */}
-      <div className="border-t border-slate-200 bg-white mt-auto">
-        <div className="max-w-4xl mx-auto px-4 py-4">
-          <p className="text-center text-xs text-slate-400">
-            お困りの際は管理者までお問い合わせください
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Launch Mode ダッシュボード:
- 日付・時刻に応じた挨拶表示
- カード左端にカラーアクセントバー
- アイコンを塗りアイコン（白字）に統一
- max-w-3xl でスマホ/ウェブ両対応のバランス

共通デザインパターン:
- カラーシステム zinc に統一（gray → zinc）
- 統計カード: 塗りアイコン + tabular-nums
- リストカード: 左アクセントバー + ステータス色連動
- active:scale-[0.98] でタッチフィードバック

打刻ページ:
- ステータスカードの色を zinc 系に統一
- 下部ナビをアイコン付きボタンに改善

承認ページ:
- サマリーカードにアイコン付き小バッジ追加
- リストカード左端にステータス色バー

入居希望ページ:
- 統計カード: bg-{color}-100 → bg-{color}-500 塗りアイコン
- リストカード: 左アクセントバー + ステータス連動色

空室管理ページ:
- 全体サマリー: 塗りアイコン + tabular-nums
- 施設カード: 左アクセントバー（稼働率色連動）
- 稼働率バー: rounded-full でなめらかに

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
