### PR TITLE
fix: /launch ページが旧デザインを描画していた問題を修正 + 自己チェックレポート

### DIFF
--- a/reports/site-self-check.md
+++ b/reports/site-self-check.md
@@ -1,0 +1,158 @@
+# AA-HUB サイト自己チェックレポート
+
+**生成日**: 2026-02-08
+**ブランチ**: `claude/hiyari-attendance-continue-PSEge`
+**ビルド結果**: 成功 (0 errors)
+**テスト結果**: 24 suites, 516 tests passed
+
+---
+
+## 1. 「デザインが変わらない」原因と修正
+
+### 根本原因
+**`/launch/page.tsx` が旧デザインを直接描画していた。**
+
+- `LAUNCH_MODE=true` のとき middleware が `/dashboard` → `/launch` にリダイレクト
+- `/launch/page.tsx` は独自の UI（旧 `slate-*` カラー、非ライブカウント版）を持っていた
+- 新デザインの `LaunchModeDashboard` は `/dashboard/page.tsx` に実装済みだったが、
+  ユーザーは `/launch` に到達するため、新デザインを見ることがなかった
+
+### 修正内容
+- `/launch/page.tsx` を書き換え、`LaunchModeDashboard` コンポーネントを描画するようにした
+- これにより `/launch` にアクセスしても新デザイン（ライブカウント付きモジュールカード）が表示される
+
+### 追加対策（キャッシュ・バージョン可視化）
+| 対策 | ファイル | 説明 |
+|------|---------|------|
+| `/api/version` | `src/app/api/version/route.ts` | Git SHA + ビルド時刻を返す |
+| Build SHA 表示 | `src/components/BuildInfo.tsx` | ダッシュボードフッターに表示 |
+| `Cache-Control: no-store` | `next.config.ts` | `/dashboard/*`, `/launch`, `/api/*` |
+| middleware Cache-Control | `src/middleware.ts` | 上記に加えてレスポンスヘッダーにも設定 |
+
+### SW/PWA チェック
+- **結果**: Service Worker / PWA / workbox は使用されていない
+- `public/sw.js`, `next-pwa`, `navigator.serviceWorker` いずれも検出なし
+- **キャッシュの原因は SW ではない** ことを確認
+
+---
+
+## 2. デプロイ確認手順
+
+```bash
+# 1. 本番の Build SHA を確認
+curl -s https://aa-g.org/api/version | jq .
+
+# 2. Cache-Control ヘッダーを確認
+curl -I https://aa-g.org/dashboard 2>&1 | grep -i cache-control
+
+# 3. ローカルの最新コミットと比較
+git log --oneline -1
+```
+
+期待される結果:
+- `api/version` の `sha` がデプロイ対象コミットの SHA と一致
+- `Cache-Control: no-store, no-cache, must-revalidate` が返る
+- Dashboard UI に Build SHA が表示される
+
+---
+
+## 3. ルート一覧と Launch Mode 分類
+
+### Launch Mode で許可されるルート (4モジュール + 共通)
+
+| カテゴリ | ルート例 | 制御方法 |
+|----------|---------|----------|
+| **打刻** | `/attendance`, `/attendance/history`, `/attendance/overtime` | featureGate: attendance |
+| **承認** | `/dashboard/approvals`, `/ringi`, `/ringi/*`, `/requests/*` | featureGate: approvals |
+| **入居希望** | `/dashboard/prospects`, `/dashboard/prospects/*` | featureGate: prospects |
+| **空室** | `/dashboard/vacancy`, `/vacancies`, `/dashboard/vacancy-inquiries` | featureGate: vacancies |
+| **共通** | `/login`, `/onboarding`, `/launch`, `/coming-soon`, `/settings/*` | commonPrefixes |
+| **通知** | `/dashboard/notifications` | commonPrefixes |
+| **API** | `/api/*` (全API) | 常に許可 |
+| **管理(打刻)** | `/admin/attendance/*` | featureGate: attendance |
+| **管理(承認)** | `/dashboard/admin/ringi`, `/admin/ringi`, `/admin/approval-routes` | featureGate: approvals |
+
+### Launch Mode でブロックされるルート (→ /coming-soon にリダイレクト)
+
+| カテゴリ | ルート例 | モジュール |
+|----------|---------|----------|
+| 報告 | `/submit`, `/incident/*`, `/admin/incidents` | incidents (disabled) |
+| 改善 | `/improvements/*`, `/admin/improvements` | improvements (disabled) |
+| ランク | `/rankings` | rankings (disabled) |
+| 営業 | `/sales/*` | sales (disabled) |
+| 経営OS | `/dashboard/os/*`, `/dashboard/os-map` | os (disabled) |
+| AI副社長 | `/dashboard/ai/*`, `/admin/ai-vp/*` | ai-vp (disabled) |
+| ドキュメント | `/dashboard/docs/*` | docs (disabled) |
+| その他管理 | `/admin/employees`, `/admin/users`, `/admin/points` | 共通ルートに未登録 |
+
+### 全ルート統計
+- **総ルート数**: 184 pages
+- **Launch Mode で許可**: ~35 routes (4モジュール + 共通)
+- **Launch Mode でブロック**: ~149 routes
+- **API ルート**: 全て許可 (UI側で制御)
+
+---
+
+## 4. Feature Gate システム
+
+### アーキテクチャ
+```
+src/config/featureGate.ts
+├── ALL_MODULES (11モジュール定義)
+├── LAUNCH_ENABLED (4モジュールID)
+├── isModuleEnabled(moduleId)     → boolean
+├── getEnabledModules()           → ModuleConfig[]
+├── isRouteEnabledByGate(path)    → boolean (middleware用)
+└── filterNavItems(items)         → T[] (ナビゲーション用)
+```
+
+### 利用箇所
+| ファイル | 関数 | 用途 |
+|---------|------|------|
+| `middleware.ts` | `isRouteEnabledByGate()` | ルートブロック |
+| `Header.tsx` | `filterNavItems()` | デスクトップナビ |
+| `MobileBottomNav.tsx` | `filterNavItems()`, `isModuleEnabled()` | モバイルナビ |
+
+### 従来の LAUNCH_MODE ハードコード → featureGate への移行
+- `LAUNCH_MODE_NAV_HREFS` → `filterNavItems(allNavItems)`
+- `LAUNCH_MODE_ADMIN_HREFS` → `filterNavItems(allAdminItems)`
+- `LAUNCH_MODE_MORE_HREFS` → `filterNavItems(allMoreItems)`
+- `!LAUNCH_MODE && isAiVpOwner()` → `isModuleEnabled('ai-vp') && isAiVpOwner()`
+
+---
+
+## 5. 新規 API エンドポイント
+
+| エンドポイント | メソッド | 用途 |
+|---------------|---------|------|
+| `/api/version` | GET | デプロイ確認 (SHA + ビルド時刻) |
+| `/api/dashboard/counts` | GET | 4モジュールライブカウント |
+| `/api/attendance/entries` | GET | 勤怠エントリ一覧 (サーバーサイド) |
+| `/api/attendance/shifts` | GET | シフト一覧 (サーバーサイド) |
+| `/api/admin/bootstrap/vacancy-from-sheets` | POST | 空室データ Sheets→Firestore インポート |
+| `/api/admin/bootstrap/purge-demo-approvals` | POST | テストデータ一括削除 |
+
+---
+
+## 6. 確認チェックリスト
+
+- [x] `npx next build` 成功 (0 errors)
+- [x] `npm test` 成功 (24 suites, 516 tests)
+- [x] `/launch` ページが `LaunchModeDashboard` を描画する
+- [x] `/api/version` が Git SHA を返す
+- [x] `Cache-Control: no-store` が `/dashboard/*`, `/api/*` に設定
+- [x] SW/PWA なし (キャッシュ原因ではない)
+- [x] featureGate で 4モジュール以外がブロックされる
+- [x] Header / MobileBottomNav が featureGate でフィルタされる
+- [x] Build SHA がダッシュボードフッターに表示される
+- [ ] **要確認**: 本番デプロイ後に `curl -s https://aa-g.org/api/version` で SHA 確認
+- [ ] **要確認**: 本番で `/dashboard` → `/launch` リダイレクト → 新デザイン表示
+
+---
+
+## 7. 今後の推奨事項
+
+1. **デプロイ後の確認 SOP**: `api/version` の SHA と UI の Build 表示で一致確認
+2. **Vercel 環境変数**: `NEXT_PUBLIC_GIT_SHA` に `VERCEL_GIT_COMMIT_SHA` を設定
+3. **モジュール追加時**: `featureGate.ts` の `LAUNCH_ENABLED` に追加するだけで公開可能
+4. **全モジュール公開時**: `NEXT_PUBLIC_LAUNCH_MODE` を削除または `false` に設定

--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -1,233 +1,35 @@
 'use client';
 
-import Link from 'next/link';
-import Image from 'next/image';
 import { redirect } from 'next/navigation';
-import { Users, Building2, Clock, CheckCircle, Sparkles, ChevronRight, LogOut } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { LAUNCH_MODE } from '@/config/launchMode';
-
-// Launch Mode が無効な場合は /dashboard へリダイレクト
-// Note: クライアントコンポーネントでのリダイレクトは useEffect で処理
+import { LaunchModeDashboard } from '@/components/launchMode/LaunchModeDashboard';
 
 /**
- * Launch Mode 専用トップページ
+ * /launch - Launch Mode 専用トップページ
  *
- * 4機能のみを大きなカードで表示
- * - 入居希望 (Prospects)
- * - 空室 (Vacancies)
- * - 打刻 (Attendance)
- * - 承認 (Approvals)
+ * LaunchModeDashboard コンポーネントを描画する。
+ * Header / MobileBottomNav は Providers 経由で自動表示。
+ *
+ * LAUNCH_MODE=false の場合は /dashboard へリダイレクト。
  */
-
-interface FeatureCard {
-  id: string;
-  href: string;
-  label: string;
-  labelEn: string;
-  description: string;
-  icon: React.ElementType;
-  theme: {
-    bg: string;
-    border: string;
-    hover: string;
-    iconBg: string;
-    iconColor: string;
-  };
-}
-
-const FEATURE_CARDS: FeatureCard[] = [
-  {
-    id: 'prospects',
-    href: '/dashboard/prospects',
-    label: '入居希望',
-    labelEn: 'Prospects',
-    description: '入居希望者の管理・対応',
-    icon: Users,
-    theme: {
-      bg: 'bg-blue-50',
-      border: 'border-blue-200',
-      hover: 'hover:bg-blue-100 hover:border-blue-400 hover:shadow-blue-100',
-      iconBg: 'bg-blue-100',
-      iconColor: 'text-blue-600',
-    },
-  },
-  {
-    id: 'vacancy',
-    href: '/dashboard/vacancy',
-    label: '空室',
-    labelEn: 'Vacancies',
-    description: '空室状況の確認・管理',
-    icon: Building2,
-    theme: {
-      bg: 'bg-emerald-50',
-      border: 'border-emerald-200',
-      hover: 'hover:bg-emerald-100 hover:border-emerald-400 hover:shadow-emerald-100',
-      iconBg: 'bg-emerald-100',
-      iconColor: 'text-emerald-600',
-    },
-  },
-  {
-    id: 'attendance',
-    href: '/attendance',
-    label: '打刻',
-    labelEn: 'Attendance',
-    description: '出退勤の記録・確認',
-    icon: Clock,
-    theme: {
-      bg: 'bg-amber-50',
-      border: 'border-amber-200',
-      hover: 'hover:bg-amber-100 hover:border-amber-400 hover:shadow-amber-100',
-      iconBg: 'bg-amber-100',
-      iconColor: 'text-amber-600',
-    },
-  },
-  {
-    id: 'approvals',
-    href: '/dashboard/approvals',
-    label: '承認',
-    labelEn: 'Approvals',
-    description: '申請の確認・承認',
-    icon: CheckCircle,
-    theme: {
-      bg: 'bg-violet-50',
-      border: 'border-violet-200',
-      hover: 'hover:bg-violet-100 hover:border-violet-400 hover:shadow-violet-100',
-      iconBg: 'bg-violet-100',
-      iconColor: 'text-violet-600',
-    },
-  },
-];
-
 export default function LaunchPage() {
-  const { user, signOut, loading } = useAuth();
-
-  // Launch Mode が無効な場合は /dashboard へリダイレクト
   if (!LAUNCH_MODE) {
     redirect('/dashboard');
   }
 
-  // ローディング中
+  const { loading } = useAuth();
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900" />
-          <p className="text-sm text-slate-500">読み込み中...</p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
+          <p className="text-sm text-zinc-500">読み込み中...</p>
         </div>
       </div>
     );
   }
 
-  // 未認証の場合は認証ページへ
-  if (!user) {
-    redirect('/auth/signin');
-  }
-
-  const handleSignOut = async () => {
-    await signOut();
-  };
-
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 flex flex-col">
-      {/* ミニマルヘッダー */}
-      <header className="bg-white/80 backdrop-blur-md border-b border-slate-200 sticky top-0 z-50">
-        <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Link href="/launch" className="flex items-center gap-2">
-              <Image
-                src="/logo-icon.svg"
-                alt="AA-HUB"
-                width={28}
-                height={28}
-                className="h-7 w-7"
-              />
-              <span className="text-base font-bold text-slate-900">AA-HUB</span>
-            </Link>
-            <span className="px-2.5 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full flex items-center gap-1">
-              <Sparkles className="w-3 h-3" />
-              Launch Mode
-            </span>
-          </div>
-
-          {/* ユーザーメニュー */}
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-slate-600 hidden sm:block">
-              {user.name || user.email?.split('@')[0]}
-            </span>
-            <button
-              onClick={handleSignOut}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-            >
-              <LogOut className="w-4 h-4" />
-              <span className="hidden sm:inline">ログアウト</span>
-            </button>
-          </div>
-        </div>
-      </header>
-
-      {/* メインコンテンツ */}
-      <main className="flex-1 flex flex-col justify-center py-8 px-4">
-        <div className="max-w-4xl mx-auto w-full">
-          {/* 挨拶 */}
-          <div className="text-center mb-8">
-            <h1 className="text-2xl sm:text-3xl font-bold text-slate-800 mb-2">
-              こんにちは、{user.name || user.email?.split('@')[0]}さん
-            </h1>
-            <p className="text-slate-500">
-              ご利用いただける機能をお選びください
-            </p>
-          </div>
-
-          {/* 4機能カード */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
-            {FEATURE_CARDS.map((card) => {
-              const Icon = card.icon;
-              return (
-                <Link
-                  key={card.id}
-                  href={card.href}
-                  className={`group block p-6 sm:p-8 rounded-2xl border-2 transition-all duration-200 ${card.theme.bg} ${card.theme.border} ${card.theme.hover} hover:shadow-xl hover:-translate-y-1`}
-                >
-                  <div className="flex items-start gap-4">
-                    <div className={`w-14 h-14 sm:w-16 sm:h-16 ${card.theme.iconBg} rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-105 transition-transform`}>
-                      <Icon className={`w-7 h-7 sm:w-8 sm:h-8 ${card.theme.iconColor}`} />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center justify-between gap-2">
-                        <h2 className="text-xl sm:text-2xl font-bold text-slate-800 group-hover:text-slate-900">
-                          {card.label}
-                        </h2>
-                        <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-slate-600 group-hover:translate-x-1 transition-all flex-shrink-0" />
-                      </div>
-                      <p className="text-sm text-slate-600 mt-1">
-                        {card.description}
-                      </p>
-                      <p className="text-xs text-slate-400 mt-2 font-medium uppercase tracking-wider">
-                        {card.labelEn}
-                      </p>
-                    </div>
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-
-          {/* 補足情報 */}
-          <div className="mt-8 p-4 bg-slate-100 rounded-xl text-center">
-            <p className="text-sm text-slate-500">
-              その他の機能は順次追加予定です。ご不便をおかけしますがお待ちください。
-            </p>
-          </div>
-        </div>
-      </main>
-
-      {/* フッター */}
-      <footer className="py-4 text-center border-t border-slate-200">
-        <p className="text-xs text-slate-400">
-          お困りの際は管理者までお問い合わせください
-        </p>
-      </footer>
-    </div>
-  );
+  return <LaunchModeDashboard />;
 }

--- a/src/config/featureGate.ts
+++ b/src/config/featureGate.ts
@@ -48,28 +48,28 @@ export const ALL_MODULES: ModuleConfig[] = [
     id: 'approvals',
     label: '承認',
     labelEn: 'Approvals',
-    routes: ['/dashboard/approvals', '/ringi', '/dashboard/admin/ringi', '/admin/ringi'],
+    routes: ['/dashboard/approvals', '/ringi', '/dashboard/admin/ringi', '/admin/ringi', '/admin/approval-routes', '/requests', '/dashboard/applications', '/dashboard/approval-flow', '/dashboard/approval-log'],
     apiRoutes: ['/api/approvals', '/api/ringi'],
   },
   {
     id: 'prospects',
     label: '入居希望',
     labelEn: 'Prospects',
-    routes: ['/dashboard/prospects'],
+    routes: ['/dashboard/prospects', '/admin/prospects'],
     apiRoutes: ['/api/prospects'],
   },
   {
     id: 'vacancies',
     label: '空室',
     labelEn: 'Vacancies',
-    routes: ['/dashboard/vacancy', '/dashboard/vacancies', '/vacancies', '/dashboard/vacancy-inquiries'],
-    apiRoutes: ['/api/vacancies', '/api/vacancy'],
+    routes: ['/dashboard/vacancy', '/dashboard/vacancies', '/vacancies', '/dashboard/vacancy-inquiries', '/dashboard/vacancy-analytics'],
+    apiRoutes: ['/api/vacancies', '/api/vacancy', '/api/admin/vacancies'],
   },
   {
     id: 'incidents',
     label: '報告',
     labelEn: 'Incidents',
-    routes: ['/submit', '/admin/incidents'],
+    routes: ['/submit', '/admin/incidents', '/incident'],
     apiRoutes: ['/api/incidents'],
   },
   {
@@ -162,7 +162,8 @@ export function isRouteEnabledByGate(pathname: string): boolean {
     '/launch', '/coming-soon', '/settings',
     '/_next', '/favicon', '/api/health', '/api/version',
     '/api/users', '/api/notifications', '/api/business-units',
-    '/api/tickets', '/dashboard/notifications',
+    '/api/tickets', '/api/admin/bootstrap', '/api/dashboard',
+    '/dashboard/notifications',
   ];
   for (const prefix of commonPrefixes) {
     if (pathname === prefix || pathname.startsWith(prefix + '/') || pathname.startsWith(prefix + '?')) {


### PR DESCRIPTION
根本原因:
  LAUNCH_MODE=true → middleware が /dashboard → /launch にリダイレクト
  → /launch/page.tsx は独自の旧UI を直接描画（LaunchModeDashboard 未使用）
  → ユーザーは新デザインを見られなかった

修正:
  - /launch/page.tsx を LaunchModeDashboard コンポーネント描画に変更
  - featureGate のモジュールルート定義を拡充 (approvals: /requests, /dashboard/applications, /approval-flow 追加) (vacancies: /dashboard/vacancy-analytics 追加) (prospects: /admin/prospects 追加) (incidents: /incident 追加)
  - featureGate 共通ルートに /api/admin/bootstrap, /api/dashboard 追加
  - reports/site-self-check.md 生成（184ルート分類、LaunchMode検証）

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
