### PR TITLE
fix: 稟議 tenantId フィルタ欠落修正 + 打刻 employeeCode 修正

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -348,6 +348,15 @@
       "collectionGroup": "ringis",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "tenantId", "order": "ASCENDING" },
+        { "fieldPath": "authorId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "ringis",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "authorId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]

--- a/reports/site-self-check.md
+++ b/reports/site-self-check.md
@@ -150,7 +150,28 @@ src/config/featureGate.ts
 
 ---
 
-## 7. 今後の推奨事項
+## 7. 追加修正 (2026-02-08 第2回)
+
+### 7-1. 稟議 (ringi) tenantId フィルタ欠落 [CRITICAL]
+
+**根本原因**: `getRingisByUser()`, `getPendingRingis()`, `getAllRingis()` の3関数が
+`tenantId` パラメータを受け取りながら Firestore クエリに `where('tenantId', '==', tenantId)` を含めていなかった。
+
+**影響**:
+- 別テナントの稟議データが表示される可能性（マルチテナント分離違反）
+- 別アカウントから申請した稟議が見えない問題の原因
+
+**修正**: 3関数すべてに `where('tenantId', '==', tenantId)` を追加。
+Firestore composite index `ringis(tenantId ASC, authorId ASC, createdAt DESC)` も追加。
+
+### 7-2. 打刻 clockIn の employeeCode パラメータ
+
+**根本原因**: `clockIn()` に `user.email` を渡していた。
+**修正**: `user.name || user.email` に変更。
+
+---
+
+## 8. 今後の推奨事項
 
 1. **デプロイ後の確認 SOP**: `api/version` の SHA と UI の Build 表示で一致確認
 2. **Vercel 環境変数**: `NEXT_PUBLIC_GIT_SHA` に `VERCEL_GIT_COMMIT_SHA` を設定

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -148,7 +148,7 @@ export default function AttendancePage() {
     try {
       await clockIn(
         user.id,
-        user.email,
+        user.name || user.email,
         selectedBranchId,
         user.tenantId
       );

--- a/src/lib/ringi.ts
+++ b/src/lib/ringi.ts
@@ -352,9 +352,9 @@ export async function getRingisByUser(
   limitCount: number = 50
 ): Promise<Ringi[]> {
   const firestore = getDb();
-  // シンプルなクエリ（インデックス不要）
   const q = query(
     collection(firestore, 'ringis'),
+    where('tenantId', '==', tenantId),
     where('authorId', '==', userId),
     limit(limitCount)
   );
@@ -387,9 +387,9 @@ export async function getPendingRingis(
 ): Promise<Ringi[]> {
   const firestore = getDb();
 
-  // シンプルなクエリ（インデックス不要）
   const q = query(
     collection(firestore, 'ringis'),
+    where('tenantId', '==', tenantId),
     where('status', '==', 'submitted'),
     limit(limitCount)
   );
@@ -430,9 +430,9 @@ export async function getAllRingis(
 ): Promise<Ringi[]> {
   const firestore = getDb();
 
-  // シンプルなクエリ（インデックス不要）
   const q = query(
     collection(firestore, 'ringis'),
+    where('tenantId', '==', tenantId),
     limit(limitCount * 2) // フィルタ後も十分な件数が残るように
   );
 


### PR DESCRIPTION
- ringi.ts: getRingisByUser/getPendingRingis/getAllRingis に where('tenantId','==',tenantId) を追加（マルチテナント分離違反を修正）
- attendance/page.tsx: clockIn の employeeCode を user.email → user.name || user.email に変更
- firestore.indexes.json: ringis(tenantId,authorId,createdAt) composite index 追加
- 自己チェックレポート更新

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
