### PR TITLE
fix: LAUNCH_MODE デフォルト true + STORAGE_DRIVER 自動検出

### DIFF
--- a/src/config/launchMode.ts
+++ b/src/config/launchMode.ts
@@ -3,10 +3,11 @@
  *
  * 先行カットオーバー用：4機能のみ公開（入居希望／空室／打刻／承認）
  *
- * NEXT_PUBLIC_LAUNCH_MODE=true で有効化
+ * デフォルト: true（本番カットオーバー状態）
+ * 全機能を開放する場合: NEXT_PUBLIC_LAUNCH_MODE=false を設定
  */
 
-export const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE === 'true';
+export const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE !== 'false';
 
 /**
  * Launch Mode が有効かどうかを判定

--- a/src/config/storage.ts
+++ b/src/config/storage.ts
@@ -12,13 +12,21 @@ export type StorageDriver = 'memory' | 'firestore';
 
 /**
  * 現在のストレージドライバーを取得
+ *
+ * 優先順位:
+ * 1. STORAGE_DRIVER 環境変数が明示的に設定されている場合はそれを使用
+ * 2. Firebase Project ID が設定されている場合は 'firestore' を自動選択
+ * 3. どちらもない場合は 'memory' フォールバック（開発用）
  */
 export function getStorageDriver(): StorageDriver {
-  const driver = process.env.STORAGE_DRIVER || 'memory';
+  const driver = process.env.STORAGE_DRIVER;
 
-  if (driver === 'firestore') {
-    return 'firestore';
-  }
+  // 明示的に設定されている場合はそれを尊重
+  if (driver === 'firestore') return 'firestore';
+  if (driver === 'memory') return 'memory';
+
+  // 未設定の場合: Firebase が使えるなら firestore を自動選択
+  if (canUseFirestore()) return 'firestore';
 
   return 'memory';
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,8 @@ import { isRouteEnabledByGate } from '@/config/featureGate';
 
 // ======== Launch Mode ========
 
-const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE === 'true';
+// デフォルト true（本番カットオーバー状態）。全機能開放は NEXT_PUBLIC_LAUNCH_MODE=false
+const LAUNCH_MODE = process.env.NEXT_PUBLIC_LAUNCH_MODE !== 'false';
 
 // ======== セキュリティヘッダー ========
 


### PR DESCRIPTION
根本原因:
- NEXT_PUBLIC_LAUNCH_MODE 環境変数が未設定 → false → 旧デザイン表示
- STORAGE_DRIVER 環境変数が未設定 → memory → データ揮発

修正:
- launchMode.ts: デフォルトを true に変更（!== 'false' で判定）
- middleware.ts: 同上（LAUNCH_MODE 判定を一致させる）
- storage.ts: Firebase Project ID があれば自動的に firestore を選択

これにより環境変数未設定でも本番カットオーバー状態で動作する

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
