### PR TITLE
fix: 承認ページでテナント全体の稟議を表示（カウント不一致修正）

### DIFF
--- a/src/app/dashboard/approvals/page.tsx
+++ b/src/app/dashboard/approvals/page.tsx
@@ -21,7 +21,7 @@ import {
   ClipboardList,
   ChevronDown,
 } from 'lucide-react';
-import { getRingisByUser } from '@/lib/ringi';
+import { getAllRingis } from '@/lib/ringi';
 import { Ringi, RingiStatus, RINGI_STATUS_LABELS, RINGI_STATUS_COLORS } from '@/types';
 import {
   ApplicationType,
@@ -77,7 +77,7 @@ export default function ApprovalsListPage() {
 
         // Fetch all three types in parallel
         const [ringisData, applicationsRes] = await Promise.all([
-          getRingisByUser(user.id, user.tenantId),
+          getAllRingis(user.tenantId),
           fetch('/api/applications?mine=1', {
             headers: { Authorization: `Bearer ${token}` },
           }),


### PR DESCRIPTION
問題: ダッシュボード「承認待ち 4」vs 承認ページ「申請中 3」の不一致
原因: 承認ページが getRingisByUser（自分の稟議のみ）を使用していた
修正: getAllRingis（テナント全体）に変更し、全ユーザーの稟議を表示

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
