### PR TITLE
fix: add ringi attachment path to Firebase Storage rules

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -12,5 +12,16 @@ service firebase.storage {
         && request.resource.size < 5 * 1024 * 1024 // 5MB制限
         && request.resource.contentType.matches('image/.*'); // 画像のみ
     }
+
+    // 稟議添付ファイル
+    match /ringi/{tenantId}/{userId}/{allPaths=**} {
+      // 認証済みユーザーは読み取り可能
+      allow read: if request.auth != null;
+
+      // 認証済みユーザーは自分のフォルダにのみアップロード可能
+      allow write: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.size < 10 * 1024 * 1024; // 10MB制限
+    }
   }
 }


### PR DESCRIPTION
Storage rules only allowed incidents/ path (images only, 5MB). Added ringi/{tenantId}/{userId}/ path allowing any file type up to 10MB for authenticated users uploading to their own folder.

User must deploy: firebase deploy --only storage --project hiyari-7f082

https://claude.ai/code/session_01B1KVxZqcY6ZSKhsC1qScqE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
