### PR TITLE
fix: /admin/module-permissionsをLaunch Mode許可ルートに追加

### DIFF
--- a/src/config/featureGate.ts
+++ b/src/config/featureGate.ts
@@ -171,6 +171,8 @@ export function isRouteEnabledByGate(pathname: string): boolean {
     '/api/users', '/api/notifications', '/api/business-units',
     '/api/tickets', '/api/admin/bootstrap', '/api/dashboard',
     '/dashboard/notifications',
+    '/admin/module-permissions', '/api/admin/module-permissions',
+    '/dashboard/admin',
   ];
   for (const prefix of commonPrefixes) {
     if (pathname === prefix || pathname.startsWith(prefix + '/') || pathname.startsWith(prefix + '?')) {


### PR DESCRIPTION
featureGateのcommonPrefixesに追加し、Launch Mode時にcoming-soonに リダイレクトされないようにする。

https://claude.ai/code/session_018e1f7hAvu9CGHJ43zWfZDa

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
