### PR TITLE
feat: 空室管理のモジュール別権限を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,6 +28,15 @@ service cloud.firestore {
             && userData.modulePermissions.prospects.canEdit == true);
     }
 
+    // 空室管理の編集権限チェック（ロールまたはモジュール個別権限）
+    function canEditVacancies() {
+      let userData = get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+      return userData.role in ['leader', 'admin', 'system_admin']
+        || (userData.keys().hasAny(['modulePermissions'])
+            && userData.modulePermissions.keys().hasAny(['vacancies'])
+            && userData.modulePermissions.vacancies.canEdit == true);
+    }
+
     // AI副社長オーナー判定（吉田専用）
     function isAiVpOwner() {
       return request.auth.token.email == 'yoshida@aska-g.com';
@@ -99,9 +108,9 @@ service cloud.firestore {
     match /vacancyStatus/{facilityId} {
       // 認証済みユーザーは読み取り可能
       allow read: if isAuthenticated();
-      // リーダー以上のみ書き込み可能（updatedByは自分のuidであること）
+      // リーダー以上、またはmodulePermissions.vacancies.canEdit権限者が書き込み可能
       allow write: if isAuthenticated()
-        && getUserRole() in ['leader', 'admin', 'system_admin']
+        && canEditVacancies()
         && request.resource.data.updatedBy == request.auth.uid;
     }
 
@@ -109,10 +118,10 @@ service cloud.firestore {
     match /vacancyEvents/{eventId} {
       // 認証済みユーザーは読み取り可能
       allow read: if isAuthenticated();
-      // リーダー以上のみ作成可能（changedByは自分のuidであること）
+      // リーダー以上、またはmodulePermissions.vacancies.canEdit権限者が作成可能
       // 更新・削除は不可
       allow create: if isAuthenticated()
-        && getUserRole() in ['leader', 'admin', 'system_admin']
+        && canEditVacancies()
         && request.resource.data.changedBy == request.auth.uid;
       allow update, delete: if false;
     }

--- a/scripts/grant-module-permission.ts
+++ b/scripts/grant-module-permission.ts
@@ -18,6 +18,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 const TARGET_EMAIL = 'ikuta@aska-g.com';
 const MODULE_PERMISSIONS = {
   prospects: { canEdit: true },
+  vacancies: { canEdit: true },
 };
 // ========================================
 

--- a/src/app/admin/module-permissions/page.tsx
+++ b/src/app/admin/module-permissions/page.tsx
@@ -21,6 +21,7 @@ function ModulePermissionsContent() {
   const { user, firebaseUser } = useAuth();
   const [email, setEmail] = useState('');
   const [prospectsCanEdit, setProspectsCanEdit] = useState(true);
+  const [vacanciesCanEdit, setVacanciesCanEdit] = useState(false);
   const [saving, setSaving] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
 
@@ -43,7 +44,8 @@ function ModulePermissionsContent() {
         body: JSON.stringify({
           email,
           modulePermissions: {
-            prospects: { canEdit: prospectsCanEdit },
+            ...(prospectsCanEdit ? { prospects: { canEdit: true } } : {}),
+            ...(vacanciesCanEdit ? { vacancies: { canEdit: true } } : {}),
           },
         }),
       });
@@ -127,6 +129,15 @@ function ModulePermissionsContent() {
                       className="rounded border-zinc-300"
                     />
                     <span className="text-sm">入居希望者の編集権限</span>
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={vacanciesCanEdit}
+                      onChange={(e) => setVacanciesCanEdit(e.target.checked)}
+                      className="rounded border-zinc-300"
+                    />
+                    <span className="text-sm">空室管理の編集権限</span>
                   </label>
                 </div>
               </div>

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button, Card, Badge } from '@/components/ui';
 import { Loading } from '@/components/Loading';
-import { hasMinRole } from '@/lib/auth';
+import { hasMinRole, canEditVacancies } from '@/lib/auth';
 import {
   Building2,
   RefreshCw,
@@ -741,7 +741,7 @@ export default function VacancyPage() {
   const AUTO_REFRESH_INTERVAL = 60000;
 
   const isAdmin = hasMinRole(user?.role, 'admin');
-  const isLeader = hasMinRole(user?.role, 'leader');
+  const isLeader = hasMinRole(user?.role, 'leader') || canEditVacancies(user?.role, user?.modulePermissions);
 
   // 施設ごとのサマリーを計算
   // rooms が十分にある（インポート済み）場合は部屋単位で集計

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -97,6 +97,19 @@ export function canEditProspects(
   return modulePermissions?.prospects?.canEdit === true;
 }
 
+/**
+ * 空室管理の編集権限があるかチェック
+ * - leader以上のロールは常に編集可能
+ * - modulePermissions.vacancies.canEdit が true のユーザーも編集可能
+ */
+export function canEditVacancies(
+  userRole: UserRole | undefined,
+  modulePermissions?: ModulePermissions
+): boolean {
+  if (hasMinRole(userRole, 'leader')) return true;
+  return modulePermissions?.vacancies?.canEdit === true;
+}
+
 // ======== CHAOS 経営OS 権限 ========
 
 /**

--- a/src/lib/vacancyUnits/types.ts
+++ b/src/lib/vacancyUnits/types.ts
@@ -196,6 +196,7 @@ export const CARE_LEVEL_LABELS: Record<number, string> = {
 export interface ViewerContext {
   userId: string;
   role: AppRole;
+  modulePermissions?: { vacancies?: { canEdit?: boolean } };
 }
 
 /**
@@ -208,9 +209,11 @@ export function canViewVacancyUnits(viewer: ViewerContext): boolean {
 /**
  * 空室ユニットを編集できるか
  * Ticket 075: leader も編集可に
+ * modulePermissions.vacancies.canEdit でも編集可
  */
 export function canEditVacancyUnits(viewer: ViewerContext): boolean {
-  return ['leader', 'manager', 'executive', 'admin'].includes(viewer.role);
+  if (['leader', 'manager', 'executive', 'admin'].includes(viewer.role)) return true;
+  return viewer.modulePermissions?.vacancies?.canEdit === true;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,7 @@ export interface ScoreBreakdownItem {
 // モジュール別権限オーバーライド
 export interface ModulePermissions {
   prospects?: { canEdit?: boolean };  // 入居希望者
+  vacancies?: { canEdit?: boolean };  // 空室管理
 }
 
 // ユーザー


### PR DESCRIPTION
入居希望者と同様に、空室管理にもmodulePermissionsによる
個別権限付与を対応。

- ModulePermissions型にvacancies.canEditを追加
- canEditVacancies()ヘルパー関数追加
- ViewerContext/canEditVacancyUnits()をmodulePermissions対応
- ダッシュボードのisLeaderチェックを拡張
- Firestoreルール: vacancyStatus/vacancyEventsにcanEditVacancies()追加
- 管理UI: 空室管理チェックボックス追加

https://claude.ai/code/session_018e1f7hAvu9CGHJ43zWfZDa

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
