### PR TITLE
feat: 全12機能のナビゲーション接続 - 通知設定/センター/リアルタイム勤怠/空室問合せ/監査ログ/修繕チケット/苦情/是正/チケ…

### DIFF
--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -25,6 +25,9 @@ import {
   ExternalLink,
   Clock,
   BarChart3,
+  Wrench,
+  BookOpen,
+  Ticket,
 } from 'lucide-react';
 
 // 管理メニュー項目
@@ -108,6 +111,60 @@ const ADMIN_MENU_ITEMS = [
     icon: BarChart3,
     label: 'インサイト',
     description: 'データ分析・レポート',
+  },
+  {
+    href: '/admin/attendance/realtime',
+    icon: Activity,
+    label: 'リアルタイム勤怠',
+    description: '全スタッフのリアルタイム出勤状況',
+  },
+  {
+    href: '/dashboard/audit',
+    icon: FileText,
+    label: '監査ログ',
+    description: 'システム操作の監査証跡',
+  },
+  {
+    href: '/dashboard/repair-tickets',
+    icon: Wrench,
+    label: '修繕チケット',
+    description: '設備故障・修理依頼の管理',
+  },
+  {
+    href: '/dashboard/complaints',
+    icon: AlertTriangle,
+    label: '苦情管理',
+    description: '苦情・クレームの追跡管理',
+  },
+  {
+    href: '/dashboard/corrective-actions',
+    icon: CheckCircle,
+    label: '是正措置',
+    description: '是正・予防措置の管理',
+  },
+  {
+    href: '/dashboard/tickets',
+    icon: Ticket,
+    label: 'チケット管理',
+    description: '業務チケットの管理',
+  },
+  {
+    href: '/dashboard/training',
+    icon: BookOpen,
+    label: '研修管理',
+    description: '研修・教育プログラムの管理',
+  },
+  {
+    href: '/dashboard/business-summary',
+    icon: TrendingUp,
+    label: '業務サマリー',
+    description: '業務KPI・トレンド分析',
+  },
+  {
+    href: '/dashboard/quality-risk',
+    icon: Shield,
+    label: '品質・リスク',
+    description: '品質指標・リスクダッシュボード',
   },
 ];
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,6 +18,8 @@ import {
   HelpCircle,
   ArrowRight,
   Eye,
+  BarChart3,
+  AlertTriangle,
 } from 'lucide-react';
 
 /**
@@ -287,6 +289,20 @@ function DashboardContent() {
           <Link href="/dashboard/knowledge" className="hover:text-zinc-600">
             知識ハブ
           </Link>
+          {(navKey === 'exec' || navKey === 'manager') && (
+            <>
+              <span>・</span>
+              <Link href="/dashboard/business-summary" className="hover:text-zinc-600 flex items-center gap-1">
+                <BarChart3 className="w-3 h-3" />
+                業務サマリー
+              </Link>
+              <span>・</span>
+              <Link href="/dashboard/quality-risk" className="hover:text-zinc-600 flex items-center gap-1">
+                <AlertTriangle className="w-3 h-3" />
+                品質・リスク
+              </Link>
+            </>
+          )}
           {navKey === 'exec' && (
             <>
               <span>・</span>

--- a/src/app/dashboard/repair-tickets/page.tsx
+++ b/src/app/dashboard/repair-tickets/page.tsx
@@ -1,11 +1,405 @@
-import { PlannedFeaturePlaceholder } from '@/components/PlannedFeaturePlaceholder';
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Wrench,
+  Plus,
+  AlertTriangle,
+  Clock,
+  CheckCircle,
+  RefreshCw,
+  Filter,
+  MapPin,
+  X,
+} from 'lucide-react';
+import type {
+  RepairRecord,
+  RepairStatus,
+  RepairCategory,
+  SafetyRisk,
+  RepairStats,
+} from '@/lib/repairs/types';
+import {
+  REPAIR_STATUS_CONFIG,
+  SAFETY_RISK_CONFIG,
+  REPAIR_CATEGORY_CONFIG,
+} from '@/lib/repairs/types';
+
+type TabType = 'all' | 'high_risk' | 'active' | 'overdue' | 'completed';
+
+const TABS: { id: TabType; label: string; icon: React.ReactNode }[] = [
+  { id: 'all', label: 'すべて', icon: <Wrench className="w-4 h-4" /> },
+  { id: 'high_risk', label: '高リスク', icon: <AlertTriangle className="w-4 h-4" /> },
+  { id: 'active', label: '対応中', icon: <RefreshCw className="w-4 h-4" /> },
+  { id: 'overdue', label: '期限超過', icon: <Clock className="w-4 h-4" /> },
+  { id: 'completed', label: '完了', icon: <CheckCircle className="w-4 h-4" /> },
+];
 
 export default function RepairTicketsPage() {
+  const [activeTab, setActiveTab] = useState<TabType>('all');
+  const [repairs, setRepairs] = useState<RepairRecord[]>([]);
+  const [stats, setStats] = useState<RepairStats | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [showNewModal, setShowNewModal] = useState(false);
+
+  // フィルタ
+  const [statusFilter, setStatusFilter] = useState<RepairStatus | ''>('');
+  const [categoryFilter, setCategoryFilter] = useState<RepairCategory | ''>('');
+  const [showFilters, setShowFilters] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // 統計取得
+      const statsRes = await fetch('/api/repairs/stats');
+      if (statsRes.ok) {
+        const statsData = await statsRes.json();
+        setStats(statsData);
+      }
+
+      // 一覧取得
+      const params = new URLSearchParams();
+
+      switch (activeTab) {
+        case 'high_risk':
+          params.append('safetyRisk', 'high');
+          break;
+        case 'active':
+          // reported, assessing, scheduled, in_progress
+          break;
+        case 'overdue':
+          params.append('overdue', 'true');
+          break;
+        case 'completed':
+          params.append('status', 'completed');
+          break;
+      }
+
+      if (statusFilter) params.append('status', statusFilter);
+      if (categoryFilter) params.append('category', categoryFilter);
+
+      const repairsRes = await fetch(`/api/repairs?${params.toString()}`);
+      if (repairsRes.ok) {
+        const repairsData = await repairsRes.json();
+        setRepairs(repairsData.repairs || []);
+        setTotalCount(repairsData.total || 0);
+      }
+    } catch (error) {
+      console.error('データ取得エラー:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [activeTab, statusFilter, categoryFilter]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // 新規作成
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+
+    try {
+      const res = await fetch('/api/repairs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: formData.get('title'),
+          description: formData.get('description'),
+          category: formData.get('category') || undefined,
+          safetyRisk: formData.get('safetyRisk') || undefined,
+          location: formData.get('location') || undefined,
+        }),
+      });
+
+      if (res.ok) {
+        setShowNewModal(false);
+        fetchData();
+      }
+    } catch (error) {
+      console.error('作成エラー:', error);
+    }
+  }
+
+  // タブに応じたフィルタリング
+  const filteredRepairs = repairs.filter((r) => {
+    if (activeTab === 'active') {
+      return ['reported', 'assessing', 'scheduled', 'in_progress'].includes(r.status);
+    }
+    return true;
+  });
+
   return (
-    <PlannedFeaturePlaceholder
-      title="修繕チケット"
-      description="修繕依頼の管理。設備故障、修理依頼の進捗を追跡します。"
-      category="業務管理"
-    />
+    <main className="max-w-5xl mx-auto px-4 py-6 safe-bottom">
+      {/* ヘッダー */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2 text-zinc-900">
+            <Wrench className="w-6 h-6" />
+            修繕チケット
+          </h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            設備故障・修理依頼の進捗を追跡します
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowFilters(!showFilters)}
+            className="flex items-center gap-2 px-3 py-2 text-sm border rounded-lg hover:bg-zinc-50 transition-colors"
+          >
+            <Filter className="w-4 h-4" />
+            フィルタ
+          </button>
+          <button
+            onClick={() => setShowNewModal(true)}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-zinc-900 rounded-lg hover:bg-zinc-800 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            新規修繕依頼
+          </button>
+        </div>
+      </div>
+
+      {/* 統計カード */}
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+          <div className="bg-white border border-zinc-200 rounded-xl p-4">
+            <div className="text-sm text-zinc-500">オープン</div>
+            <div className="text-2xl font-bold text-blue-600 tabular-nums">{stats.open}</div>
+          </div>
+          <div className="bg-white border border-zinc-200 rounded-xl p-4">
+            <div className="text-sm text-zinc-500">高リスク</div>
+            <div className="text-2xl font-bold text-red-600 tabular-nums">{stats.highRiskOpen}</div>
+          </div>
+          <div className="bg-white border border-zinc-200 rounded-xl p-4">
+            <div className="text-sm text-zinc-500">期限超過</div>
+            <div className="text-2xl font-bold text-amber-600 tabular-nums">{stats.overdue}</div>
+          </div>
+          <div className="bg-white border border-zinc-200 rounded-xl p-4">
+            <div className="text-sm text-zinc-500">今月完了</div>
+            <div className="text-2xl font-bold text-green-600 tabular-nums">{stats.completedThisMonth}</div>
+          </div>
+        </div>
+      )}
+
+      {/* フィルタ */}
+      {showFilters && (
+        <div className="bg-zinc-50 border border-zinc-200 rounded-xl p-4 mb-4 flex flex-wrap gap-3">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as RepairStatus | '')}
+            className="border rounded-lg px-3 py-2 text-sm bg-white"
+          >
+            <option value="">ステータス: すべて</option>
+            {Object.entries(REPAIR_STATUS_CONFIG).map(([key, cfg]) => (
+              <option key={key} value={key}>{cfg.label}</option>
+            ))}
+          </select>
+          <select
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value as RepairCategory | '')}
+            className="border rounded-lg px-3 py-2 text-sm bg-white"
+          >
+            <option value="">カテゴリ: すべて</option>
+            {Object.entries(REPAIR_CATEGORY_CONFIG).map(([key, cfg]) => (
+              <option key={key} value={key}>{cfg.icon} {cfg.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* タブ */}
+      <div className="flex gap-1 mb-4 overflow-x-auto pb-1">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+              activeTab === tab.id
+                ? 'bg-zinc-900 text-white'
+                : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
+            }`}
+          >
+            {tab.icon}
+            {tab.label}
+            {tab.id === 'high_risk' && stats?.highRiskOpen ? (
+              <span className="ml-1 px-1.5 py-0.5 text-[10px] font-bold bg-red-500 text-white rounded-full">
+                {stats.highRiskOpen}
+              </span>
+            ) : null}
+            {tab.id === 'overdue' && stats?.overdue ? (
+              <span className="ml-1 px-1.5 py-0.5 text-[10px] font-bold bg-amber-500 text-white rounded-full">
+                {stats.overdue}
+              </span>
+            ) : null}
+          </button>
+        ))}
+      </div>
+
+      {/* 一覧 */}
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <div className="flex flex-col items-center gap-3">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zinc-900" />
+            <p className="text-sm text-zinc-500">読み込み中...</p>
+          </div>
+        </div>
+      ) : filteredRepairs.length === 0 ? (
+        <div className="text-center py-16 text-zinc-400">
+          <Wrench className="w-12 h-12 mx-auto mb-3 opacity-30" />
+          <p>修繕チケットはありません</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filteredRepairs.map((repair) => {
+            const statusCfg = REPAIR_STATUS_CONFIG[repair.status];
+            const riskCfg = SAFETY_RISK_CONFIG[repair.safetyRisk];
+            const catCfg = REPAIR_CATEGORY_CONFIG[repair.category];
+
+            return (
+              <div
+                key={repair.id}
+                className="bg-white border border-zinc-200 rounded-xl p-4 hover:border-zinc-300 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${statusCfg.bg} ${statusCfg.color}`}>
+                        {statusCfg.label}
+                      </span>
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${riskCfg.bg} ${riskCfg.color}`}>
+                        {riskCfg.label}
+                      </span>
+                      {catCfg && (
+                        <span className="text-xs text-zinc-500">
+                          {catCfg.icon} {catCfg.label}
+                        </span>
+                      )}
+                    </div>
+                    <h3 className="font-medium text-zinc-900">{repair.title}</h3>
+                    <p className="text-sm text-zinc-500 mt-1 line-clamp-2">{repair.description}</p>
+                    <div className="flex items-center gap-4 mt-2 text-xs text-zinc-400">
+                      {repair.location && (
+                        <span className="flex items-center gap-1">
+                          <MapPin className="w-3 h-3" />
+                          {repair.location}
+                        </span>
+                      )}
+                      <span className="flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {new Date(repair.createdAt).toLocaleDateString('ja-JP')}
+                      </span>
+                      {repair.dueAt && (
+                        <span className={`flex items-center gap-1 ${
+                          new Date(repair.dueAt) < new Date() && repair.status !== 'completed'
+                            ? 'text-red-500 font-medium'
+                            : ''
+                        }`}>
+                          期限: {new Date(repair.dueAt).toLocaleDateString('ja-JP')}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 件数表示 */}
+      {!loading && (
+        <div className="mt-4 text-center text-sm text-zinc-400">
+          {totalCount}件中 {filteredRepairs.length}件を表示
+        </div>
+      )}
+
+      {/* 新規作成モーダル */}
+      {showNewModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between p-4 border-b">
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                <Plus className="w-5 h-5" />
+                新規修繕依頼
+              </h2>
+              <button onClick={() => setShowNewModal(false)} className="p-2 hover:bg-zinc-100 rounded-lg">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <form onSubmit={handleCreate} className="p-4 space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">
+                  タイトル <span className="text-red-500">*</span>
+                </label>
+                <input
+                  name="title"
+                  required
+                  placeholder="例: 2F廊下の照明が点灯しない"
+                  className="w-full border rounded-lg px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">
+                  詳細 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  name="description"
+                  required
+                  placeholder="状況を詳しく記載..."
+                  className="w-full border rounded-lg px-3 py-2 text-sm h-24 resize-none"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 mb-1">カテゴリ</label>
+                  <select name="category" className="w-full border rounded-lg px-3 py-2 text-sm">
+                    <option value="">選択...</option>
+                    {Object.entries(REPAIR_CATEGORY_CONFIG).map(([key, cfg]) => (
+                      <option key={key} value={key}>{cfg.icon} {cfg.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-zinc-700 mb-1">安全リスク</label>
+                  <select name="safetyRisk" className="w-full border rounded-lg px-3 py-2 text-sm">
+                    <option value="">選択...</option>
+                    {Object.entries(SAFETY_RISK_CONFIG).map(([key, cfg]) => (
+                      <option key={key} value={key}>{cfg.label}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 mb-1">場所</label>
+                <input
+                  name="location"
+                  placeholder="例: 2F廊下"
+                  className="w-full border rounded-lg px-3 py-2 text-sm"
+                />
+              </div>
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowNewModal(false)}
+                  className="flex-1 px-4 py-2 text-sm border rounded-lg hover:bg-zinc-50"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="submit"
+                  className="flex-1 px-4 py-2 text-sm font-medium text-white bg-zinc-900 rounded-lg hover:bg-zinc-800"
+                >
+                  作成
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </main>
   );
 }

--- a/src/app/dashboard/vacancy/page.tsx
+++ b/src/app/dashboard/vacancy/page.tsx
@@ -993,6 +993,17 @@ export default function VacancyPage() {
               )}
             </div>
             <div className="flex items-center gap-2 flex-wrap">
+              {isLeader && (
+                <Link href="/dashboard/vacancy-inquiries">
+                  <Button
+                    variant="secondary"
+                    className="flex items-center gap-2"
+                  >
+                    <Users className="w-4 h-4" />
+                    問合せ管理
+                  </Button>
+                </Link>
+              )}
               {isAdmin && (
                 <Button
                   variant="secondary"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -212,6 +212,15 @@ export function Header() {
             {/* Role Switcher (Admin only) */}
             <RoleSwitcher />
 
+            {/* Notification Settings (gear icon) */}
+            <Link
+              href="/dashboard/notification-settings"
+              className="p-2 rounded-xl hover:bg-zinc-100 transition-colors"
+              aria-label="通知設定"
+            >
+              <Settings className="w-5 h-5 text-zinc-600" />
+            </Link>
+
             {/* Notification Bell */}
             <NotificationBell />
 

--- a/src/components/navigation/MobileBottomNav.tsx
+++ b/src/components/navigation/MobileBottomNav.tsx
@@ -28,6 +28,11 @@ import {
   LogOut,
   Sparkles,
   FolderOpen,
+  Wrench,
+  AlertTriangle,
+  BookOpen,
+  Ticket,
+  CheckCircle2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { isAiVpOwner } from '@/lib/auth';
@@ -241,6 +246,7 @@ export function MobileBottomNav() {
     { href: '/rankings', label: 'ランク', icon: Trophy },
     { href: '/dashboard/docs', label: 'ドキュメント', icon: FolderOpen },
     { href: '/dashboard/os', label: '経営OS', icon: Activity },
+    { href: '/dashboard/tickets', label: 'チケット', icon: Ticket },
   ];
 
   // featureGate でフィルタ
@@ -258,6 +264,10 @@ export function MobileBottomNav() {
         { href: '/admin/users', label: '権限管理', icon: Shield },
         { href: '/admin/employees', label: '従業員', icon: Users },
         { href: '/admin/settings', label: '設定', icon: Settings },
+        { href: '/dashboard/repair-tickets', label: '修繕', icon: Wrench },
+        { href: '/dashboard/complaints', label: '苦情管理', icon: AlertTriangle },
+        { href: '/dashboard/corrective-actions', label: '是正措置', icon: CheckCircle2 },
+        { href: '/dashboard/training', label: '研修管理', icon: BookOpen },
       ]
     : [];
 

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Bell, X, Check, Clock, FileText, AlertTriangle, Calendar, MessageSquare, ClipboardCheck, RotateCcw, Brain, Heart, Flame, Banknote } from 'lucide-react';
+import { Bell, X, Check, Clock, FileText, AlertTriangle, Calendar, MessageSquare, ClipboardCheck, RotateCcw, Brain, Heart, Flame, Banknote, ChevronRight } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Notification, NotificationType } from '@/types/notification';
 import {
@@ -209,6 +210,18 @@ export function NotificationBell() {
                 })}
               </ul>
             )}
+          </div>
+
+          {/* フッター - 通知センターリンク */}
+          <div className="border-t border-zinc-100 px-4 py-3">
+            <Link
+              href="/dashboard/notifications"
+              className="text-sm text-blue-600 hover:text-blue-700 font-medium flex items-center justify-center gap-1"
+              onClick={() => setIsOpen(false)}
+            >
+              通知センターを見る
+              <ChevronRight className="w-4 h-4" />
+            </Link>
           </div>
         </div>
       )}


### PR DESCRIPTION
…ット/研修/業務サマリー/品質リスク

すぐ出せる（リンク追加）:
1. 通知設定 - ヘッダー歯車アイコン追加
2. 通知センター - ベルドロップダウンに「通知センターを見る」リンク追加
3. リアルタイム勤怠 - 管理画面メニューに追加
4. 空室問合せ管理 - 空室管理ヘッダーに「問合せ管理」ボタン追加
5. 監査ログ - 管理画面メニューに追加

業務に直結（管理メニュー追加）:
6. 修繕チケット - プレースホルダーを実装に置換（タブ/統計/フィルタ/新規作成）
7. 苦情管理 - 管理メニュー・モバイルナビ追加
8. 是正措置 - 管理メニュー・モバイルナビ追加
9. チケット管理 - モバイル「その他」メニュー追加（全員向け）
10. 研修管理 - 管理メニュー・モバイルナビ追加

経営層向け（ダッシュボード追加）:
11. 業務サマリー - ダッシュボードフッターに追加（manager/exec向け）
12. 品質・リスク - ダッシュボードフッターに追加（manager/exec向け）

https://claude.ai/code/session_018e1f7hAvu9CGHJ43zWfZDa

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
