### PR TITLE
fix: オンボーディングページのAPI呼び出しに認証トークンを付与

### DIFF
--- a/src/app/onboarding/contracts/page.tsx
+++ b/src/app/onboarding/contracts/page.tsx
@@ -8,25 +8,23 @@
  * 必須文書の一覧と署名状況を表示
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import {
   REQUIRED_ITEM_STATUS_CONFIG,
   type UserOnboarding,
 } from '@/lib/onboarding/types';
+import { useApiFetch } from '@/hooks/useApiFetch';
 
 export default function OnboardingContractsPage() {
+  const apiFetch = useApiFetch();
   const [onboarding, setOnboarding] = useState<UserOnboarding | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchOnboarding();
-  }, []);
-
-  const fetchOnboarding = async () => {
+  const fetchOnboarding = useCallback(async () => {
     try {
-      const res = await fetch('/api/onboarding/status');
+      const res = await apiFetch('/api/onboarding/status');
       if (!res.ok) {
         throw new Error('オンボーディング情報の取得に失敗しました');
       }
@@ -37,7 +35,11 @@ export default function OnboardingContractsPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiFetch]);
+
+  useEffect(() => {
+    fetchOnboarding();
+  }, [fetchOnboarding]);
 
   if (loading) {
     return (

--- a/src/app/onboarding/contracts/sign/[documentVersionId]/page.tsx
+++ b/src/app/onboarding/contracts/sign/[documentVersionId]/page.tsx
@@ -9,10 +9,11 @@
  * 署名確認と実行、改訂時は差分を表示
  */
 
-import { useState, useEffect, use } from 'react';
+import { useState, useEffect, useCallback, use } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { UserRequiredItem } from '@/lib/onboarding/types';
+import { useApiFetch } from '@/hooks/useApiFetch';
 
 interface PageProps {
   params: Promise<{ documentVersionId: string }>;
@@ -47,6 +48,7 @@ interface DiffData {
 export default function SignDocumentPage({ params }: PageProps) {
   const { documentVersionId } = use(params);
   const router = useRouter();
+  const apiFetch = useApiFetch();
 
   const [document, setDocument] = useState<UserRequiredItem | null>(null);
   const [diffData, setDiffData] = useState<DiffData | null>(null);
@@ -64,14 +66,9 @@ export default function SignDocumentPage({ params }: PageProps) {
     diffReviewed: false, // 差分確認済みチェック
   });
 
-  useEffect(() => {
-    fetchDocument();
-    fetchDiff();
-  }, [documentVersionId]);
-
-  const fetchDocument = async () => {
+  const fetchDocument = useCallback(async () => {
     try {
-      const res = await fetch('/api/onboarding/status');
+      const res = await apiFetch('/api/onboarding/status');
       if (!res.ok) {
         throw new Error('オンボーディング情報の取得に失敗しました');
       }
@@ -92,11 +89,11 @@ export default function SignDocumentPage({ params }: PageProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiFetch, documentVersionId, router]);
 
-  const fetchDiff = async () => {
+  const fetchDiff = useCallback(async () => {
     try {
-      const res = await fetch(`/api/onboarding/diff?documentVersionId=${documentVersionId}`);
+      const res = await apiFetch(`/api/onboarding/diff?documentVersionId=${documentVersionId}`);
       if (res.ok) {
         const data = await res.json();
         setDiffData(data);
@@ -104,7 +101,12 @@ export default function SignDocumentPage({ params }: PageProps) {
     } catch (err) {
       console.error('差分の取得に失敗:', err);
     }
-  };
+  }, [apiFetch, documentVersionId]);
+
+  useEffect(() => {
+    fetchDocument();
+    fetchDiff();
+  }, [fetchDocument, fetchDiff]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -129,9 +131,8 @@ export default function SignDocumentPage({ params }: PageProps) {
     setError(null);
 
     try {
-      const res = await fetch('/api/onboarding/sign', {
+      const res = await apiFetch('/api/onboarding/sign', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           documentId: document?.documentId,
           documentVersionId,


### PR DESCRIPTION
オンボーディング契約ページと署名ページで /api/onboarding/* への
fetch() に Authorization ヘッダーが付いておらず、APIが401を返して
「オンボーディング情報の取得に失敗しました」エラーが発生していた。

素の fetch() を useApiFetch() フックに置き換えて、Firebase IDトークン が自動的に付与されるようにした。

https://claude.ai/code/session_018e1f7hAvu9CGHJ43zWfZDa

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
