### PR TITLE
fix: 契約署名完了後にダッシュボードに進めない問題を修正

### DIFF
--- a/src/app/onboarding/contracts/page.tsx
+++ b/src/app/onboarding/contracts/page.tsx
@@ -15,6 +15,7 @@ import {
   type UserOnboarding,
 } from '@/lib/onboarding/types';
 import { useApiFetch } from '@/hooks/useApiFetch';
+import { LAUNCH_MODE } from '@/config/launchMode';
 
 export default function OnboardingContractsPage() {
   const apiFetch = useApiFetch();
@@ -62,22 +63,46 @@ export default function OnboardingContractsPage() {
 
   // 完了済みの場合
   if (onboarding?.status === 'completed') {
+    const dashboardHref = LAUNCH_MODE ? '/launch' : '/dashboard';
     return (
       <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
-        <div className="bg-white rounded-lg shadow-sm p-8 max-w-md text-center">
+        <div className="bg-white rounded-lg shadow-sm p-8 max-w-lg text-center">
           <div className="text-4xl mb-4">✅</div>
-          <h1 className="text-xl font-semibold text-green-700 mb-4">
+          <h1 className="text-xl font-semibold text-green-700 mb-2">
             契約署名完了
           </h1>
           <p className="text-zinc-600 mb-6">
-            すべての必須文書への署名が完了しました。
+            すべての必須文書への署名が完了しました。業務を開始できます。
           </p>
           <Link
-            href="/dashboard"
+            href={dashboardHref}
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700"
           >
             ダッシュボードへ
           </Link>
+          <div className="mt-6 pt-6 border-t border-zinc-200">
+            <p className="text-sm text-zinc-500 mb-3">よく使う機能</p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              <Link
+                href="/attendance"
+                className="inline-block bg-zinc-100 text-zinc-700 px-4 py-2 rounded-md text-sm hover:bg-zinc-200"
+              >
+                打刻
+              </Link>
+              <Link
+                href="/dashboard/prospects"
+                className="inline-block bg-zinc-100 text-zinc-700 px-4 py-2 rounded-md text-sm hover:bg-zinc-200"
+              >
+                入居希望
+              </Link>
+              <Link
+                href="/dashboard/approvals"
+                className="inline-block bg-zinc-100 text-zinc-700 px-4 py-2 rounded-md text-sm hover:bg-zinc-200"
+              >
+                承認
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -85,6 +110,7 @@ export default function OnboardingContractsPage() {
 
   // 必須文書がない場合
   if (!onboarding || onboarding.requiredItems.length === 0) {
+    const dashboardHref = LAUNCH_MODE ? '/launch' : '/dashboard';
     return (
       <div className="min-h-screen bg-zinc-50 flex items-center justify-center">
         <div className="bg-white rounded-lg shadow-sm p-8 max-w-md text-center">
@@ -92,7 +118,7 @@ export default function OnboardingContractsPage() {
             署名が必要な文書はありません
           </h1>
           <Link
-            href="/dashboard"
+            href={dashboardHref}
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700"
           >
             ダッシュボードへ

--- a/src/lib/onboarding/serverGate.ts
+++ b/src/lib/onboarding/serverGate.ts
@@ -38,6 +38,12 @@ export async function checkOnboardingGate(): Promise<void> {
   try {
     const user = await getCurrentUser();
 
+    // サーバーサイドで認証できない場合（Authorizationヘッダーなし）は
+    // クライアント側の認証に委ねてスキップする
+    if (user.id === 'anonymous') {
+      return;
+    }
+
     // 対象外ロールはスキップ
     if (EXEMPT_ROLES.includes(user.role as typeof EXEMPT_ROLES[number])) {
       return;
@@ -87,6 +93,11 @@ export async function getOnboardingState(): Promise<{
 }> {
   try {
     const user = await getCurrentUser();
+
+    // サーバーサイドで認証できない場合は完了扱い
+    if (user.id === 'anonymous') {
+      return { isRequired: false, isComplete: true, pendingCount: 0, totalCount: 0 };
+    }
 
     // 対象外ロールは完了扱い
     if (EXEMPT_ROLES.includes(user.role as typeof EXEMPT_ROLES[number])) {


### PR DESCRIPTION
- checkOnboardingGate: サーバーサイドで認証できない場合（anonymous）は ゲートをスキップし、クライアント側の認証に委ねる
- 完了画面: LAUNCH_MODEでは/launchに直接リンク
- 完了画面: 打刻・入居希望・承認へのショートカットリンクを追加

https://claude.ai/code/session_0163LMEBzhdm1UUzseYD7TGE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
