### PR TITLE
feat: モックデータ除去・朝イチダイジェスト・チケット滞留検知・KPI閾値判定・契約スキャン実装

### DIFF
--- a/src/lib/dailyOps/executor.ts
+++ b/src/lib/dailyOps/executor.ts
@@ -40,6 +40,7 @@ import { getStats as getCorrectiveActionsStats } from '@/lib/correctiveActions/r
 import { scanOverdueSteps as scanOverdueCollectionSteps } from '@/lib/collection/repo';
 import { scanMbrActionsOverdue, buildMbrOverdueAlert } from './scanMbrActionsOverdue';
 import { scanExpiredConsents, getStats as getAgreementsStats, getAgreementTypeById } from '@/lib/agreements/repo';
+import { scanExpiringContracts, scanDecisionOverdueContracts } from '@/lib/contracts/repo';
 import type { ViewerContext } from '@/lib/business/types';
 
 // ========== 重要度フィルタ ==========
@@ -310,7 +311,7 @@ async function runLicensesScan(
 
 /**
  * 契約期限スキャン（Task 026）
- * ※実際の契約リポジトリがある場合はそれを使用、ここでは簡易スキャン
+ * 契約リポジトリから期限間近・更新判断超過の契約を検出
  */
 async function runContractsScan(
   options: DailyOpsOptions,
@@ -320,14 +321,72 @@ async function runContractsScan(
   const stepName: DailyOpsStepName = 'contracts_scan';
 
   try {
-    // TODO: 実際の契約リポジトリと連携
-    // 現在はモック実装
+    const alerts: CreateAlertRequest[] = [];
+
+    // 期限間近の契約（30日以内）
+    const expiringContracts = scanExpiringContracts(30);
+    for (const info of expiringContracts) {
+      const severity: AlertSeverity =
+        info.daysUntilEnd <= 7 ? 'critical' : 'warning';
+
+      alerts.push({
+        type: 'deadline_overdue',
+        sourceId: info.contract.id,
+        title: `契約期限間近: ${info.contract.name}`,
+        message: `${info.contract.name}（${info.contract.counterpartyName}）の契約が${info.daysUntilEnd}日後に満了します。`,
+        severity,
+        fingerprint: generateDailyFingerprint('contract_expiring', info.contract.id, date),
+        meta: {
+          contractId: info.contract.id,
+          contractName: info.contract.name,
+          counterpartyName: info.contract.counterpartyName,
+          daysUntilEnd: info.daysUntilEnd,
+          endAt: info.contract.endAt,
+        },
+      });
+    }
+
+    // 更新判断期限超過の契約
+    const overdueContracts = scanDecisionOverdueContracts();
+    for (const contract of overdueContracts) {
+      alerts.push({
+        type: 'deadline_overdue',
+        sourceId: contract.id,
+        title: `契約更新判断超過: ${contract.name}`,
+        message: `${contract.name}の更新判断期限が超過しています。早急に対応してください。`,
+        severity: 'critical',
+        fingerprint: generateDailyFingerprint('contract_decision_overdue', contract.id, date),
+        meta: {
+          contractId: contract.id,
+          contractName: contract.name,
+          counterpartyName: contract.counterpartyName,
+          renewalDecisionDueAt: contract.renewalDecisionDueAt,
+        },
+      });
+    }
+
+    if (options.dryRun) {
+      return {
+        name: stepName,
+        ok: true,
+        alertsCreated: 0,
+        alertsSkipped: alerts.length,
+        notificationsCreated: 0,
+        durationMs: Date.now() - start,
+      };
+    }
+
+    const filteredAlerts = alerts.filter((a) =>
+      meetsSeverityThreshold(a.severity, options.notificationThreshold ?? 'warning')
+    );
+
+    const result = createAlertsFromScan(filteredAlerts);
 
     return {
       name: stepName,
       ok: true,
-      alertsCreated: 0,
-      alertsSkipped: 0,
+      alertsCreated: result.created,
+      alertsSkipped: result.skipped + (alerts.length - filteredAlerts.length),
       notificationsCreated: 0,
       durationMs: Date.now() - start,
     };

--- a/src/lib/digest/morningDigest.ts
+++ b/src/lib/digest/morningDigest.ts
@@ -13,6 +13,12 @@
  */
 
 import type { AlertSeverity } from '@/lib/alerts/types';
+import { listAlerts, getAlertStats } from '@/lib/alerts/repo';
+import { getOverdueTickets, listTickets } from '@/lib/tickets/repo';
+import type { ViewerContext } from '@/lib/tickets/types';
+import { scanExpired as scanExpiredLicenses } from '@/lib/licenses/repo';
+import { scanExpiredConsents } from '@/lib/agreements/repo';
+import { getUnassignedQueueStats } from '@/lib/assignment/autoAssign';
 import { MORNING_DIGEST_ITEMS, DIGEST_ALERT_TYPES } from '@/config/opsSchedule';
 
 // ========== ダイジェスト項目型 ==========
@@ -181,29 +187,35 @@ export function buildMorningDigest(): MorningDigest {
   };
 }
 
-// ========== データ取得ヘルパー（モック） ==========
+// ========== データ取得ヘルパー ==========
+
+const SYSTEM_VIEWER: ViewerContext = { userId: 'system', role: 'admin' };
 
 /**
  * Critical Open アラート数を取得
  */
 function getCriticalOpenAlerts(): { count: number } {
-  // 実際にはアラートリポジトリから取得
-  // ここではモック値を返す
-  return { count: 0 };
+  const stats = getAlertStats();
+  return { count: stats.criticalOpen };
 }
 
 /**
  * System Error アラート数を取得
  */
 function getSystemErrorAlerts(): { count: number } {
-  return { count: 0 };
+  const { alerts } = listAlerts({ status: 'open', type: 'system_error' });
+  return { count: alerts.length };
 }
 
 /**
  * 未分類アラート数を取得
  */
 function getUnclassifiedAlerts(): { count: number } {
-  return { count: 0 };
+  const stats = getAlertStats();
+  const count =
+    (stats.byType.business_scope_unclassified || 0) +
+    (stats.byType.unclassified_scope || 0);
+  return { count };
 }
 
 /**
@@ -214,10 +226,14 @@ function getOverdueDeadlines(): {
   agreements: number;
   tickets: number;
 } {
+  const expiredLicenses = scanExpiredLicenses();
+  const expiredConsents = scanExpiredConsents();
+  const overdueTickets = getOverdueTickets();
+
   return {
-    licenses: 0,
-    agreements: 0,
-    tickets: 0,
+    licenses: expiredLicenses.length,
+    agreements: expiredConsents.length,
+    tickets: overdueTickets.length,
   };
 }
 
@@ -225,7 +241,8 @@ function getOverdueDeadlines(): {
  * 未割当アイテム数を取得
  */
 function getUnassignedItems(): { count: number } {
-  return { count: 0 };
+  const stats = getUnassignedQueueStats();
+  return { count: stats.total };
 }
 
 // ========== 通知テキスト生成 ==========

--- a/src/lib/tickets/detectTicketBacklog.ts
+++ b/src/lib/tickets/detectTicketBacklog.ts
@@ -98,10 +98,24 @@ export function detectTicketBacklog(): {
 }
 
 /**
- * 単一チケットの滞留チェック（将来拡張用）
- * 例：同一チケットが3日以上動いていない場合にアラート
+ * 単一チケットの滞留チェック
+ * 同一チケットが3日以上動いていない場合にtrue
  */
 export function checkTicketStale(ticketId: string): boolean {
-  // TODO: 実装予定
-  return false;
+  const STALE_DAYS = 3;
+  const { items } = listTickets({}, ADMIN_VIEWER);
+  const ticket = items.find((t) => t.id === ticketId);
+
+  if (!ticket) return false;
+
+  // 解決済み・クローズ済みは滞留とみなさない
+  if (['resolved', 'closed', 'archived'].includes(ticket.status)) {
+    return false;
+  }
+
+  const lastUpdate = new Date(ticket.updatedAt).getTime();
+  const now = Date.now();
+  const daysSinceUpdate = (now - lastUpdate) / (1000 * 60 * 60 * 24);
+
+  return daysSinceUpdate >= STALE_DAYS;
 }

--- a/src/lib/wbr/buildKpiHighlights.ts
+++ b/src/lib/wbr/buildKpiHighlights.ts
@@ -124,17 +124,35 @@ function calculateImpact(
   changePercent: number,
   direction: WbrKpiHighlight['direction'],
   trend: 'up' | 'down' | 'flat',
-  entry: KPIDictionaryEntry | null
+  entry: KPIDictionaryEntry | null,
+  currentValue?: number | string
 ): 'high' | 'medium' | 'low' {
   const absChange = Math.abs(changePercent);
 
-  // 閾値がある場合はそれを参照
-  if (entry?.thresholds) {
-    const { warning, critical } = entry.thresholds;
-    // TODO: 閾値ベースの判定を実装
+  // 閾値ベースの判定（辞書に閾値が定義されている場合）
+  if (entry?.thresholds && currentValue !== undefined) {
+    const numVal = typeof currentValue === 'string' ? parseFloat(currentValue) : currentValue;
+    if (!isNaN(numVal)) {
+      const { warning, critical } = entry.thresholds;
+
+      // 方向性を考慮した閾値判定
+      if (direction === 'higher_is_better') {
+        // 高い方が良い → 閾値を下回るとリスク
+        if (critical !== undefined && numVal <= critical) return 'high';
+        if (warning !== undefined && numVal <= warning) return 'medium';
+      } else if (direction === 'lower_is_better') {
+        // 低い方が良い → 閾値を上回るとリスク
+        if (critical !== undefined && numVal >= critical) return 'high';
+        if (warning !== undefined && numVal >= warning) return 'medium';
+      } else {
+        // neutral/unknown → 絶対値で判定
+        if (critical !== undefined && (numVal >= critical || numVal <= -critical)) return 'high';
+        if (warning !== undefined && (numVal >= warning || numVal <= -warning)) return 'medium';
+      }
+    }
   }
 
-  // 変化率ベースの簡易判定
+  // 変化率ベースの簡易判定（フォールバック）
   if (absChange >= 20) return 'high';
   if (absChange >= 10) return 'medium';
   return 'low';
@@ -257,7 +275,7 @@ export function buildSingleKpiHighlight(
   const { isGood, isBad } = determineGoodBad(trend, direction);
 
   // 影響度算出
-  const impact = calculateImpact(changePercent, direction, trend, entry);
+  const impact = calculateImpact(changePercent, direction, trend, entry, raw.currentValue);
 
   // 異常検知チェック
   const { isAnomaly, explanation: anomalyExplanation } = checkAnomaly(


### PR DESCRIPTION
- 朝イチダイジェスト: 5つのモック関数を実データ取得に置換（アラート、チケット、資格、同意書、未割当）
- checkTicketStale: 3日以上更新なしのチケットを滞留検知する実装
- KPIハイライト: 辞書の閾値（warning/critical）と方向性に基づく影響度判定を実装
- 契約スキャン: 期限間近（30日以内）と更新判断超過の契約をスキャン・アラート化

https://claude.ai/code/session_0163LMEBzhdm1UUzseYD7TGE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
