### PR TITLE
fix: 稟議コメントの権限チェックを修正（manager/executive/system_adminロール対応）

### DIFF
--- a/src/app/api/ringi/comments/route.ts
+++ b/src/app/api/ringi/comments/route.ts
@@ -116,11 +116,16 @@ export async function POST(request: NextRequest) {
 
     const ringiData = ringiDoc.data()!;
 
-    // 権限チェック: 起案者、承認者（leader以上）、admin
+    // 権限チェック: 起案者、承認フロー内の承認者、管理職以上
     const isAuthor = ringiData.authorId === user.uid;
-    const isApprover = ['leader', 'admin', 'system_admin'].includes(user.role);
+    // 旧ロール(system_admin) + 新ロール(manager,executive)の両方をカバー
+    const COMMENT_ALLOWED_ROLES = ['leader', 'manager', 'executive', 'admin', 'system_admin'];
+    const isApprover = COMMENT_ALLOWED_ROLES.includes(user.role);
+    const isDesignatedApprover = ringiData.approvalFlow?.steps?.some(
+      (step: { approverValue?: string }) => step.approverValue === user.uid
+    ) ?? false;
 
-    if (!isAuthor && !isApprover) {
+    if (!isAuthor && !isApprover && !isDesignatedApprover) {
       return NextResponse.json(
         { error: 'この稟議にコメントする権限がありません' },
         { status: 403 }


### PR DESCRIPTION
- 旧ロール(system_admin)と新ロール(manager, executive)の両方をカバー
- 承認フロー内の指定承認者もコメント可能に追加
- 403エラーでコメント投稿できない問題を修正

https://claude.ai/code/session_0163LMEBzhdm1UUzseYD7TGE

## 変更点
<!-- 何を変更したかを箇条書きで記載 -->
-

## 画面確認URL
<!-- Vercel Preview URLを貼り付け -->
- Preview:

## テスト結果
<!-- テストの実行結果 -->
- [ ] Unit tests passed
- [ ] E2E tests passed
- [ ] 手動テスト完了

## スクリーンショット（任意）
<!-- UI変更がある場合はスクリーンショットを添付 -->

## 影響範囲
<!-- この変更が影響を与える範囲 -->
-

## ロールバック手順
<!-- 問題が発生した場合のロールバック方法 -->
1. このPRをRevertする
2. `git revert <commit-hash>`
3. 再度デプロイ

## チェックリスト
- [ ] 支援目的の文言を確認（「評価」「査定」の表現がないこと）
- [ ] Preview環境で外部副作用が無効化されていること
- [ ] セキュリティ上の問題がないこと
- [ ] パフォーマンスに悪影響がないこと
